### PR TITLE
chore: fix dead links to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ DSP-APP is [free software](http://www.gnu.org/philosophy/free-sw.en.html), relea
 
 ### User guide
 
-➡ [for latest released version](https://docs.dasch.swiss/dsp-app/user-guide/)
+➡ [for latest released version](https://docs.dasch.swiss/DSP-APP/user-guide/)
 
 ### Developer docs
 
-➡ [for developers](https://docs.dasch.swiss/dsp-app/contribution)
+➡ [for developers](https://docs.dasch.swiss/DSP-APP/contribution)
 
 ## Contribution
 

--- a/src/app/main/help/help.component.ts
+++ b/src/app/main/help/help.component.ts
@@ -27,21 +27,21 @@ export class HelpComponent implements OnInit {
             icon: 'assignment',
             title: 'Project administration',
             text: 'Read more about project administration and how to manage project members.',
-            url: 'https://docs.dasch.swiss/dsp-app/user-guide/project',
+            url: 'https://docs.dasch.swiss/DSP-APP/user-guide/project',
             urlText: 'Open Documentation'
         },
         {
             icon: 'bubble_chart',
             title: 'Data model creation',
             text: 'Find everything about data modelling and how to setup the project database.',
-            url: 'https://docs.dasch.swiss/dsp-app/user-guide/project/#data-model',
+            url: 'https://docs.dasch.swiss/DSP-APP/user-guide/project/#data-model',
             urlText: 'Open Documentation'
         },
         {
             icon: 'image_search',
             title: 'Research tools',
             text: 'Get more information about data handling, search methods and how to use the research tools.',
-            url: 'https://docs.dasch.swiss/dsp-app/user-guide/',
+            url: 'https://docs.dasch.swiss/DSP-APP/user-guide/',
             urlText: 'Open Documentation'
         }
     ];


### PR DESCRIPTION
I thought the case-sensitivity in a URL doesn't matter. I was wrong. The links to the <https://docs.dasch.swiss/DSP-APP> were broken because <https://docs.dasch.swiss/dsp-app> does not work.
