### PR TITLE
feat(resource): create link / collection resource (DSP-1835)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,28 +76,6 @@
         "typescript": "4.0.7"
       }
     },
-    ".yalc/@dasch-swiss/dsp-ui": {
-      "version": "1.7.1",
-      "extraneous": true,
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/cdk": "^11.2.5",
-        "@angular/common": "~11.2.6",
-        "@angular/core": "~11.2.6",
-        "@angular/material": "^11.2.5",
-        "@ckeditor/ckeditor5-angular": "^1.2.3",
-        "@dasch-swiss/dsp-js": "^2.7.0",
-        "ckeditor5-custom-build": "github:dasch-swiss/ckeditor_custom_build",
-        "jdnconvertiblecalendar": "^0.0.7",
-        "jdnconvertiblecalendardateadapter": "^0.0.17",
-        "ngx-color-picker": "^11.0.0",
-        "openseadragon": "^2.4.2",
-        "svg-overlay": "github:openseadragon/svg-overlay"
-      }
-    },
     "node_modules/@angular-devkit/architect": {
       "version": "0.1102.14",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/router": "^11.2.9",
         "@ckeditor/ckeditor5-angular": "^1.2.3",
         "@dasch-swiss/dsp-js": "^3.0.0",
-        "@dasch-swiss/dsp-ui": "^1.7.4",
+        "@dasch-swiss/dsp-ui": "^1.7.5",
         "@ngx-translate/core": "^12.1.2",
         "@ngx-translate/http-loader": "5.0.0",
         "3d-force-graph": "^1.60.12",
@@ -2115,9 +2115,9 @@
       }
     },
     "node_modules/@dasch-swiss/dsp-ui": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-ui/-/dsp-ui-1.7.4.tgz",
-      "integrity": "sha512-fQyHcgl8w68T3XcvamR0jhcTiUqo3b+VB+uwJHWP6pjHx4uF9DQCSKHtDVmBkmAbCo+99bD3I4hDROrvNbq/TQ==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-ui/-/dsp-ui-1.7.5.tgz",
+      "integrity": "sha512-SeJ4sBlhtH+lQVrhucsJdik4XI9Ek7u20j5OmyjDxG6ekoZFXmdhGcn1BmS5VjJAo48H67z3L+7kj05Za8s94Q==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2128,6 +2128,7 @@
         "@angular/material": "^11.2.5",
         "@ckeditor/ckeditor5-angular": "^1.2.3",
         "@dasch-swiss/dsp-js": "^3.0.0",
+        "angular-split": "^4.0.0",
         "ckeditor5-custom-build": "github:dasch-swiss/ckeditor_custom_build",
         "jdnconvertiblecalendar": "^0.0.7",
         "jdnconvertiblecalendardateadapter": "^0.0.17",
@@ -9906,9 +9907,10 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.6.0",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
-      "license": "(MIT OR GPL-3.0)",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -15845,9 +15847,10 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.0",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
+      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -16526,9 +16529,10 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.1",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -20014,9 +20018,9 @@
       }
     },
     "@dasch-swiss/dsp-ui": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-ui/-/dsp-ui-1.7.4.tgz",
