### PR TITLE
DSP-920 Renaming default github branch to "main"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-resolves [DSP-xy](https://dasch.myjetbrains.com/youtrack/issue/DSP-xy)
+resolves DSP-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
     name: Update next release draft
     needs: build-test
     runs-on: ubuntu-latest
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    if: github.ref == 'refs/heads/master'
+    # Drafts your next Release notes as Pull Requests are merged into "main" branch
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: release-drafter/release-drafter@v5
         env:
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 50
       - name: Get previous tag
         id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        uses: "WyriHaximus/github-action-get-previous-tag@1.0.0"
       - name: Update version in package.json
         run: npm version ${{steps.previoustag.outputs.tag}} --git-tag-version=false --commit-hooks=false
       - name: Build and publish image


### PR DESCRIPTION
resolves DSP-920

- Default branch is already set to "main" branch
&rarr; <https://github.com/dasch-swiss/dsp-app/settings/branches>
- Branch protections rule is set to "main" branch too
&rarr; <https://github.com/dasch-swiss/dsp-app/settings/branches>

- The base branch of all open PRs is already set to "main" branch