### PR TITLE
DSP-674 Replace search-panel with fulltext-search

### DIFF
--- a/src/app/main/header/header.component.html
+++ b/src/app/main/header/header.component.html
@@ -12,8 +12,8 @@
 
     <!-- search-panel (in desktop and tablet version) -->
     <span class="action searchbar-large-screen">
-        <dsp-search-panel [projectfilter]="true" [expert]="false" [advanced]="false" (search)="doSearch($event)">
-        </dsp-search-panel>
+        <dsp-fulltext-search [projectfilter]="true" (search)="doSearch($event)">
+        </dsp-fulltext-search>
          <!-- advanced and expert search (in desktop and tablet version) -->
          <span class="other-search-link">
             <button mat-button color="primary" class="advanced-search-link" routerLink="/search/advanced">

--- a/src/app/main/header/header.component.spec.ts
+++ b/src/app/main/header/header.component.spec.ts
@@ -95,8 +95,8 @@ describe('HeaderComponent', () => {
         expect(loginBtnLabel).toEqual('LOGIN');
     });
 
-    it('should display the search panel', () => {
-        const searchPanel = fixture.debugElement.query(By.css('dsp-search-panel'));
+    it('should display fulltext-search', () => {
+        const searchPanel = fixture.debugElement.query(By.css('dsp-fulltext-search-panel'));
         expect(searchPanel).toBeDefined();
     });
 


### PR DESCRIPTION
resolves [DSP-674](https://dasch.myjetbrains.com/youtrack/issue/DSP-674)

As long we do not use the full dsp-ui search panel, which comes with advanced and expert search included, we can use only the fulltext-search-panel. 
The real bug will be solved in dsp-ui-lib.