### PR TITLE
Replace reset buttons with cancel button

### DIFF
--- a/src/app/main/dialog/dialog.component.html
+++ b/src/app/main/dialog/dialog.component.html
@@ -148,7 +148,7 @@
     <div *ngSwitchCase="'editListInfo'">
         <app-dialog-header [title]="data.title" [subtitle]="'Edit list info'" (close)="dialogRef.close()">
         </app-dialog-header>
-        <app-list-info-form [iri]="data.id" [projectIri]="data.project"></app-list-info-form>
+        <app-list-info-form [iri]="data.id" [projectIri]="data.project" (closeDialog)="dialogRef.close()"></app-list-info-form>
     </div>
 
     <!-- Delete list -->

--- a/src/app/project/list/list-info-form/list-info-form.component.html
+++ b/src/app/project/list/list-info-form/list-info-form.component.html
@@ -3,7 +3,7 @@
     <dsp-progress-indicator *ngIf="loading"></dsp-progress-indicator>
 
     <!-- success message after updating -->
-    <dsp-message *ngIf="success" [message]="successMessage" [short]="true" (click)="closeMessage()"></dsp-message>
+    <dsp-message *ngIf="success" [message]="successMessage" [short]="true"></dsp-message>
 
     <div *ngIf="!loading && !createList" class="form-content list-info">
 
@@ -24,8 +24,8 @@
 
         <div class="form-panel form-action">
             <span>
-                <button mat-button type="button" (click)="resetForm($event, list)">
-                    {{ 'appLabels.form.action.reset' | translate }}
+                <button mat-button type="button" (click)="closeDialog.emit(list)">
+                    {{ 'appLabels.form.action.cancel' | translate }}
                 </button>
             </span>
             <span class="fill-remaining-space"></span>

--- a/src/app/project/list/list-info-form/list-info-form.component.ts
+++ b/src/app/project/list/list-info-form/list-info-form.component.ts
@@ -227,9 +227,4 @@ export class ListInfoFormComponent implements OnInit {
                 break;
         }
     }
-
-    closeMessage() {
-        this.closeDialog.emit(this.list);
-    }
-
 }

--- a/src/app/project/ontology/source-type-form/source-type-form.component.html
+++ b/src/app/project/ontology/source-type-form/source-type-form.component.html
@@ -1,7 +1,7 @@
 <div class="no-shadow" *ngIf="!errorMessage; else errorMsg">
 
     <!-- success message after updating -->
-    <dsp-message *ngIf="success" [message]="successMessage" [short]="true" (click)="closeMessage()"></dsp-message>
+    <dsp-message *ngIf="success" [message]="successMessage" [short]="true"></dsp-message>
 
     <!-- content: Step 1 = define resource type -->
     <form [formGroup]="sourceTypeForm" class="form-content">
@@ -37,7 +37,7 @@
             <!-- action buttons -->
             <div class="form-panel form-action">
                 <span>
-                    <button mat-button type="button" (click)="closeMessage()">
+                    <button mat-button type="button" (click)="closeDialog.emit()">
                         {{ 'appLabels.form.action.cancel' | translate }}
                     </button>
                 </span>

--- a/src/app/project/ontology/source-type-form/source-type-form.component.ts
+++ b/src/app/project/ontology/source-type-form/source-type-form.component.ts
@@ -562,9 +562,6 @@ export class SourceTypeFormComponent implements OnInit, OnDestroy, AfterViewChec
         );
 
         */
