### PR TITLE
DSP-860: Ontology editor: Create resource class

### DIFF
--- a/src/app/main/dialog/dialog.component.html
+++ b/src/app/main/dialog/dialog.component.html
@@ -192,7 +192,7 @@
         </mat-dialog-actions>
     </div>
 
-    <!-- Ontology editor: customize and add resource type -->
+    <!-- Ontology editor: customize and add resource class -->
     <div *ngSwitchCase="'addResourceClass'">
         <app-dialog-header [title]="data.title" [subtitle]="data.subtitle"></app-dialog-header>
         <app-resource-class-form [subClassOf]="data.name" [name]="data.title" [projectIri]="data.project"
@@ -212,8 +212,8 @@
     </div>
 
     <div *ngSwitchCase="'deleteResourceClass'">
-        <app-dialog-header [title]="data.title" [subtitle]="'Delete resource type'"></app-dialog-header>
-        Do you want to delete this resource type?
+        <app-dialog-header [title]="data.title" [subtitle]="'Delete resource class'"></app-dialog-header>
+        Do you want to delete this resource class?
         <mat-dialog-actions>
             <button mat-button mat-dialog-close class="cancel-button center" [mat-dialog-close]="false">
                 Cancel

--- a/src/app/main/dialog/dialog.component.html
+++ b/src/app/main/dialog/dialog.component.html
@@ -172,9 +172,9 @@
     </div>
 
     <div *ngSwitchCase="'editOntology'">
-        <app-dialog-header [title]="'Data model'" [subtitle]="'Create new'" (close)="dialogRef.close()">
+        <app-dialog-header [title]="'Data model'" [subtitle]="'Edit'" (close)="dialogRef.close()">
         </app-dialog-header>
-        The component{{data.mode}} is not implemented yet.
+        <p class="todo" [innerHtml]="notYetImplemented"></p>
     </div>
 
     <div *ngSwitchCase="'deleteOntology'">
@@ -203,7 +203,7 @@
     <div *ngSwitchCase="'editResourceClass'">
         <app-dialog-header [title]="data.title" [subtitle]="data.subtitle">
         </app-dialog-header>
-        The component{{data.mode}} is not implemented yet.
+        <p class="todo" [innerHtml]="notYetImplemented"></p>
         <mat-dialog-actions>
             <button mat-button mat-dialog-close class="cancel-button center" [mat-dialog-close]="false">
                 Cancel
@@ -250,6 +250,6 @@
     <div *ngSwitchDefault>
         <app-dialog-header [title]="'Not yet implemented'" [subtitle]="'ERROR 400'" (close)="dialogRef.close()">
         </app-dialog-header>
-        The component <b>{{data.mode}}</b> is not implemented yet.
+        <p class="todo" [innerHtml]="notYetImplemented"></p>
     </div>
 </div>

--- a/src/app/main/dialog/dialog.component.scss
+++ b/src/app/main/dialog/dialog.component.scss
@@ -1,0 +1,6 @@
+.todo {
+    background-color: bisque;
+    padding: 6px;
+    border-radius: 4px;
+    text-align: center;
+}

