### PR TITLE
fix(ontology): fix regex pattern in ontology form (DSP-1139)

### DIFF
--- a/src/app/project/ontology/ontology-form/ontology-form.component.html
+++ b/src/app/project/ontology/ontology-form/ontology-form.component.html
@@ -2,7 +2,7 @@
     <!-- auto complete list to select resource classes -->
     <div class="form-content">
         <mat-form-field class="large-field ontology-name">
-            <input matInput class="ontology-name" [maxlength]="nameMaxLength" [formControl]="ontologyForm.controls['name']"
+            <input matInput class="ontology-name" autocomplete="off" [maxlength]="nameMaxLength" [formControl]="ontologyForm.controls['name']"
                 [placeholder]="'Set a unique name *'">
             <mat-icon matSuffix [matTooltip]="ontologyNameInfo" matTooltipPosition="above" matTooltipClass="multi-line-tooltip">help</mat-icon>
             <mat-hint *ngIf="formErrors.name" class="medium-field">

--- a/src/app/project/ontology/ontology-form/ontology-form.component.spec.ts
+++ b/src/app/project/ontology/ontology-form/ontology-form.component.spec.ts
@@ -126,6 +126,50 @@ describe('OntologyFormComponent', () => {
 
     });
 
+    it('should test form validity with not allowed names', () => {
+        const form = ontologyFormComponent.ontologyForm;
+        expect(form.valid).toBeFalsy();
+
+        const nameInput = form.controls.name;
+
+        nameInput.setValue('v2onto');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('my-onto');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('2ndOnto');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('-notAllowed');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('_notAllowed');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('not-allowed');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('not_allowed');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('not.allowed');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('no$or€');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('no spaces');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('ältereOnto');
+        expect(form.valid).toBeFalsy();
+
+        nameInput.setValue('bestOnto');
+        expect(form.valid).toBeTruthy();
+
+    });
+
     it('should test form validity without label', () => {
         const form = ontologyFormComponent.ontologyForm;
         expect(form.valid).toBeFalsy();

--- a/src/app/project/ontology/ontology-form/ontology-form.component.ts
+++ b/src/app/project/ontology/ontology-form/ontology-form.component.ts
@@ -51,8 +51,10 @@ export class OntologyFormComponent implements OnInit {
 
     lastModificationDate: string;
 
-    nameRegex = /^(?![vV][0-9]|[0-9]|[\u00C0-\u017F]).[a-zA-Z0-9]+\S*$/;
+    // regex to check ontology name: shouldn't start with a number or with 'v' followed by a number, spaces or special characters are not allowed
+    nameRegex = /^(?![vV]+[0-9])+^([a-zA-Z_])[a-zA-Z0-9]*$/;
 
+    // ontology name must not contain one of the following words
     forbiddenNames: string[] = [
         'knora',
         'salsah',

--- a/src/app/project/ontology/ontology-form/ontology-form.component.ts
+++ b/src/app/project/ontology/ontology-form/ontology-form.component.ts
@@ -52,7 +52,7 @@ export class OntologyFormComponent implements OnInit {
     lastModificationDate: string;
 
     // regex to check ontology name: shouldn't start with a number or with 'v' followed by a number, spaces or special characters are not allowed
-    nameRegex = /^(?![vV]+[0-9])+^([a-zA-Z_])[a-zA-Z0-9]*$/;
+    nameRegex = /^(?![vV]+[0-9])+^([a-zA-Z])[a-zA-Z0-9]*$/;
 
     // ontology name must not contain one of the following words
     forbiddenNames: string[] = [


### PR DESCRIPTION
resolves DSP-1139

We had an issue in the "create ontology" form. The regex didn't work as expected. As the DSP-API documentation says: "An ontology name must be a valid XML NCName. [...] A user-created ontology name may not start with the letter v followed by a digit". Special characters (incl. Umlauts etc), spaces and leading numbers are not allowed.
In this PR I fixed the regex and turned off the autocomplete (because it hides the error message below the field).