-      "integrity": "sha512-fQyHcgl8w68T3XcvamR0jhcTiUqo3b+VB+uwJHWP6pjHx4uF9DQCSKHtDVmBkmAbCo+99bD3I4hDROrvNbq/TQ==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-ui/-/dsp-ui-1.7.5.tgz",
+      "integrity": "sha512-SeJ4sBlhtH+lQVrhucsJdik4XI9Ek7u20j5OmyjDxG6ekoZFXmdhGcn1BmS5VjJAo48H67z3L+7kj05Za8s94Q==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -25347,7 +25351,9 @@
       }
     },
     "jszip": {
-      "version": "3.6.0",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -29286,7 +29292,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.0",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
+      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -29743,7 +29751,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/router": "^11.2.9",
     "@ckeditor/ckeditor5-angular": "^1.2.3",
     "@dasch-swiss/dsp-js": "^3.0.0",
-    "@dasch-swiss/dsp-ui": "^1.7.4",
+    "@dasch-swiss/dsp-ui": "^1.7.5",
     "@ngx-translate/core": "^12.1.2",
     "@ngx-translate/http-loader": "5.0.0",
     "3d-force-graph": "^1.60.12",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -97,6 +97,7 @@ import { ResourceComponent } from './workspace/resource/resource.component';
 import { ResultsComponent } from './workspace/results/results.component';
 import { AudioComponent } from './workspace/resource/representation/audio/audio.component';
 import { IntermediateComponent } from './workspace/intermediate/intermediate.component';
+import { ResourceLinkFormComponent } from './workspace/resource/resource-link-form/resource-link-form.component';
 
 // translate: AoT requires an exported function for factories
 export function httpLoaderFactory(httpClient: HttpClient) {
@@ -180,6 +181,7 @@ export function httpLoaderFactory(httpClient: HttpClient) {
         VisualizerComponent,
         AudioComponent,
         IntermediateComponent,
+        ResourceLinkFormComponent,
     ],
     imports: [
         AppRoutingModule,

--- a/src/app/main/dialog/dialog.component.html
+++ b/src/app/main/dialog/dialog.component.html
@@ -387,6 +387,13 @@
         </mat-dialog-actions>
     </div>
 
+    <div *ngSwitchCase="'linkResources'">
+        <app-dialog-header [title]="data.title" [subtitle]="'Link resources'"></app-dialog-header>
+        <mat-dialog-content>
+            <app-resource-link-form [resources]="data.selectedResources"></app-resource-link-form>
+        </mat-dialog-content>
+    </div>
+
     <!-- general error message -->
     <div *ngSwitchCase="'error'">
         <app-error [status]="data.id"></app-error>

--- a/src/app/main/dialog/dialog.component.html
+++ b/src/app/main/dialog/dialog.component.html
@@ -390,7 +390,7 @@
     <div *ngSwitchCase="'linkResources'">
         <app-dialog-header [title]="data.title" [subtitle]="'Link resources'"></app-dialog-header>
         <mat-dialog-content>
-            <app-resource-link-form [resources]="data.selectedResources"></app-resource-link-form>
+            <app-resource-link-form [resources]="data.selectedResources" (closeDialog)="dialogRef.close($event)"></app-resource-link-form>
         </mat-dialog-content>
     </div>
 

--- a/src/app/main/dialog/dialog.component.ts
+++ b/src/app/main/dialog/dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { FilteredResources } from '@dasch-swiss/dsp-ui';
 import { PropertyInfoObject } from 'src/app/project/ontology/default-data/default-properties';
 
 export interface DialogData {
@@ -17,7 +17,7 @@ export interface DialogData {
     position?: number;
     parentIri?: string;
     projectCode?: string;
-    selectedResources?: FilteredResouces;
+    selectedResources?: FilteredResources;
 }
 
 export interface ConfirmationWithComment {

--- a/src/app/main/dialog/dialog.component.ts
+++ b/src/app/main/dialog/dialog.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FilteredResouces } from '@dasch-swiss/dsp-ui';
 import { PropertyInfoObject } from 'src/app/project/ontology/default-data/default-properties';
 
 export interface DialogData {
@@ -16,6 +17,7 @@ export interface DialogData {
     position?: number;
     parentIri?: string;
     projectCode?: string;
+    selectedResources?: FilteredResouces;
 }
 
 export interface ConfirmationWithComment {

--- a/src/app/workspace/intermediate/intermediate.component.html
+++ b/src/app/workspace/intermediate/intermediate.component.html
@@ -9,26 +9,15 @@
         <div class="action">
             <span class="fill-remaining-space"></span>
             <span>
-                <!-- link button to create a link resource (linkObj); TODO: add function to create link object -->
-                <!-- at the moment the button is disabled because of the missing functionality; it needs a "span-tag-hack" to display the tooltip -->
-                <span matTooltip="Create a link object from this selection | Currently not implemented"
-                [matTooltipPosition]="'above'">
-                    <button mat-mini-fab color="primary"
-                    class="link"
-                    matTooltip="Create a link object from this selection"
-                    [matTooltipPosition]="'above'"
-                    [disabled]="true"
-                    (click)="action.emit('link')">
+                <!-- link button to create a link resource (linkObj) -->
+                <button mat-mini-fab color="primary" class="link" matTooltip="Create a link object from this selection"
+                    [matTooltipPosition]="'above'" [disabled]="resources.count < 2" (click)="linkResources(resources)">
                     <mat-icon>link</mat-icon>
                 </button>
-            </span>
+                <!-- TODO: add more functionality for multiple resources: edit (only if same resource type), add to favorites, delete etc. -->
                 <!-- compare button to compare more than two resources -->
-                <button mat-mini-fab color="primary"
-                    class="compare"
-                    matTooltip="Compare the selected resources"
-                    [matTooltipPosition]="'above'"
-                    [disabled]="resources.count < 2"
-                    (click)="action.emit('compare')">
+                <button mat-mini-fab color="primary" class="compare" matTooltip="Compare the selected resources"
+                    [matTooltipPosition]="'above'" [disabled]="resources.count < 2" (click)="action.emit('compare')">
                     <mat-icon>compare_arrows</mat-icon>
                 </button>
             </span>

--- a/src/app/workspace/intermediate/intermediate.component.html
+++ b/src/app/workspace/intermediate/intermediate.component.html
@@ -11,7 +11,7 @@
             <span>
                 <!-- link button to create a link resource (linkObj) -->
                 <button mat-mini-fab color="primary" class="link" matTooltip="Create a link object from this selection"
-                    [matTooltipPosition]="'above'" [disabled]="resources.count < 2" (click)="linkResources(resources)">
+                    [matTooltipPosition]="'above'" [disabled]="resources.count < 2" (click)="openDialog('link', resources)">
                     <mat-icon>link</mat-icon>
                 </button>
                 <!-- TODO: add more functionality for multiple resources: edit (only if same resource type), add to favorites, delete etc. -->

--- a/src/app/workspace/intermediate/intermediate.component.spec.ts
+++ b/src/app/workspace/intermediate/intermediate.component.spec.ts
@@ -1,10 +1,13 @@
 import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { By } from '@angular/platform-browser';
-import { FilteredResources } from '@dasch-swiss/dsp-ui';
+import { KnoraApiConnection } from '@dasch-swiss/dsp-js';
+import { AppInitService, DspActionModule, DspApiConfigToken, DspApiConnectionToken, FilteredResources } from '@dasch-swiss/dsp-ui';
+import { TestConfig } from 'test.config';
 import { IntermediateComponent } from './intermediate.component';
 
 /**
@@ -81,12 +84,24 @@ describe('IntermediateComponent', () => {
                 ThreeSelectedResourcesComponent
             ],
             imports: [
+                DspActionModule,
                 MatButtonModule,
+                MatDialogModule,
                 MatIconModule,
                 MatTooltipModule
+            ],
+            providers: [
+                AppInitService,
+                {
+                    provide: DspApiConfigToken,
+                    useValue: TestConfig.ApiConfig
+                },
+                {
+                    provide: DspApiConnectionToken,
+                    useValue: new KnoraApiConnection(TestConfig.ApiConfig)
+                }
             ]
-        })
-            .compileComponents();
+        }).compileComponents();
     });
 
     beforeEach(() => {

--- a/src/app/workspace/intermediate/intermediate.component.spec.ts
+++ b/src/app/workspace/intermediate/intermediate.component.spec.ts
@@ -4,7 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { By } from '@angular/platform-browser';
-import { FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { FilteredResources } from '@dasch-swiss/dsp-ui';
 import { IntermediateComponent } from './intermediate.component';
 
 /**
@@ -17,12 +17,13 @@ class OneSelectedResourcesComponent {
 
     @ViewChild('intermediateView') intermediateComponent: IntermediateComponent;
 
-    resources: FilteredResouces = {
+    resources: FilteredResources = {
         'count': 1,
         'resListIndex': [1],
-        'resIds': [
-            'http://rdfh.ch/0803/83616f8d8501'
-        ],
+        'resInfo': [{
+            'id': 'http://rdfh.ch/0803/83616f8d8501',
+            'label': '65r'
+        }],
         'selectionType': 'multiple'
     };
 
@@ -40,13 +41,22 @@ class ThreeSelectedResourcesComponent {
 
     @ViewChild('intermediateView') intermediateComponent: IntermediateComponent;
 
-    resources: FilteredResouces = {
+    resources: FilteredResources = {
         'count': 3,
         'resListIndex': [3, 2, 1],
-        'resIds': [
-            'http://rdfh.ch/0803/83616f8d8501',
-            'http://rdfh.ch/0803/71e0b9958a01',
-            'http://rdfh.ch/0803/683d5cd26f01'
+        'resInfo': [
+            {
+                'id': 'http://rdfh.ch/0803/83616f8d8501',
+                'label': '65r'
+            },
+            {
+                'id': 'http://rdfh.ch/0803/71e0b9958a01',
+                'label': '76r'
+            },
+            {
+                'id': 'http://rdfh.ch/0803/683d5cd26f01',
+                'label': '17v'
+            },
         ],
         'selectionType': 'multiple'
     };

--- a/src/app/workspace/intermediate/intermediate.component.ts
+++ b/src/app/workspace/intermediate/intermediate.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { FilteredResources } from '@dasch-swiss/dsp-ui';
 import { DialogComponent } from 'src/app/main/dialog/dialog.component';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
 
@@ -11,7 +11,7 @@ import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
 })
 export class IntermediateComponent implements OnInit {
 
-    @Input() resources: FilteredResouces;
+    @Input() resources: FilteredResources;
 
     @Output() action: EventEmitter<string> = new EventEmitter<string>();
 
@@ -35,9 +35,9 @@ export class IntermediateComponent implements OnInit {
      * @param type 'link' --> TODO: will be expanded with other types like edit, delete etc.
      * @param data
      */
-    openDialog(type: 'link', data: FilteredResouces) {
+    openDialog(type: 'link', data: FilteredResources) {
 
-        const title = 'Create collection of ' + data.count + ' resources';
+        const title = 'Create a collection of ' + data.count + ' resources';
 
         const dialogConfig: MatDialogConfig = {
             width: '640px',

--- a/src/app/workspace/intermediate/intermediate.component.ts
+++ b/src/app/workspace/intermediate/intermediate.component.ts
@@ -1,5 +1,15 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
+import {
+    ApiResponseError,
+    Constants,
+    CreateLinkValue,
+    CreateResource,
+    CreateTextValueAsString,
+    KnoraApiConnection,
+    ReadResource
+} from '@dasch-swiss/dsp-js';
+import { DspApiConnectionToken, FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
 
 @Component({
     selector: 'app-intermediate',
@@ -20,8 +30,71 @@ export class IntermediateComponent implements OnInit {
         }
     };
 
-    constructor() { }
+    constructor(
+        @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
+        private _errorHandler: ErrorHandlerService,
+    ) { }
 
     ngOnInit(): void { }
+
+    /**
+     * create a link resource from selected resources
+     * @param resources
+     */
+    linkResources(resources: FilteredResouces) {
+
+        // step 1: open dialog box with form to define label and comment
+
+
+        // step 2: submit link resource
+        const linkObj = new CreateResource();
+
+        // --> TODO: will be replaced by label input from form value
+        linkObj.label = 'Label from link resource form: input';
+
+        linkObj.type = Constants.KnoraApiV2 + Constants.HashDelimiter + 'LinkObj';
+
+        linkObj.attachedToProject = 'http://rdfh.ch/projects/1111';
+
+        const propertyValues = [];
+        const hasComment = [];
+        // hasComment[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment'] = [];
+        const hasLinkToValue = [];
+        // hasLinkToValue[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue'] = [];
+        resources.resIds.forEach(id => {
+            const linkVal = new CreateLinkValue();
+            linkVal.type = Constants.LinkValue;
+            linkVal.linkedResourceIri = id;
+            // the value could have a comment
+            // linkVal.valueHasComment = 'comment from link res form?';
+
+            hasLinkToValue.push(linkVal);
+        });
+
+        // --> TODO: will be replaced by comment input from form value
+        const comment = 'Comment from link resource form: textarea';
+        if (comment) {
+            const commentVal = new CreateTextValueAsString();
+            commentVal.type = Constants.TextValue;
+            commentVal.text = comment;
+            hasComment.push(commentVal);
+        }
+
+        linkObj.properties = {
+            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue']: hasLinkToValue,
+            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment']: hasComment,
+        };
+
+
+        this._dspApiConnection.v2.res.createResource(linkObj).subscribe(
+            (response: ReadResource) => {
+                // --> TODO: do something with the successful response
+            },
+            (error: ApiResponseError) => {
+                this._errorHandler.showMessage(error);
+            }
+        );
+
+    }
 
 }

--- a/src/app/workspace/intermediate/intermediate.component.ts
+++ b/src/app/workspace/intermediate/intermediate.component.ts
@@ -1,14 +1,7 @@
-import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
-import {
-    ApiResponseError,
-    Constants,
-    CreateLinkValue,
-    CreateResource,
-    CreateTextValueAsString,
-    KnoraApiConnection,
-    ReadResource
-} from '@dasch-swiss/dsp-js';
-import { DspApiConnectionToken, FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { DialogComponent } from 'src/app/main/dialog/dialog.component';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
 
 @Component({
@@ -31,70 +24,39 @@ export class IntermediateComponent implements OnInit {
     };
 
     constructor(
-        @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
+        private _dialog: MatDialog,
         private _errorHandler: ErrorHandlerService,
     ) { }
 
     ngOnInit(): void { }
 
     /**
-     * create a link resource from selected resources
-     * @param resources
+     * opens the dialog box with a form to create a link resource, to edit resources etc.
+     * @param type 'link' --> TODO: will be expanded with other types like edit, delete etc.
+     * @param data
      */
-    linkResources(resources: FilteredResouces) {
+    openDialog(type: 'link', data: FilteredResouces) {
 
-        // step 1: open dialog box with form to define label and comment
+        const title = 'Create collection of ' + data.count + ' resources';
 
-
-        // step 2: submit link resource
-        const linkObj = new CreateResource();
-
-        // --> TODO: will be replaced by label input from form value
-        linkObj.label = 'Label from link resource form: input';
-
-        linkObj.type = Constants.KnoraApiV2 + Constants.HashDelimiter + 'LinkObj';
-
-        linkObj.attachedToProject = 'http://rdfh.ch/projects/1111';
-
-        const propertyValues = [];
-        const hasComment = [];
-        // hasComment[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment'] = [];
-        const hasLinkToValue = [];
-        // hasLinkToValue[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue'] = [];
-        resources.resIds.forEach(id => {
-            const linkVal = new CreateLinkValue();
-            linkVal.type = Constants.LinkValue;
-            linkVal.linkedResourceIri = id;
-            // the value could have a comment
-            // linkVal.valueHasComment = 'comment from link res form?';
-
-            hasLinkToValue.push(linkVal);
-        });
-
-        // --> TODO: will be replaced by comment input from form value
-        const comment = 'Comment from link resource form: textarea';
-        if (comment) {
-            const commentVal = new CreateTextValueAsString();
-            commentVal.type = Constants.TextValue;
-            commentVal.text = comment;
-            hasComment.push(commentVal);
-        }
-
-        linkObj.properties = {
-            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue']: hasLinkToValue,
-            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment']: hasComment,
+        const dialogConfig: MatDialogConfig = {
+            width: '640px',
+            maxHeight: '80vh',
+            position: {
+                top: '112px'
+            },
+            data: { mode: type + 'Resources', title: title, selectedResources: data }
         };
 
-
-        this._dspApiConnection.v2.res.createResource(linkObj).subscribe(
-            (response: ReadResource) => {
-                // --> TODO: do something with the successful response
-            },
-            (error: ApiResponseError) => {
-                this._errorHandler.showMessage(error);
-            }
+        const dialogRef = this._dialog.open(
+            DialogComponent,
+            dialogConfig
         );
 
+        dialogRef.afterClosed().subscribe((resId: string) => {
+
+            // do something with the intermediate view... but what should we do / display? Maybe the new resource...
+        });
     }
 
 }

--- a/src/app/workspace/resource/project.service.spec.ts
+++ b/src/app/workspace/resource/project.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProjectService } from './project.service';
+
+describe('ProjectService', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ProjectService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/workspace/resource/project.service.spec.ts
+++ b/src/app/workspace/resource/project.service.spec.ts
@@ -1,16 +1,41 @@
 import { TestBed } from '@angular/core/testing';
-
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DspActionModule, DspApiConnectionToken, DspCoreModule } from '@dasch-swiss/dsp-ui';
 import { ProjectService } from './project.service';
 
+
 describe('ProjectService', () => {
-  let service: ProjectService;
+    let service: ProjectService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(ProjectService);
-  });
+    beforeEach(() => {
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
-  });
+        const apiEndpointSpyObj = {
+            v2: {
+                auth: jasmine.createSpyObj('auth', ['logout'])
+            }
+        };
+
+        TestBed.configureTestingModule({
+            imports: [
+                BrowserAnimationsModule,
+                DspActionModule,
+                DspCoreModule,
+                MatDialogModule,
+                MatSnackBarModule
+            ],
+            providers: [
+                {
+                    provide: DspApiConnectionToken,
+                    useValue: apiEndpointSpyObj
+                },
+            ]
+        });
+        service = TestBed.inject(ProjectService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
 });

--- a/src/app/workspace/resource/project.service.ts
+++ b/src/app/workspace/resource/project.service.ts
@@ -1,0 +1,65 @@
+import { Inject, Injectable } from '@angular/core';
+import { ApiResponseData, ApiResponseError, Constants, KnoraApiConnection, ProjectsResponse, StoredProject, UserResponse } from '@dasch-swiss/dsp-js';
+import { DspApiConnectionToken, SessionService } from '@dasch-swiss/dsp-ui';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { CacheService } from 'src/app/main/cache/cache.service';
+import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ProjectService {
+
+    constructor(
+        @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
+        private _cache: CacheService,
+        private _errorHandler: ErrorHandlerService,
+        private _session: SessionService
+    ) { }
+
+    /**
+     * initializes projects
+     * @returns projects
+     */
+    initializeProjects(): Observable<StoredProject[]> {
+        const usersProjects: StoredProject[] = [];
+
+        // get info about logged-in user from the session object
+        const session = this._session.getSession();
+
+        if (session.user.sysAdmin === false) {
+            return this._cache.get(session.user.name, this._dspApiConnection.admin.usersEndpoint.getUserByUsername(session.user.name)).pipe(
+                map((response: ApiResponseData<UserResponse>) => {
+
+                    for (const project of response.body.user.projects) {
+                        if (project.status) {
+                            usersProjects.push(project);
+                        }
+                    }
+                    return <StoredProject[]>usersProjects;
+                },
+                (error: ApiResponseError) => {
+                    this._errorHandler.showMessage(error);
+                    return <StoredProject[]>[];
+                })
+            );
+        } else {
+            return this._dspApiConnection.admin.projectsEndpoint.getProjects().pipe(
+                map((response: ApiResponseData<ProjectsResponse>) => {
+                    for (const project of response.body.projects) {
+                        if (project.status && project.id !== Constants.SystemProjectIRI && project.id !== Constants.DefaultSharedOntologyIRI) {
+                            usersProjects.push(project);
+                        }
+                    }
+                    return <StoredProject[]>usersProjects;
+                },
+                (error: ApiResponseError) => {
+                    this._errorHandler.showMessage(error);
+                    return <StoredProject[]>[];
+                })
+            );
+        }
+
+    }
+}

--- a/src/app/workspace/resource/resource-instance-form/resource-instance-form.component.spec.ts
+++ b/src/app/workspace/resource/resource-instance-form/resource-instance-form.component.spec.ts
@@ -35,13 +35,19 @@ import {
     UsersEndpointAdmin
 } from '@dasch-swiss/dsp-js';
 import { OntologyCache } from '@dasch-swiss/dsp-js/src/cache/ontology-cache/OntologyCache';
-import { DspActionModule, DspApiConnectionToken, IntValueComponent, Session, SessionService, ValueService } from '@dasch-swiss/dsp-ui';
+import {
+    DspActionModule,
+    DspApiConnectionToken,
+    IntValueComponent,
+    Session,
+    SessionService,
+    ValueService
+} from '@dasch-swiss/dsp-ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { AjaxResponse } from 'rxjs/ajax';
 import { CacheService } from 'src/app/main/cache/cache.service';
 import { BaseValueDirective } from 'src/app/main/directive/base-value.directive';
-import { ResourceComponent } from '../resource.component';
 import { ResourceInstanceFormComponent } from './resource-instance-form.component';
 import { SwitchPropertiesComponent } from './select-properties/switch-properties/switch-properties.component';
 
@@ -252,7 +258,7 @@ describe('ResourceInstanceFormComponent', () => {
 
         const cacheServiceSpy = jasmine.createSpyObj('CacheService', ['get']);
 
-        const routerSpy = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl']);
+        // const routerSpy = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl']);
 
         TestBed.configureTestingModule({
             declarations: [
@@ -275,9 +281,7 @@ describe('ResourceInstanceFormComponent', () => {
                 MatSelectModule,
                 MatSnackBarModule,
                 ReactiveFormsModule,
-                RouterTestingModule.withRoutes([
-                    { path: 'resource', component: ResourceComponent }
-                ]),
+                RouterTestingModule,
                 TranslateModule.forRoot()
             ],
             providers: [
@@ -340,11 +344,6 @@ describe('ResourceInstanceFormComponent', () => {
                 return of(ApiResponseData.fromAjaxResponse({ response } as AjaxResponse));
             }
         );
-
-        // const routerSpy = TestBed.inject(Router);
-
-        // (routerSpy as jasmine.SpyObj<Router>).navigate.and.stub();
-        // (routerSpy as jasmine.SpyObj<Router>).navigateByUrl.and.stub();
 
         testHostFixture = TestBed.createComponent(TestHostComponent);
         testHostComponent = testHostFixture.componentInstance;

--- a/src/app/workspace/resource/resource-instance-form/resource-instance-form.component.ts
+++ b/src/app/workspace/resource/resource-instance-form/resource-instance-form.component.ts
@@ -27,6 +27,7 @@ import {
 import { Subscription } from 'rxjs';
 import { CacheService } from 'src/app/main/cache/cache.service';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
+import { ProjectService } from '../project.service';
 import { SelectOntologyComponent } from './select-ontology/select-ontology.component';
 import { SelectPropertiesComponent } from './select-properties/select-properties.component';
 import { SelectResourceClassComponent } from './select-resource-class/select-resource-class.component';
@@ -90,6 +91,7 @@ export class ResourceInstanceFormComponent implements OnInit, OnDestroy {
         private _errorHandler: ErrorHandlerService,
         private _fb: FormBuilder,
         private _router: Router,
+        private _project: ProjectService,
         private _session: SessionService
     ) {
         this.session = this._session.getSession();
@@ -104,7 +106,16 @@ export class ResourceInstanceFormComponent implements OnInit, OnDestroy {
         this.propertiesParentForm = this._fb.group({});
 
         // initialize projects to be used for the project selection in the creation form
-        this.initializeProjects();
+        this._project.initializeProjects().subscribe(
+            (proj: StoredProject[]) => {
+                this.usersProjects = proj;
+
+                // notifies the user that he/she is not part of any project
+                if (proj.length === 0) {
+                    this.errorMessage = 'You are not a part of any active projects or something went wrong';
+                }
+            }
+        );
 
         // boolean to show only the first step of the form (= selectResourceForm)
         this.showNextStepForm = true;
@@ -197,48 +208,6 @@ export class ResourceInstanceFormComponent implements OnInit, OnDestroy {
         } else {
             this.propertiesParentForm.markAllAsTouched();
         }
-    }
-
-    /**
-     * get the user's project(s)
-     */
-    initializeProjects(): void {
-        this.usersProjects = [];
-
-        if (this.username && this.session.user.sysAdmin === false) {
-            this._cache.get(this.username, this._dspApiConnection.admin.usersEndpoint.getUserByUsername(this.username)).subscribe(
-                (response: ApiResponseData<UserResponse>) => {
-
-                    for (const project of response.body.user.projects) {
-                        if (project.status) {
-                            this.usersProjects.push(project);
-                        }
-                    }
-
-                    // notifies the user that he/she is not part of any project
-                    if (this.usersProjects.length === 0) {
-                        this.errorMessage = 'You are not a part of any active projects.';
-                    }
-                },
-                (error: ApiResponseError) => {
-                    this._errorHandler.showMessage(error);
-                }
-            );
-        } else if (this.session.user.sysAdmin === true) {
-            this._dspApiConnection.admin.projectsEndpoint.getProjects().subscribe(
-                (response: ApiResponseData<ProjectsResponse>) => {
-                    for (const project of response.body.projects) {
-                        if (project.status && project.id !== Constants.SystemProjectIRI && project.id !== Constants.DefaultSharedOntologyIRI) {
-                            this.usersProjects.push(project);
-                        }
-                    }
-                },
-                (error: ApiResponseError) => {
-                    this._errorHandler.showMessage(error);
-                }
-            );
-        }
-
     }
 
     /**

--- a/src/app/workspace/resource/resource-instance-form/resource-instance-form.component.ts
+++ b/src/app/workspace/resource/resource-instance-form/resource-instance-form.component.ts
@@ -2,30 +2,23 @@ import { Component, EventEmitter, Inject, OnDestroy, OnInit, Output, ViewChild }
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import {
-    ApiResponseData,
     ApiResponseError,
     Constants,
     CreateFileValue,
     CreateResource,
     CreateValue,
     KnoraApiConnection,
-    OntologiesMetadata,
-    ProjectsResponse,
-    ReadOntology,
+    OntologiesMetadata, ReadOntology,
     ReadResource,
     ResourceClassAndPropertyDefinitions,
     ResourceClassDefinition,
     ResourcePropertyDefinition,
-    StoredProject,
-    UserResponse
+    StoredProject
 } from '@dasch-swiss/dsp-js';
 import {
-    DspApiConnectionToken,
-    Session,
-    SessionService
+    DspApiConnectionToken
 } from '@dasch-swiss/dsp-ui';
 import { Subscription } from 'rxjs';
-import { CacheService } from 'src/app/main/cache/cache.service';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
 import { ProjectService } from '../project.service';
 import { SelectOntologyComponent } from './select-ontology/select-ontology.component';
@@ -58,9 +51,6 @@ export class ResourceInstanceFormComponent implements OnInit, OnDestroy {
     // form validation status
     formValid = false;
 
-    session: Session;
-    username: string;
-
     showNextStepForm: boolean;
 
     usersProjects: StoredProject[];
@@ -87,16 +77,11 @@ export class ResourceInstanceFormComponent implements OnInit, OnDestroy {
 
     constructor(
         @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
-        private _cache: CacheService,
         private _errorHandler: ErrorHandlerService,
         private _fb: FormBuilder,
-        private _router: Router,
         private _project: ProjectService,
-        private _session: SessionService
-    ) {
-        this.session = this._session.getSession();
-        this.username = this.session.user.name;
-    }
+        private _router: Router
+    ) { }
 
 
     ngOnInit(): void {
@@ -196,7 +181,7 @@ export class ResourceInstanceFormComponent implements OnInit, OnDestroy {
                     this.resource = res;
 
                     const goto = '/resource/' + encodeURIComponent(this.resource.id);
-                    this._router.navigateByUrl(goto, { skipLocationChange: false });
+                    this._router.navigate([]).then(result => window.open(goto, '_blank'));
 
                     this.closeDialog.emit();
                 },

--- a/src/app/workspace/resource/resource-instance-form/select-project/select-project.component.ts
+++ b/src/app/workspace/resource/resource-instance-form/select-project/select-project.component.ts
@@ -9,8 +9,7 @@ import {
     Output
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { KnoraApiConnection, StoredProject } from '@dasch-swiss/dsp-js';
-import { DspApiConnectionToken } from '@dasch-swiss/dsp-ui';
+import { StoredProject } from '@dasch-swiss/dsp-js';
 import { Subscription } from 'rxjs';
 
 const resolvedPromise = Promise.resolve(null);

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.html
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.html
@@ -1,0 +1,1 @@
+<p>resource-link-form works!</p>

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.html
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.html
@@ -1,6 +1,15 @@
 <form [formGroup]="form" (ngSubmit)="submitData()" class="form" *ngIf="usersProjects?.length; else notProjectMember">
     <!-- auto complete list to select resource classes -->
     <div class="form-content">
+
+        <app-select-project
+            matTooltip="The link resource has to be added to a project. Please select one of yours."
+            [matTooltipPosition]="'above'"
+            [formGroup]="form"
+            [usersProjects]="usersProjects"
+            (projectSelected)="selectedProject = $event">
+        </app-select-project>
+
         <mat-form-field class="large-field label">
             <input matInput autocomplete="off" [formControl]="form.controls['label']"
                 [placeholder]="'Collection label *'">
@@ -16,11 +25,12 @@
             </textarea>
         </mat-form-field>
 
-        <app-select-project
-            [formGroup]="form"
-            [usersProjects]="usersProjects"
-            (projectSelected)="selectedProject = $event">
-        </app-select-project>
+        <div class="resource-container">
+            <p>The following resources will be connected:</p>
+            <ul>
+                <li *ngFor="let res of resources.resInfo">{{res.label}}</li>
+            </ul>
+        </div>
 
         <div class="form-panel form-action">
             <span>

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.html
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.html
@@ -1,1 +1,46 @@
-<p>resource-link-form works!</p>
+<form [formGroup]="form" (ngSubmit)="submitData()" class="form" *ngIf="usersProjects?.length; else notProjectMember">
+    <!-- auto complete list to select resource classes -->
+    <div class="form-content">
+        <mat-form-field class="large-field label">
+            <input matInput autocomplete="off" [formControl]="form.controls['label']"
+                [placeholder]="'Collection label *'">
+            <mat-hint *ngIf="formErrors.label" class="medium-field">
+                {{ formErrors.label }}
+            </mat-hint>
+        </mat-form-field>
+
+        <mat-form-field class="large-field ontology-comment">
+            <textarea matInput [formControl]="form.controls['comment']"
+                [placeholder]="'Comment'"
+                matTextareaAutosize [matAutosizeMinRows]="6" [matAutosizeMaxRows]="12">
+            </textarea>
+        </mat-form-field>
+
+        <app-select-project
+            [formGroup]="form"
+            [usersProjects]="usersProjects"
+            (projectSelected)="selectedProject = $event">
+        </app-select-project>
+
+        <div class="form-panel form-action">
+            <span>
+                <button mat-button type="button" (click)="closeDialog.emit()">
+                    {{ 'appLabels.form.action.cancel' | translate }}
+                </button>
+            </span>
+            <span class="fill-remaining-space"></span>
+            <span>
+                <button mat-raised-button type="submit" [color]="error ? 'warn' : 'primary'" [disabled]="!form.valid">
+                    <dsp-progress-indicator [color]="'white'" [status]="0" *ngIf="loading" class="submit-progress">
+                    </dsp-progress-indicator>
+                    <mat-icon *ngIf="error && !loading">close</mat-icon>
+                    {{error ? 'Failed' : 'Create'}}
+                </button>
+            </span>
+        </div>
+    </div>
+</form>
+
+<ng-template #notProjectMember>
+    You have to be a member in at least one project to link the selected resources.
+</ng-template>

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.spec.ts
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.spec.ts
@@ -1,25 +1,279 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { Component, DebugElement, EventEmitter, Inject, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+    ApiResponseData,
+    Constants,
+    CreateLinkValue,
+    CreateResource,
+    MockProjects,
+    MockResource,
+    MockUsers,
+    ReadResource, ResourcesEndpointV2,
+    StoredProject,
+    UserResponse,
+    UsersEndpointAdmin
+} from '@dasch-swiss/dsp-js';
+import {
+    DspActionModule,
+    DspApiConnectionToken,
+    FilteredResources,
+    Session,
+    SessionService
+} from '@dasch-swiss/dsp-ui';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { AjaxResponse } from 'rxjs/ajax';
+import { CacheService } from 'src/app/main/cache/cache.service';
 import { ResourceLinkFormComponent } from './resource-link-form.component';
 
+const resolvedPromise = Promise.resolve(null);
+
+/**
+ * test host component to simulate parent component.
+ */
+@Component({
+    template: `
+        <app-resource-link-form #resourceLinkFormComp [resources]="resources"></app-resource-link-form>`
+})
+class TestHostComponent implements OnInit {
+
+    @ViewChild('resourceLinkFormComp') resourceLinkFormComponent: ResourceLinkFormComponent;
+
+    resources: FilteredResources = {
+        'count': 3,
+        'resListIndex': [3, 2, 1],
+        'resInfo': [
+            {
+                'id': 'http://rdfh.ch/0803/83616f8d8501',
+                'label': '65r'
+            },
+            {
+                'id': 'http://rdfh.ch/0803/71e0b9958a01',
+                'label': '76r'
+            },
+            {
+                'id': 'http://rdfh.ch/0803/683d5cd26f01',
+                'label': '17v'
+            },
+        ],
+        'selectionType': 'multiple'
+    };
+
+    constructor() { }
+
+    ngOnInit() {
+    }
+
+}
+
+/**
+ * mock select-project component to use in tests.
+ */
+@Component({
+    selector: 'app-select-project'
+})
+class MockSelectProjectComponent implements OnInit {
+    @Input() formGroup: FormGroup;
+    @Input() usersProjects: StoredProject[];
+    @Output() projectSelected = new EventEmitter<string>();
+
+    form: FormGroup;
+
+    constructor(@Inject(FormBuilder) private _fb: FormBuilder) { }
+
+    ngOnInit() {
+        this.form = this._fb.group({
+            projects: [null, Validators.required]
+        });
+
+        resolvedPromise.then(() => {
+            // add form to the parent form group
+            this.formGroup.addControl('projects', this.form);
+        });
+    }
+}
+
 describe('ResourceLinkFormComponent', () => {
-  let component: ResourceLinkFormComponent;
-  let fixture: ComponentFixture<ResourceLinkFormComponent>;
+    let testHostComponent: TestHostComponent;
+    let testHostFixture: ComponentFixture<TestHostComponent>;
+    let resourceLinkFormComponentDe: DebugElement;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ ResourceLinkFormComponent ]
-    })
-    .compileComponents();
-  });
+    beforeEach(waitForAsync(() => {
+        const dspConnSpy = {
+            admin: {
+                usersEndpoint: jasmine.createSpyObj('usersEndpoint', ['getUserByUsername'])
+            },
+            v2: {
+                onto: jasmine.createSpyObj('onto', ['getOntologiesByProjectIri']),
+                ontologyCache: jasmine.createSpyObj('ontologyCache', ['getOntology', 'getResourceClassDefinition']),
+                res: jasmine.createSpyObj('res', ['createResource'])
+            }
+        };
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ResourceLinkFormComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+        const sessionServiceSpy = jasmine.createSpyObj('SessionService', ['getSession']);
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+        const cacheServiceSpy = jasmine.createSpyObj('CacheService', ['get']);
+
+        TestBed.configureTestingModule({
+            declarations: [
+                ResourceLinkFormComponent,
+                TestHostComponent,
+                MockSelectProjectComponent
+            ],
+            imports: [
+                BrowserAnimationsModule,
+                DspActionModule,
+                MatButtonModule,
+                MatFormFieldModule,
+                MatIconModule,
+                MatInputModule,
+                MatSelectModule,
+                MatSnackBarModule,
+                MatTooltipModule,
+                ReactiveFormsModule,
+                RouterTestingModule,
+                TranslateModule.forRoot()
+            ],
+            providers: [
+                {
+                    provide: DspApiConnectionToken,
+                    useValue: dspConnSpy
+                },
+                {
+                    provide: SessionService,
+                    useValue: sessionServiceSpy
+                },
+                {
+                    provide: CacheService,
+                    useValue: cacheServiceSpy
+                }
+            ]
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+
+        const sessionSpy = TestBed.inject(SessionService);
+
+        (sessionSpy as jasmine.SpyObj<SessionService>).getSession.and.callFake(
+            () => {
+                const session: Session = {
+                    id: 12345,
+                    user: {
+                        name: 'username',
+                        jwt: 'myToken',
+                        lang: 'en',
+                        sysAdmin: false,
+                        projectAdmin: []
+                    }
+                };
+
+                return session;
+            }
+        );
+
+        const cacheSpy = TestBed.inject(CacheService);
+
+        (cacheSpy as jasmine.SpyObj<CacheService>).get.and.callFake(
+            () => {
+                const response: UserResponse = new UserResponse();
+
+                const project = MockProjects.mockProject();
+
+                response.user.projects = new Array<StoredProject>();
+
+                response.user.projects.push(project.body.project);
+
+                return of(ApiResponseData.fromAjaxResponse({ response } as AjaxResponse));
+            }
+        );
+
+        testHostFixture = TestBed.createComponent(TestHostComponent);
+        testHostComponent = testHostFixture.componentInstance;
+        testHostFixture.detectChanges();
+
+        const dspConnSpy = TestBed.inject(DspApiConnectionToken);
+
+        (dspConnSpy.admin.usersEndpoint as jasmine.SpyObj<UsersEndpointAdmin>).getUserByUsername.and.callFake(
+            () => {
+                const loggedInUser = MockUsers.mockUser();
+                return of(loggedInUser);
+            }
+        );
+
+        const hostCompDe = testHostFixture.debugElement;
+
+        resourceLinkFormComponentDe = hostCompDe.query(By.directive(ResourceLinkFormComponent));
+
+    });
+
+
+    it('should initialize the usersProjects array', () => {
+        expect(testHostComponent.resourceLinkFormComponent.usersProjects.length).toEqual(1);
+    });
+
+
+    it('should show the select project component', () => {
+
+        const comp = resourceLinkFormComponentDe.query(By.directive(MockSelectProjectComponent));
+
+        expect((comp.componentInstance as MockSelectProjectComponent).usersProjects.length).toEqual(1);
+    });
+
+    it('should submit the form', () => {
+        const dspConnSpy = TestBed.inject(DspApiConnectionToken);
+
+        (dspConnSpy.v2.res as jasmine.SpyObj<ResourcesEndpointV2>).createResource.and.callFake(
+            () => {
+                let resource = new ReadResource();
+
+                MockResource.getTestThing().subscribe((res) => {
+                    resource = res;
+                });
+
+                return of(resource);
+            }
+        );
+
+        testHostComponent.resourceLinkFormComponent.form.controls['label'].setValue('My Label');
+
+        testHostFixture.detectChanges();
+
+        const props = {};
+        const createVal: CreateLinkValue[] = [];
+        // res 1
+        testHostComponent.resources.resInfo.forEach(res => {
+            const linkVal = new CreateLinkValue();
+            linkVal.linkedResourceIri = res.id;
+            linkVal.type = Constants.LinkValue;
+            createVal.push(linkVal);
+        });
+
+        props[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue'] = createVal;
+
+        const expectedCreateResource = new CreateResource();
+        expectedCreateResource.label = 'My Label';
+        expectedCreateResource.type = Constants.KnoraApiV2 + Constants.HashDelimiter + 'LinkObj';
+        expectedCreateResource.properties = props;
+
+        // --> TODO create a Router spy to mock the navigation
+        testHostComponent.resourceLinkFormComponent.submitData();
+
+        expect(dspConnSpy.v2.res.createResource).toHaveBeenCalledTimes(1);
+
+
+    });
+
 });

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.spec.ts
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResourceLinkFormComponent } from './resource-link-form.component';
+
+describe('ResourceLinkFormComponent', () => {
+  let component: ResourceLinkFormComponent;
+  let fixture: ComponentFixture<ResourceLinkFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ResourceLinkFormComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResourceLinkFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
@@ -1,7 +1,16 @@
 import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { ApiResponseError, Constants, CreateLinkValue, CreateResource, CreateTextValueAsString, KnoraApiConnection, ReadResource, StoredProject } from '@dasch-swiss/dsp-js';
-import { DspApiConnectionToken, FilteredResouces } from '@dasch-swiss/dsp-ui';
+import {
+    ApiResponseError,
+    Constants,
+    CreateLinkValue,
+    CreateResource,
+    CreateTextValueAsString,
+    KnoraApiConnection,
+    ReadResource,
+    StoredProject
+} from '@dasch-swiss/dsp-js';
+import { DspApiConnectionToken, FilteredResources } from '@dasch-swiss/dsp-ui';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
 import { ProjectService } from '../project.service';
 
@@ -12,7 +21,7 @@ import { ProjectService } from '../project.service';
 })
 export class ResourceLinkFormComponent implements OnInit {
 
-    @Input() resources: FilteredResouces;
+    @Input() resources: FilteredResources;
 
     @Output() closeDialog: EventEmitter<any> = new EventEmitter<any>();
 
@@ -113,10 +122,10 @@ export class ResourceLinkFormComponent implements OnInit {
         // hasComment[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment'] = [];
         const hasLinkToValue = [];
         // hasLinkToValue[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue'] = [];
-        this.resources.resIds.forEach(id => {
+        this.resources.resInfo.forEach(res => {
             const linkVal = new CreateLinkValue();
             linkVal.type = Constants.LinkValue;
-            linkVal.linkedResourceIri = id;
+            linkVal.linkedResourceIri = res.id;
             // the value could have a comment
             // linkVal.valueHasComment = 'comment from link res form?';
 

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 import {
     ApiResponseError,
     Constants,
@@ -51,7 +52,8 @@ export class ResourceLinkFormComponent implements OnInit {
         @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
         private _errorHandler: ErrorHandlerService,
         private _fb: FormBuilder,
-        private _project: ProjectService
+        private _project: ProjectService,
+        private _router: Router
     ) { }
 
     ngOnInit(): void {
@@ -119,19 +121,14 @@ export class ResourceLinkFormComponent implements OnInit {
 
         linkObj.attachedToProject = this.selectedProject;
 
-        // hasComment[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment'] = [];
         const hasLinkToValue = [];
-        // hasLinkToValue[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue'] = [];
+
         this.resources.resInfo.forEach(res => {
             const linkVal = new CreateLinkValue();
             linkVal.type = Constants.LinkValue;
             linkVal.linkedResourceIri = res.id;
-            // the value could have a comment
-            // linkVal.valueHasComment = 'comment from link res form?';
-
             hasLinkToValue.push(linkVal);
         });
-
 
         const comment = this.form.controls['comment'].value;
         if (comment) {
@@ -149,8 +146,11 @@ export class ResourceLinkFormComponent implements OnInit {
         }
 
         this._dspApiConnection.v2.res.createResource(linkObj).subscribe(
-            (response: ReadResource) => {
+            (res: ReadResource) => {
                 // --> TODO: do something with the successful response
+                const goto = '/resource/' + encodeURIComponent(res.id);
+                this._router.navigate([]).then(result => window.open(goto, '_blank'));
+                this.closeDialog.emit();
                 this.loading = false;
             },
             (error: ApiResponseError) => {

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
@@ -1,0 +1,82 @@
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { ApiResponseError, Constants, CreateLinkValue, CreateResource, CreateTextValueAsString, KnoraApiConnection, ReadResource } from '@dasch-swiss/dsp-js';
+import { DspApiConnectionToken, FilteredResouces } from '@dasch-swiss/dsp-ui';
+import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
+
+@Component({
+    selector: 'app-resource-link-form',
+    templateUrl: './resource-link-form.component.html',
+    styleUrls: ['./resource-link-form.component.scss']
+})
+export class ResourceLinkFormComponent implements OnInit {
+
+    @Input() resources: FilteredResouces;
+
+    constructor(
+        @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
+        private _errorHandler: ErrorHandlerService
+    ) { }
+
+    ngOnInit(): void {
+    }
+
+    /**
+     * create a link resource from selected resources
+     * @param resources
+     */
+    linkResources(resources: FilteredResouces) {
+
+        // step 1: open dialog box with form to define label and comment
+
+
+        // step 2: submit link resource
+        const linkObj = new CreateResource();
+
+        // --> TODO: will be replaced by label input from form value
+        linkObj.label = 'Label from link resource form: input';
+
+        linkObj.type = Constants.KnoraApiV2 + Constants.HashDelimiter + 'LinkObj';
+
+        linkObj.attachedToProject = 'http://rdfh.ch/projects/1111';
+
+        const propertyValues = [];
+        const hasComment = [];
+        // hasComment[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment'] = [];
+        const hasLinkToValue = [];
+        // hasLinkToValue[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue'] = [];
+        resources.resIds.forEach(id => {
+            const linkVal = new CreateLinkValue();
+            linkVal.type = Constants.LinkValue;
+            linkVal.linkedResourceIri = id;
+            // the value could have a comment
+            // linkVal.valueHasComment = 'comment from link res form?';
+
+            hasLinkToValue.push(linkVal);
+        });
+
+        // --> TODO: will be replaced by comment input from form value
+        const comment = 'Comment from link resource form: textarea';
+        if (comment) {
+            const commentVal = new CreateTextValueAsString();
+            commentVal.type = Constants.TextValue;
+            commentVal.text = comment;
+            hasComment.push(commentVal);
+        }
+
+        linkObj.properties = {
+            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue']: hasLinkToValue,
+            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment']: hasComment,
+        };
+
+
+        this._dspApiConnection.v2.res.createResource(linkObj).subscribe(
+            (response: ReadResource) => {
+                // --> TODO: do something with the successful response
+            },
+            (error: ApiResponseError) => {
+                this._errorHandler.showMessage(error);
+            }
+        );
+
+    }
+}

--- a/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
+++ b/src/app/workspace/resource/resource-link-form/resource-link-form.component.ts
@@ -1,7 +1,9 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
-import { ApiResponseError, Constants, CreateLinkValue, CreateResource, CreateTextValueAsString, KnoraApiConnection, ReadResource } from '@dasch-swiss/dsp-js';
+import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { ApiResponseError, Constants, CreateLinkValue, CreateResource, CreateTextValueAsString, KnoraApiConnection, ReadResource, StoredProject } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken, FilteredResouces } from '@dasch-swiss/dsp-ui';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
+import { ProjectService } from '../project.service';
 
 @Component({
     selector: 'app-resource-link-form',
@@ -12,39 +14,106 @@ export class ResourceLinkFormComponent implements OnInit {
 
     @Input() resources: FilteredResouces;
 
+    @Output() closeDialog: EventEmitter<any> = new EventEmitter<any>();
+
+    /**
+     * form group, errors and validation messages
+     */
+    form: FormGroup;
+
+    formErrors = {
+        'label': ''
+    };
+
+    validationMessages = {
+        'label': {
+            'required': 'A label is required.'
+        }
+    };
+
+    usersProjects: StoredProject[];
+
+    selectedProject: string;
+
+    error = false;
+    loading = false;
+
     constructor(
         @Inject(DspApiConnectionToken) private _dspApiConnection: KnoraApiConnection,
-        private _errorHandler: ErrorHandlerService
+        private _errorHandler: ErrorHandlerService,
+        private _fb: FormBuilder,
+        private _project: ProjectService
     ) { }
 
     ngOnInit(): void {
+
+        // initialize projects to be used for the project selection in the creation form
+        this._project.initializeProjects().subscribe(
+            (proj: StoredProject[]) => {
+                this.usersProjects = proj;
+            }
+        );
+
+        this.form = this._fb.group({
+            'label': new FormControl({
+                value: '', disabled: false
+            }, [
+                Validators.required
+            ]),
+            'comment': new FormControl(),
+            'project': new FormControl()
+        });
+
+        this.form.valueChanges
+            .subscribe(data => this.onValueChanged(data));
     }
 
     /**
-     * create a link resource from selected resources
-     * @param resources
+     * this method is for the form error handling
+     *
+     * @param data Data which changed.
      */
-    linkResources(resources: FilteredResouces) {
+    onValueChanged(data?: any) {
 
-        // step 1: open dialog box with form to define label and comment
+        if (!this.form) {
+            return;
+        }
 
+        const form = this.form;
 
-        // step 2: submit link resource
+        Object.keys(this.formErrors).map(field => {
+            this.formErrors[field] = '';
+            const control = form.get(field);
+            if (control && control.dirty && !control.valid) {
+                const messages = this.validationMessages[field];
+                Object.keys(control.errors).map(key => {
+                    this.formErrors[field] += messages[key] + ' ';
+                });
+
+            }
+        });
+    }
+
+    /**
+     * submits the data
+     */
+    submitData() {
+
+        this.loading = true;
+
+        // build link resource as type CreateResource
         const linkObj = new CreateResource();
 
-        // --> TODO: will be replaced by label input from form value
-        linkObj.label = 'Label from link resource form: input';
+        linkObj.label = this.form.controls['label'].value;
 
         linkObj.type = Constants.KnoraApiV2 + Constants.HashDelimiter + 'LinkObj';
 
-        linkObj.attachedToProject = 'http://rdfh.ch/projects/1111';
+        linkObj.attachedToProject = this.selectedProject;
 
-        const propertyValues = [];
-        const hasComment = [];
         // hasComment[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment'] = [];
         const hasLinkToValue = [];
         // hasLinkToValue[Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue'] = [];
-        resources.resIds.forEach(id => {
+        this.resources.resIds.forEach(id => {
             const linkVal = new CreateLinkValue();
             linkVal.type = Constants.LinkValue;
             linkVal.linkedResourceIri = id;
@@ -54,27 +123,31 @@ export class ResourceLinkFormComponent implements OnInit {
             hasLinkToValue.push(linkVal);
         });
 
-        // --> TODO: will be replaced by comment input from form value
-        const comment = 'Comment from link resource form: textarea';
+
+        const comment = this.form.controls['comment'].value;
         if (comment) {
             const commentVal = new CreateTextValueAsString();
             commentVal.type = Constants.TextValue;
             commentVal.text = comment;
-            hasComment.push(commentVal);
+            linkObj.properties = {
+                [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue']: hasLinkToValue,
+                [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment']: [commentVal],
+            };
+        } else {
+            linkObj.properties = {
+                [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue']: hasLinkToValue,
+            };
         }
-
-        linkObj.properties = {
-            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasLinkToValue']: hasLinkToValue,
-            [Constants.KnoraApiV2 + Constants.HashDelimiter + 'hasComment']: hasComment,
-        };
-
 
         this._dspApiConnection.v2.res.createResource(linkObj).subscribe(
             (response: ReadResource) => {
                 // --> TODO: do something with the successful response
+                this.loading = false;
             },
             (error: ApiResponseError) => {
                 this._errorHandler.showMessage(error);
+                this.error = true;
+                this.loading = false;
             }
         );
 

--- a/src/app/workspace/results/results.component.html
+++ b/src/app/workspace/results/results.component.html
@@ -4,22 +4,23 @@
     <as-split direction="horizontal">
         <as-split-area [size]="40">
             <dsp-list-view [search]="searchParams" [displayViewSwitch]="false" [withMultipleSelection]="true"
-                (multipleResourcesSelected)="openMultipleResources($event)"
-                (singleResourceSelected)="openResource($event)">
+            (selectedResources)="openSelectedResources($event)">
+                <!-- (multipleResourcesSelected)="openMultipleResources($event)" -->
+                <!-- (singleResourceSelected)="openResource($event)"> -->
             </dsp-list-view>
         </as-split-area>
-        <as-split-area [size]="60" *ngIf="resourceIri">
+        <as-split-area [size]="60" *ngIf="selectedResources?.count > 0">
 
             <div [ngSwitch]="viewMode">
                 <!-- single resource view -->
-                <app-resource *ngSwitchCase="'single'" [resourceIri]="resourceIri"></app-resource>
+                <app-resource *ngSwitchCase="'single'" [resourceIri]="selectedResources.resInfo[0].id"></app-resource>
 
                 <!-- intermediate view -->
-                <app-intermediate *ngSwitchCase="'intermediate'" [resources]="multipleResources" (action)="viewMode=$event"></app-intermediate>
+                <app-intermediate *ngSwitchCase="'intermediate'" [resources]="selectedResources" (action)="viewMode=$event"></app-intermediate>
 
                 <!-- multiple resources view / comparison viewer -->
-                <dsp-multiple-resources-view *ngSwitchCase="'compare'" [noOfResources]="multipleResources.count"
-                    [resourceIds]="multipleResources.resIds">
+                <dsp-multiple-resources-view *ngSwitchCase="'compare'" [noOfResources]="selectedResources.count"
+                    [resources]="selectedResources.resInfo">
                 </dsp-multiple-resources-view>
             </div>
         </as-split-area>

--- a/src/app/workspace/results/results.component.html
+++ b/src/app/workspace/results/results.component.html
@@ -5,12 +5,9 @@
         <as-split-area [size]="40">
             <dsp-list-view [search]="searchParams" [displayViewSwitch]="false" [withMultipleSelection]="true"
             (selectedResources)="openSelectedResources($event)">
-                <!-- (multipleResourcesSelected)="openMultipleResources($event)" -->
-                <!-- (singleResourceSelected)="openResource($event)"> -->
             </dsp-list-view>
         </as-split-area>
         <as-split-area [size]="60" *ngIf="selectedResources?.count > 0">
-
             <div [ngSwitch]="viewMode">
                 <!-- single resource view -->
                 <app-resource *ngSwitchCase="'single'" [resourceIri]="selectedResources.resInfo[0].id"></app-resource>

--- a/src/app/workspace/results/results.component.ts
+++ b/src/app/workspace/results/results.component.ts
@@ -1,14 +1,14 @@
-import { SearchParams, FilteredResources } from '.yalc/@dasch-swiss/dsp-ui/public-api';
-import { Component, OnChanges, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Params } from '@angular/router';
+import { FilteredResources, SearchParams } from '@dasch-swiss/dsp-ui';
 
 @Component({
     selector: 'app-results',
     templateUrl: './results.component.html',
     styleUrls: ['./results.component.scss']
 })
-export class ResultsComponent implements OnInit {
+export class ResultsComponent {
 
     searchParams: SearchParams;
 
@@ -17,13 +17,10 @@ export class ResultsComponent implements OnInit {
     resourceIri: string;
 
     // display single resource or intermediate page in case of multiple selection
-    multipleResources: FilteredResources;
     viewMode: 'single' | 'intermediate' | 'compare' = 'single';
 
+    // which resources are selected?
     selectedResources: FilteredResources;
-
-    // number of all results
-    numberOfAllResults: number;
 
     // search params
     searchQuery: string;
@@ -57,24 +54,8 @@ export class ResultsComponent implements OnInit {
         this._titleService.setTitle('Search results for ' + this.searchParams.mode + ' search');
     }
 
-    ngOnInit() {
-        // this.selectedResources = {
-        //     count: 0,
-        //     resListIndex: [],
-        //     resInfo: [],
-        //     selectionType: 'single'
-        // };
-        console.warn('on changes', this.selectedResources);
-
-    }
-
-    // openResource(id: string) {
-    //     this.viewMode = 'single';
-    //     // this.multipleResources = undefined;
-    //     this.resourceIri = id;
-    // }
-
     openSelectedResources(res: FilteredResources) {
+
         this.selectedResources = res;
 
         if (!res || res.count <= 1) {
@@ -85,43 +66,6 @@ export class ResultsComponent implements OnInit {
             }
         }
 
-        this.loading = false;
-
-
-        // if (!res || res.count === 0) {
-        //     // reset the resource view
-        //     this.resourceIri = undefined;
-        //     this.selectedResources = undefined;
-
-        // } else if (res.count === 1) {
-        //     // open one resource
-        //     this.resourceIri = res.resInfo[0].id;
-        // } else {
-        //     // open intermediate view if viewMode is not 'compare'
-        //     if (this.viewMode !== 'compare' && res) {
-
-        //         this.viewMode = ((res && res.count > 0) ? 'intermediate' : 'single');
-
-        //         this.multipleResources = (this.viewMode !== 'single' ? res : undefined);
-        //     } else {
-        //         this.multipleResources = res;
-        //     }
-
-        // }
     }
-
-    // this funtion is called when 'withMultipleSelection' is true and
-    // multiple resources are selected for comparision
-    // openMultipleResources(resources: FilteredResources) {
-
-    //     if (this.viewMode !== 'compare' && resources) {
-
-    //         this.viewMode = ((resources && resources.count > 0) ? 'intermediate' : 'single');
-
-    //         this.multipleResources = (this.viewMode !== 'single' ? resources : undefined);
-    //     }
-
-
-    // }
 
 }

--- a/src/app/workspace/results/results.component.ts
+++ b/src/app/workspace/results/results.component.ts
@@ -1,14 +1,14 @@
-import { Component } from '@angular/core';
+import { SearchParams, FilteredResources } from '.yalc/@dasch-swiss/dsp-ui/public-api';
+import { Component, OnChanges, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Params } from '@angular/router';
-import { FilteredResouces, SearchParams } from '@dasch-swiss/dsp-ui';
 
 @Component({
     selector: 'app-results',
     templateUrl: './results.component.html',
     styleUrls: ['./results.component.scss']
 })
-export class ResultsComponent {
+export class ResultsComponent implements OnInit {
 
     searchParams: SearchParams;
 
@@ -17,8 +17,10 @@ export class ResultsComponent {
     resourceIri: string;
 
     // display single resource or intermediate page in case of multiple selection
-    multipleResources: FilteredResouces;
+    multipleResources: FilteredResources;
     viewMode: 'single' | 'intermediate' | 'compare' = 'single';
+
+    selectedResources: FilteredResources;
 
     // number of all results
     numberOfAllResults: number;
@@ -26,6 +28,8 @@ export class ResultsComponent {
     // search params
     searchQuery: string;
     searchMode: 'fulltext' | 'gravsearch';
+
+    loading = true;
 
     constructor(
         private _route: ActivatedRoute,
@@ -53,24 +57,71 @@ export class ResultsComponent {
         this._titleService.setTitle('Search results for ' + this.searchParams.mode + ' search');
     }
 
-    openResource(id: string) {
-        this.viewMode = 'single';
-        this.multipleResources = undefined;
-        this.resourceIri = id;
+    ngOnInit() {
+        // this.selectedResources = {
+        //     count: 0,
+        //     resListIndex: [],
+        //     resInfo: [],
+        //     selectionType: 'single'
+        // };
+        console.warn('on changes', this.selectedResources);
+
+    }
+
+    // openResource(id: string) {
+    //     this.viewMode = 'single';
+    //     // this.multipleResources = undefined;
+    //     this.resourceIri = id;
+    // }
+
+    openSelectedResources(res: FilteredResources) {
+        this.selectedResources = res;
+
+        if (!res || res.count <= 1) {
+            this.viewMode = 'single';
+        } else {
+            if (this.viewMode !== 'compare') {
+                this.viewMode = ((res && res.count > 0) ? 'intermediate' : 'single');
+            }
+        }
+
+        this.loading = false;
+
+
+        // if (!res || res.count === 0) {
+        //     // reset the resource view
+        //     this.resourceIri = undefined;
+        //     this.selectedResources = undefined;
+
+        // } else if (res.count === 1) {
+        //     // open one resource
+        //     this.resourceIri = res.resInfo[0].id;
+        // } else {
+        //     // open intermediate view if viewMode is not 'compare'
+        //     if (this.viewMode !== 'compare' && res) {
+
+        //         this.viewMode = ((res && res.count > 0) ? 'intermediate' : 'single');
+
+        //         this.multipleResources = (this.viewMode !== 'single' ? res : undefined);
+        //     } else {
+        //         this.multipleResources = res;
+        //     }
+
+        // }
     }
 
     // this funtion is called when 'withMultipleSelection' is true and
     // multiple resources are selected for comparision
-    openMultipleResources(resources: FilteredResouces) {
+    // openMultipleResources(resources: FilteredResources) {
 
-        if (this.viewMode !== 'compare') {
+    //     if (this.viewMode !== 'compare' && resources) {
 
-            this.viewMode = ((resources && resources.count > 0) ? 'intermediate' : 'single');
+    //         this.viewMode = ((resources && resources.count > 0) ? 'intermediate' : 'single');
 
-            this.multipleResources = (this.viewMode !== 'single' ? resources : undefined);
-        }
+    //         this.multipleResources = (this.viewMode !== 'single' ? resources : undefined);
+    //     }
 
 
-    }
+    // }
 
 }


### PR DESCRIPTION
resolves DSP-1835 and resolves the issues mentioned in DSP-1820

After creating a `linkObj` resource it opens the new resource in a new tab. In this PR I have integrated the same logic when creating a new resource instance.

There's an "ugly" error from Angular lifecycle hook where I wasn't able to resolve it resp. when resolving it in DSP-APP we got another lifecycle hook error from DSP-UI and nothing works anymore. I hope to resolve the issue when moving DSP-UI components to DSP-APP (DSP-1857):

```console
ERROR Error: NG0100: ExpressionChangedAfterItHasBeenCheckedError: 
Expression has changed after it was checked. Previous value: 'false'. Current value: 'true'.. 
Find more at https://angular.io/errors/NG0100
```