--- a/src/app/main/dialog/dialog.component.ts
+++ b/src/app/main/dialog/dialog.component.ts
@@ -19,6 +19,8 @@ export interface DialogData {
 })
 export class DialogComponent implements OnInit {
 
+    notYetImplemented = `The component <strong>${this.data.mode}</strong> is not implemented yet.`;
+
     constructor(
         public dialogRef: MatDialogRef<DialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: DialogData

--- a/src/app/project/ontology/default-data/default-resource-classes.ts
+++ b/src/app/project/ontology/default-data/default-resource-classes.ts
@@ -1,48 +1,40 @@
 import { Constants } from '@dasch-swiss/dsp-js';
 
-export interface ResourceClass {
+export interface DefaultClass {
     iri: string;
-    name: string;
-    label?: string;
+    label: string;
     icons?: string[];
 }
 
 export class DefaultResourceClasses {
 
-    public static data: ResourceClass[] = [
+    public static data: DefaultClass[] = [
         {
             iri: Constants.Resource,
-            name: 'knora-api:Resource',
             label: 'Object without file representation (metadata only)'
         },
         {
-            iri: Constants.StillImageFileValue,
-            name: 'knora-api:StillImageRepresentation',
+            iri: Constants.KnoraApiV2 + Constants.Delimiter + "StillImageRepresentation",
             label: 'Still Image'
         },
         {
-            iri: Constants.MovingImageFileValue,
-            name: 'knora-api:MovingImageRepresentation',
+            iri: Constants.KnoraApiV2 + Constants.Delimiter + "MovingImageRepresentation",
             label: 'Moving Image'
         },
         {
-            iri: Constants.AudioFileValue,
-            name: 'knora-api:AudioRepresentation',
+            iri: Constants.KnoraApiV2 + Constants.Delimiter + "AudioRepresentation",
             label: 'Audio'
         },
         {
-            iri: Constants.TextFileValue,
-            name: 'knora-api:TextRepresentation',
+            iri: Constants.KnoraApiV2 + Constants.Delimiter + "TextRepresentation",
             label: 'Text'
         },
         {
-            iri: Constants.DocumentFileValue,
-            name: 'knora-api:DocumentRepresentation',
+            iri: Constants.KnoraApiV2 + Constants.Delimiter + "DocumentRepresentation",
             label: 'Document (Word, PDF, etc.)'
         },
         {
-            iri: Constants.DDDFileValue,
-            name: 'knora-api:DDDRepresentation',
+            iri: Constants.KnoraApiV2 + Constants.Delimiter + "DDDRepresentation",
             label: 'RTI Image'
         }
     ];

--- a/src/app/project/ontology/ontology.component.html
+++ b/src/app/project/ontology/ontology.component.html
@@ -111,7 +111,7 @@
                         <mat-menu #resClassMenu="matMenu" xPosition="before">
                             <button mat-menu-item
                                 (click)="openResourceClassForm('editResourceClass', {iri: resClass.id, name: '', label: resClass.label})">Edit</button>
-                            <button mat-menu-item [disabled]="resClass.propertiesList.length > 17"
+                            <button mat-menu-item
                                 (click)="delete(resClass.id, 'ResourceClass', resClass.label)">Delete</button>
                         </mat-menu>
                     </mat-toolbar-row>

--- a/src/app/project/ontology/ontology.component.html
+++ b/src/app/project/ontology/ontology.component.html
@@ -84,7 +84,7 @@
 
         <div #ontologyEditor *ngIf="!loadOntology && view === 'grid'" class="ontology-editor-canvas">
             <!-- button to select and add new resource class to the ontology -->
-            <div class="add-resource-class" *ngIf="project?.status && sysAdmin && ontologyIri">
+            <div class="add-resource-class" *ngIf="project?.status && (sysAdmin || projectAdmin) && ontologyIri">
                 <button mat-raised-button color="primary" [matMenuTriggerFor]="addResClassMenu">
                     Add resource class&nbsp;
                     <mat-icon>add</mat-icon>

--- a/src/app/project/ontology/ontology.component.html
+++ b/src/app/project/ontology/ontology.component.html
@@ -1,5 +1,4 @@
 <div *ngIf="projectAdmin" class="desktop-only">
-    <!-- <dsp-message [medium]="true" [message]="{status: 206, statusText: 'The ontology/data model editor is not yet fully implemented. The functionality is still work in progress.'}"></dsp-message> -->
 
     <dsp-progress-indicator *ngIf="loading"></dsp-progress-indicator>
 
@@ -86,7 +85,6 @@
         <div #ontologyEditor *ngIf="!loadOntology && view === 'grid'" class="ontology-editor-canvas">
             <!-- button to select and add new resource class to the ontology -->
             <div class="add-resource-class" *ngIf="project?.status && sysAdmin && ontologyIri">
-                <!-- TODO: will be reactivated with the improvements of ontology editor
                 <button mat-raised-button color="primary" [matMenuTriggerFor]="addResClassMenu">
                     Add resource class&nbsp;
                     <mat-icon>add</mat-icon>
@@ -97,16 +95,9 @@
                         {{ type?.label }}
                     </button>
                 </mat-menu>
-                -->
             </div>
 
-            <!-- <app-add-resource-class *ngIf="project?.status && sysAdmin && ontologyIri" [projectcode]="projectcode"
-                class="add-resource-class" (refreshParent)="resetOntology(ontologyIri)" #addResourceClassComponent>
-            </app-add-resource-class> -->
-
             <!-- list of resource classs -->
-            <!-- <svg width="100%" height="1200" class="mySvg" (click)="clicked($event)"></svg> -->
-
             <div *ngFor="let resClass of ontoClasses; let i = index" class="resource-class" cdkDrag
                 cdkDragBoundary=".drag-drop-stop">
                 <mat-toolbar class="resource-class-header" cdkDragHandle>

--- a/src/app/project/ontology/ontology.component.html
+++ b/src/app/project/ontology/ontology.component.html
@@ -71,7 +71,7 @@
                     <mat-icon>scatter_plot</mat-icon> Graph
                 </button>
                 <button mat-stroked-button
-                    (click)="$event.stopPropagation(); openOntologyForm('editOntologyInfo', ontology?.id, ontology?.id)">
+                    (click)="$event.stopPropagation(); openOntologyForm('editOntology', ontology.id)">
                     Edit
                 </button>
                 &nbsp;

--- a/src/app/project/ontology/ontology.component.ts
+++ b/src/app/project/ontology/ontology.component.ts
@@ -265,7 +265,12 @@ export class OntologyComponent implements OnInit {
         return (owlClass['@type'] === 'owl:class');
     }
 
-    openOntologyForm(mode: string, name?: string, iri?: string): void {
+    /**
+     * Opens ontology form
+     * @param mode
+     * @param [iri] only in edit mode
+     */
+    openOntologyForm(mode: 'createOntology' | 'editOntology', iri?: string): void {
         const dialogConfig: MatDialogConfig = {
             width: '640px',
             position: {
@@ -293,9 +298,12 @@ export class OntologyComponent implements OnInit {
         });
     }
 
-
-
-    openResourceClassForm(mode: string, type: DefaultClass): void {
+    /**
+     * Opens resource class form
+     * @param mode
+     * @param subClassOf
+     */
+    openResourceClassForm(mode: 'createResourceClass' | 'editResourceClass', subClassOf: DefaultClass): void {
 
         // set ontology cache
         this._cache.set('currentOntology', this.ontology);
@@ -306,7 +314,7 @@ export class OntologyComponent implements OnInit {
             position: {
                 top: '112px'
             },
-            data: { name: type.iri, title: type.label, subtitle: 'Customize resource class', mode: mode, project: this.project.id }
+            data: { name: subClassOf.iri, title: subClassOf.label, subtitle: 'Customize resource class', mode: mode, project: this.project.id }
         };
 
         const dialogRef = this._dialog.open(DialogComponent, dialogConfig);
@@ -316,6 +324,7 @@ export class OntologyComponent implements OnInit {
             this.getOntology(this.ontologyIri);
         });
     }
+
     /**
      * Delete either ontology or sourcetype
      *
@@ -384,45 +393,11 @@ export class OntologyComponent implements OnInit {
                                 this.loading = false;
                             }
                         );
-
-                        // TODO: replace by js-lib OntologiesEndpoint
-                        // this._ontologyService.deleteResourceClass(id, this.ontology.lastModificationDate).subscribe(
-                        //     (response: ApiServiceResult) => {
-                        //         this.getOntology(this.ontologyIri);
-                        //     },
-                        //     (error: ApiServiceError) => {
-                        //         console.error(error.errorInfo);
-
-                        //         const dialogErrorConfig: MatDialogConfig = {
-                        //             width: '560px',
-                        //             position: {
-                        //                 top: '112px'
-                        //             },
-                        //             data: { mode: 'error', title: 'Error: Not able to delete' }
-                        //         };
-
-                        //         const dialogErrorRef = this._dialog.open(
-                        //             DialogComponent,
-                        //             dialogErrorConfig
-                        //         );
-
-                        //         dialogErrorRef.afterClosed().subscribe(result => {
-                        //             this.getOntology(this.ontologyIri);
-                        //         });
-                        //     }
-                        // );
-                        break;
+                    break;
                 }
 
             }
         });
-    }
-
-    disableDeleteButton(properties: any): boolean {
-
-        console.log(properties);
-        return false;
-
     }
 
     /**

--- a/src/app/project/ontology/ontology.component.ts
+++ b/src/app/project/ontology/ontology.component.ts
@@ -8,6 +8,7 @@ import {
     ApiResponseError,
     ClassDefinition,
     DeleteOntologyResponse,
+    DeleteResourceClass,
     KnoraApiConnection,
     OntologiesMetadata,
     OntologyMetadata,
@@ -368,12 +369,12 @@ export class OntologyComponent implements OnInit {
                     case 'ResourceClass':
                         // delete reresource class and refresh the view
                         this.loadOntology = true;
-                        const resClass = new UpdateOntology();
-                        resClass.id = this.resourceClass[0].iri;
+                        const resClass: DeleteResourceClass = new DeleteResourceClass();
+                        resClass.id = id;
                         resClass.lastModificationDate = this.ontology.lastModificationDate;
 
 
-                        this._dspApiConnection.v2.onto.deleteResourceClass(ontology).subscribe(
+                        this._dspApiConnection.v2.onto.deleteResourceClass(resClass).subscribe(
                             (response: OntologyMetadata) => {
                                 this.loading = false;
                                 this.getOntology(this.ontologyIri);

--- a/src/app/project/ontology/ontology.component.ts
+++ b/src/app/project/ontology/ontology.component.ts
@@ -19,7 +19,7 @@ import {
 import { DspApiConnectionToken, Session, SessionService } from '@dasch-swiss/dsp-ui';
 import { CacheService } from 'src/app/main/cache/cache.service';
 import { DialogComponent } from 'src/app/main/dialog/dialog.component';
-import { DefaultResourceClasses, ResourceClass } from './default-data/default-resource-classes';
+import { DefaultResourceClasses, DefaultClass } from './default-data/default-resource-classes';
 import { ResourceClassFormService } from './resource-class-form/resource-class-form.service';
 
 export interface OntologyInfo {
@@ -81,7 +81,7 @@ export class OntologyComponent implements OnInit {
     /**
      * list of all default resource classs (sub class of)
      */
-    resourceClass: ResourceClass[] = DefaultResourceClasses.data;
+    resourceClass: DefaultClass[] = DefaultResourceClasses.data;
 
     @ViewChild('ontologyEditor', { read: ViewContainerRef }) ontologyEditor: ViewContainerRef;
 
@@ -294,7 +294,7 @@ export class OntologyComponent implements OnInit {
 
 
 
-    openResourceClassForm(mode: string, type: ResourceClass): void {
+    openResourceClassForm(mode: string, type: DefaultClass): void {
 
         // set ontology cache
         this._cache.set('currentOntology', this.ontology);
@@ -305,7 +305,7 @@ export class OntologyComponent implements OnInit {
             position: {
                 top: '112px'
             },
-            data: { name: type.name, title: type.label, subtitle: 'Customize resource class', mode: mode, project: this.project.id }
+            data: { name: type.iri, title: type.label, subtitle: 'Customize resource class', mode: mode, project: this.project.id }
         };
 
         const dialogRef = this._dialog.open(DialogComponent, dialogConfig);

--- a/src/app/project/ontology/resource-class-form/resource-class-form.component.ts
+++ b/src/app/project/ontology/resource-class-form/resource-class-form.component.ts
@@ -364,6 +364,10 @@ export class ResourceClassFormComponent implements OnInit, OnDestroy, AfterViewC
 
                 console.log(classResponse);
 
+                // close the dialog box
+                this.loading = false;
+                this.closeDialog.emit();
+
                 // prepare last modification date and properties data
                 // lastModificationDate = classResponse.
 


### PR DESCRIPTION
resolves DSP-860

In this PR I reactivated the "Create resource class" and "Delete resource class". "Create" and "Add" properties to resource class is part of another user story (DSP-861 and DSP-862) and will be done in next PR.
For the reviewers: You can try to add resource class to the ontology with following steps:
- Login as system admin or as project admin
- Go to project page. In case you're logged-in as project admin, open the corresponding project.
- Open tab "Data model"
- Select ontology (in case the project has more than 1 ontology)
- Click on "Create resource class" and select the resource type you want to add
- A dialog box opens and you have to enter a resource class name and description
- Click on next and just fill in first input field of first property e.g. "Title" --> This will not be saved; it's part of another PR, but it's needed in form validation
- Click on "Submit" --> The dialog box closes and the new created resource class should be added to the board

