### PR TITLE
fix: disable progress bar if search results are empty (DSP-1575)

### DIFF
--- a/src/app/workspace/results/results.component.html
+++ b/src/app/workspace/results/results.component.html
@@ -1,5 +1,5 @@
 <!-- In case if results present -->
-<div class="content" *ngIf="searchParams && ((!loading && (numberOfAllResults > 0)) || (searchMode === 'gravsearch'))">
+<div class="content" *ngIf="searchParams && !loading && (numberOfAllResults > 0)">
     <as-split direction="horizontal">
         <as-split-area [size]="40">
             <dsp-list-view [search]="searchParams" [displayViewSwitch]="false" (resourceSelected)="openResource($event)"></dsp-list-view>

--- a/src/app/workspace/results/results.component.html
+++ b/src/app/workspace/results/results.component.html
@@ -1,4 +1,5 @@
-<div class="content" *ngIf="searchParams">
+<!-- In case if results present -->
+<div class="content" *ngIf="searchParams && !loading && (numberOfAllResults > 0)">
     <as-split direction="horizontal">
         <as-split-area [size]="40">
             <dsp-list-view [search]="searchParams" [displayViewSwitch]="false" (resourceSelected)="openResource($event)"></dsp-list-view>
@@ -8,4 +9,16 @@
             <app-resource [resourceIri]="resourceIri"></app-resource>
         </as-split-area>
     </as-split>
+</div>
+
+<!-- In case of 0 result -->
+<div class="no-results" *ngIf="!loading && numberOfAllResults === 0">
+    <p>Your search <span *ngIf="searchMode === 'fulltext'">- <strong> {{searchQuery}}</strong> -</span> did not match any documents.</p>
+    <p>Suggestions:</p>
+    <ul>
+        <li>Make sure that all words are spelled correctly.</li>
+        <li>Try different keywords.</li>
+        <li>Try more general keywords.</li>
+        <li>Try fewer keywords.</li>
+    </ul>
 </div>

--- a/src/app/workspace/results/results.component.html
+++ b/src/app/workspace/results/results.component.html
@@ -1,5 +1,5 @@
 <!-- In case if results present -->
-<div class="content" *ngIf="searchParams && !loading && (numberOfAllResults > 0)">
+<div class="content" *ngIf="searchParams && ((!loading && (numberOfAllResults > 0)) || (searchMode === 'gravsearch'))">
     <as-split direction="horizontal">
         <as-split-area [size]="40">
             <dsp-list-view [search]="searchParams" [displayViewSwitch]="false" (resourceSelected)="openResource($event)"></dsp-list-view>

--- a/src/app/workspace/results/results.component.scss
+++ b/src/app/workspace/results/results.component.scss
@@ -3,3 +3,7 @@
 .content {
   height: calc(100vh - #{$header-height});
 }
+
+.no-results {
+  margin: 64px;
+}

--- a/src/app/workspace/results/results.component.scss
+++ b/src/app/workspace/results/results.component.scss
@@ -5,5 +5,6 @@
 }
 
 .no-results {
-  margin: 64px;
+  margin: 64px auto;
+  width: 400px;
 }

--- a/src/app/workspace/results/results.component.ts
+++ b/src/app/workspace/results/results.component.ts
@@ -74,9 +74,20 @@ export class ResultsComponent {
                     this.loading = false;
                 }
             );
+        } else if (this.searchMode === 'gravsearch') {
+            // search mode: gravsearch
+            // perform count query
+            this._dspApiConnection.v2.search.doExtendedSearchCountQuery(this.searchQuery).subscribe(
+                (response: CountQueryResponse) => {
+                    this.numberOfAllResults = response.numberOfResults;
+                    this.loading = false;
+                },
+                (error: ApiResponseError) => {
+                    this._notification.openSnackBar(error);
+                    this.loading = false;
+                }
+            );
         }
-        // in case of gravsearch
-        this.loading = false;
     }
 
     openResource(id: string) {

--- a/src/app/workspace/results/results.component.ts
+++ b/src/app/workspace/results/results.component.ts
@@ -1,14 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Params } from '@angular/router';
-import { SearchParams } from '@dasch-swiss/dsp-ui';
+import { ApiResponseError, CountQueryResponse, KnoraApiConnection } from '@dasch-swiss/dsp-js';
+import { DspApiConnectionToken, NotificationService, SearchParams } from '@dasch-swiss/dsp-ui';
 
 @Component({
     selector: 'app-results',
     templateUrl: './results.component.html',
     styleUrls: ['./results.component.scss']
 })
-export class ResultsComponent implements OnInit {
+export class ResultsComponent {
 
     searchParams: SearchParams;
 
@@ -16,15 +17,32 @@ export class ResultsComponent implements OnInit {
 
     resourceIri: string;
 
+    // number of all results
+    numberOfAllResults: number;
+
+    // search params
+    searchQuery: string;
+    searchMode: 'fulltext' | 'gravsearch';
+
+    // progress status
+    loading = true;
+
     constructor(
+        @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
+        private _notification: NotificationService,
         private _route: ActivatedRoute,
         private _titleService: Title
     ) {
 
         this._route.paramMap.subscribe((params: Params) => {
+            this.searchQuery = decodeURIComponent(params.get('q'));
+            this.searchMode = (decodeURIComponent(params.get('mode')) === 'fulltext' ? 'fulltext' : 'gravsearch');
+
+            this.checkResourceCount();
+
             this.searchParams = {
-                query: decodeURIComponent(params.get('q')),
-                mode: (decodeURIComponent(params.get('mode')) === 'fulltext' ? 'fulltext' : 'gravsearch')
+                query: this.searchQuery,
+                mode: this.searchMode
             };
             // get the project iri if exists
             if (params.get('project')) {
@@ -39,7 +57,24 @@ export class ResultsComponent implements OnInit {
         this._titleService.setTitle('Search results for ' + this.searchParams.mode + ' search');
     }
 
-    ngOnInit() {
+    // get the number of search results for given query
+    checkResourceCount() {
+
+        this.loading = true;
+
+        if (this.searchMode === 'fulltext') {
+            // perform count query
+            this._dspApiConnection.v2.search.doFulltextSearchCountQuery(this.searchQuery).subscribe(
+                (response: CountQueryResponse) => {
+                    this.numberOfAllResults = response.numberOfResults;
+                    this.loading = false;
+                },
+                (error: ApiResponseError) => {
+                    this._notification.openSnackBar(error);
+                    this.loading = false;
+                }
+            );
+        }
     }
 
     openResource(id: string) {

--- a/src/app/workspace/results/results.component.ts
+++ b/src/app/workspace/results/results.component.ts
@@ -75,6 +75,8 @@ export class ResultsComponent {
                 }
             );
         }
+        // in case of gravsearch
+        this.loading = false;
     }
 
     openResource(id: string) {


### PR DESCRIPTION
resolves DSP-1575

@flavens When page is refreshed with search string in the url, it displays search results on the page but same search string is not displayed in the search input box.

This bug requires changes in dsp-ui-lib and can be fixed in separate PR.

<img width="1783" alt="Screenshot 2021-05-19 at 13 25 50" src="https://user-images.githubusercontent.com/25031092/118805232-fc7b8480-b8a5-11eb-8ae0-3d57a4b8e80f.png">
