### PR TITLE
chore(tests): script to find ignored tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
         run: npm install
       - name: Build app in prod mode
         run: npm run build-prod
+      - name: Find ignored tests
+        run: ./find-ignored-tests.sh
       - name: Run unit tests
         run: npm run test-ci
       - name: Run e2e tests

--- a/e2e/src/footer.e2e-spec.ts
+++ b/e2e/src/footer.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { browser } from 'protractor';
 import { FooterPage } from './page-objects/footer.po';
 
-fdescribe('footer', () => {
+describe('footer', () => {
     let footer: FooterPage;
 
     beforeEach(() => {

--- a/find-ignored-tests.sh
+++ b/find-ignored-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# find deactivated and exclusive tests: fdescirbe / fit / xdescribe / xit
+# list=$(find . -name "*spec.ts" | xargs grep 'fit\|fdescribe\|xdescribe\|xit')
+
+# TODO: the following command has to be replaced with the one above
+# as soon DSP-Admin is connected with DSP-VRE again
+
+# Find exclusive tests: fdescribe / fit
+exclusive=$(find . -name "*spec.ts" | xargs grep 'fit\|fdescribe')
+
+# get all exclusive tests
+hits=$(find . -name "*spec.ts" | xargs grep 'fit\|fdescribe' | wc -l)
+if [ $hits -ne 0 ]; then
+    for i in "${exclusive[@]}"; do
+        echo "WARNING: Exclusive tests found: "
+        echo "$i"
+    done
+    exit 1
+fi


### PR DESCRIPTION
This PR adds a script to the app that finds ignored tests. At the moment it's prepared to find only `fdescribe` and `fit` in tests. `xdescribe` and `xit` are commented out because of the ignored VRE part of the app. 
The script runs in github actions (CI) workflow. 