-
-        // show message to close dialog box
-        // this.closeMessage();
     }
     /**
      * Convert cardinality values (multiple? & required?) from form to string 1-0, 0-n, 1, 0-1

--- a/src/app/project/project-form/project-form.component.html
+++ b/src/app/project/project-form/project-form.component.html
@@ -3,7 +3,7 @@
     <dsp-progress-indicator *ngIf="loading"></dsp-progress-indicator>
 
     <!-- success message after updating -->
-    <dsp-message *ngIf="success" [message]="successMessage" [short]="true" (click)="closeMessage()"></dsp-message>
+    <dsp-message *ngIf="success" [message]="successMessage" [short]="true"></dsp-message>
 
     <!-- content -->
     <form *ngIf="!loading && project.status" [formGroup]="form" class="form-content project-data"
@@ -39,7 +39,7 @@
 
         <!-- description -->
         <dsp-string-literal-input placeholder="{{'appLabels.form.project.general.description' | translate}} *"
-            [disabled]="project.id !== undefined && !project.status" [textarea]="true" [value]="project.description"
+            [disabled]="!project.status" [textarea]="true" [value]="project.description"
             (dataChanged)="getStringLiteral($event)">
         </dsp-string-literal-input>
         <mat-hint class="string-literal-error" *ngIf="formErrors.description">
@@ -80,12 +80,6 @@
                     [matChipInputSeparatorKeyCodes]="separatorKeyCodes" [matChipInputAddOnBlur]="addOnBlur"
                     (matChipInputTokenEnd)="addKeyword($event)" />
             </mat-chip-list>
-
-            <!--
-            <mat-hint *ngIf="formErrors.keywords">
-                {{ formErrors.keywords }}
-            </mat-hint>
-            -->
         </mat-form-field>
 
         <!-- upload logo -->
@@ -102,10 +96,9 @@
 
         <div class="form-panel form-action">
             <span>
-                <button mat-button type="reset" (click)="resetForm($event, project)">
-                    {{ 'appLabels.form.action.reset' | translate }}
+                <button mat-button type="reset" (click)="closeDialog.emit()">
+                    {{ 'appLabels.form.action.cancel' | translate }}
                 </button>
-
             </span>
             <span class="fill-remaining-space"></span>
             <span>

--- a/src/app/user/user-form/password-form/password-form.component.html
+++ b/src/app/user/user-form/password-form/password-form.component.html
@@ -125,5 +125,5 @@
 
 <!-- in the case of an API error: show the error message -->
 <ng-template #errorMsg>
-    <dsp-message *ngIf="errorMessage" [message]="errorMessage" [short]="true" (click)="closeMessage()"></dsp-message>
+    <dsp-message *ngIf="errorMessage" [message]="errorMessage" [short]="true"></dsp-message>
 </ng-template>

--- a/src/app/user/user-form/user-form.component.html
+++ b/src/app/user/user-form/user-form.component.html
@@ -3,7 +3,7 @@
     <dsp-progress-indicator *ngIf="loading"></dsp-progress-indicator>
 
     <!-- success message after updating -->
-    <dsp-message *ngIf="success" [message]="successMessage" [short]="true" (click)="closeMessage()"></dsp-message>
+    <dsp-message *ngIf="success" [message]="successMessage" [short]="true"></dsp-message>
 
     <!-- content -->
     <form *ngIf="!loading" [formGroup]="form" class="form-content user-data" (ngSubmit)="submitData()">
@@ -75,10 +75,9 @@
 
         <div class="form-panel form-action">
             <span>
-                <button mat-button type="reset" (click)="resetForm($event, user)">
-                    {{ 'appLabels.form.action.reset' | translate }}
+                <button mat-button type="reset" (click)="closeDialog.emit()">
+                    {{ 'appLabels.form.action.cancel' | translate }}
                 </button>
-
             </span>
             <span class="fill-remaining-space"></span>
             <span>

--- a/src/app/user/user-form/user-form.component.ts
+++ b/src/app/user/user-form/user-form.component.ts
@@ -422,7 +422,7 @@ export class UserFormComponent implements OnInit, OnChanges {
                                         // update project cache and member of project cache
                                         this._cache.get(this.projectcode, this._dspApiConnection.admin.projectsEndpoint.getProjectByShortcode(this.projectcode));
                                         this._cache.get('members_of_' + this.projectcode, this._dspApiConnection.admin.projectsEndpoint.getProjectMembersByShortcode(this.projectcode));
-                                        this.closeMessage();
+                                        this.closeDialog.emit(this.user);
                                         this.loading = false;
                                     },
                                     (error: any) => {
@@ -435,7 +435,7 @@ export class UserFormComponent implements OnInit, OnChanges {
                             }
                         );
                     } else {
-                        this.closeMessage();
+                        this.closeDialog.emit(this.user);
                         this.loading = false;
                     }
                 },
@@ -458,7 +458,4 @@ export class UserFormComponent implements OnInit, OnChanges {
         this.buildForm(user);
     }
 
-    closeMessage() {
-        this.closeDialog.emit(this.user);
-    }
 }


### PR DESCRIPTION
In this PR I replaced the reset buttons in forms like:
- project-form
- user-form
- list-form

We had some issues with the reset button in combination with stringLiteralInput and list of keywords. So, I replaced reset with cancel which closes the dialog box without doing anything on the form data. I kept the method `reset()` to go back to reset-button and to fix the issues we had. But at the moment I do not have time to fix it. We can discuss if we should get rid of the reset functionality completely... In this case I will try to refactor the relevant forms