### PR TITLE
chore(deps): bump dsp-js to latest version (DSP-1883)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^11.2.9",
         "@angular/router": "^11.2.9",
         "@ckeditor/ckeditor5-angular": "^1.2.3",
-        "@dasch-swiss/dsp-js": "^3.0.0",
+        "@dasch-swiss/dsp-js": "^4.0.0",
         "@dasch-swiss/dsp-ui": "^1.8.0",
         "@ngx-translate/core": "^12.1.2",
         "@ngx-translate/http-loader": "5.0.0",
@@ -652,7 +652,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.14.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -746,7 +745,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.14.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.14.5",
@@ -996,7 +994,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.14.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2102,10 +2099,11 @@
       }
     },
     "node_modules/@dasch-swiss/dsp-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-js/-/dsp-js-3.0.0.tgz",
-      "integrity": "sha512-2mhtgQsh5KfxTHysqZ8KL9HJA576qyabAe+giaDZ64A+79BOTD9S0o7YGRXeXyOrJ6sxJsu0RYSDv+hwSYTAWA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-js/-/dsp-js-4.0.0.tgz",
+      "integrity": "sha512-Aa1oKXMCxfOx+YYb3ZtfI2W2syLQtGdlqkmi6cs/EbGx+/ByIUcTxUexUZyJ3MTI9IzGBzV8JPKvWq7IUGO15Q==",
       "dependencies": {
+        "@babel/helper-compilation-targets": "^7.14.5",
         "@types/jsonld": "^1.5.0",
         "json2typescript": "1.4.1",
         "jsonld": "^5.2.0"
@@ -4396,7 +4394,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.16.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30001219",
@@ -4601,7 +4598,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001241",
-      "dev": true,
       "license": "CC-BY-4.0",
       "funding": {
         "type": "opencollective",
@@ -4976,7 +4972,6 @@
     },
     "node_modules/colorette": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colors": {
@@ -6556,7 +6551,6 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.3.766",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/elliptic": {
@@ -6773,7 +6767,6 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11328,7 +11321,6 @@
     },
     "node_modules/node-releases": {
       "version": "1.1.73",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -19104,8 +19096,7 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.7",
-      "dev": true
+      "version": "7.14.7"
     },
     "@babel/core": {
       "version": "7.12.10",
@@ -19170,7 +19161,6 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.14.5",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
@@ -19334,8 +19324,7 @@
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "dev": true
+      "version": "7.14.5"
     },
     "@babel/helper-wrap-function": {
       "version": "7.14.5",
@@ -20009,10 +19998,11 @@
       }
     },
     "@dasch-swiss/dsp-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-js/-/dsp-js-3.0.0.tgz",
-      "integrity": "sha512-2mhtgQsh5KfxTHysqZ8KL9HJA576qyabAe+giaDZ64A+79BOTD9S0o7YGRXeXyOrJ6sxJsu0RYSDv+hwSYTAWA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-js/-/dsp-js-4.0.0.tgz",
+      "integrity": "sha512-Aa1oKXMCxfOx+YYb3ZtfI2W2syLQtGdlqkmi6cs/EbGx+/ByIUcTxUexUZyJ3MTI9IzGBzV8JPKvWq7IUGO15Q==",
       "requires": {
+        "@babel/helper-compilation-targets": "^7.14.5",
         "@types/jsonld": "^1.5.0",
         "json2typescript": "1.4.1",
         "jsonld": "^5.2.0"
@@ -20063,12 +20053,10 @@
       }
     },
     "@ngx-translate/core": {
-      "version": "12.1.2",
-      "requires": {}
+      "version": "12.1.2"
     },
     "@ngx-translate/http-loader": {
-      "version": "5.0.0",
-      "requires": {}
+      "version": "5.0.0"
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -20970,8 +20958,7 @@
     },
     "acorn-jsx": {
       "version": "5.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "adjust-sourcemap-loader": {
       "version": "4.0.0",
@@ -21021,13 +21008,11 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -21562,7 +21547,6 @@
     },
     "browserslist": {
       "version": "4.16.6",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
@@ -21699,8 +21683,7 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001241",
-      "dev": true
+      "version": "1.0.30001241"
     },
     "canonical-path": {
       "version": "1.0.0",
@@ -21758,8 +21741,7 @@
     },
     "circular-dependency-plugin": {
       "version": "5.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ckeditor5-custom-build": {
       "version": "git+ssh://git@github.com/dasch-swiss/ckeditor_custom_build.git#c3c67816fd7fa7e7dfd9295ef99a5e49ca431876",
@@ -21909,13 +21891,11 @@
       "dependencies": {
         "@angular/compiler": {
           "version": "9.0.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@angular/core": {
           "version": "9.0.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -21951,8 +21931,7 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.2.2",
-      "dev": true
+      "version": "1.2.2"
     },
     "colors": {
       "version": "1.4.0",
@@ -22552,8 +22531,7 @@
     },
     "cssnano-utils": {
       "version": "2.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -23105,8 +23083,7 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.766",
-      "dev": true
+      "version": "1.3.766"
     },
     "elliptic": {
       "version": "6.5.4",
@@ -23265,8 +23242,7 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "escape-html": {
       "version": "1.0.3",
@@ -24658,8 +24634,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -25474,8 +25449,7 @@
     },
     "karma-jasmine-html-reporter": {
       "version": "1.6.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -26328,8 +26302,7 @@
       }
     },
     "node-releases": {
-      "version": "1.1.73",
-      "dev": true
+      "version": "1.1.73"
     },
     "nopt": {
       "version": "5.0.0",
@@ -26987,8 +26960,7 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.7.570",
-      "requires": {}
+      "version": "2.7.570"
     },
     "performance-now": {
       "version": "2.1.0",
@@ -27119,23 +27091,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-import": {
       "version": "14.0.0",
@@ -27232,8 +27200,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -27260,8 +27227,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -29387,8 +29353,7 @@
       }
     },
     "three-spritetext": {
-      "version": "1.6.2",
-      "requires": {}
+      "version": "1.6.2"
     },
     "through": {
       "version": "2.3.8",
@@ -31246,8 +31211,7 @@
     },
     "ws": {
       "version": "7.4.6",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/platform-browser-dynamic": "^11.2.9",
     "@angular/router": "^11.2.9",
     "@ckeditor/ckeditor5-angular": "^1.2.3",
-    "@dasch-swiss/dsp-js": "^3.0.0",
+    "@dasch-swiss/dsp-js": "^4.0.0",
     "@dasch-swiss/dsp-ui": "^1.8.0",
     "@ngx-translate/core": "^12.1.2",
     "@ngx-translate/http-loader": "5.0.0",


### PR DESCRIPTION
resolves DSP-1883

Since we use the latest version of DSP-API (v14) we should also use the latest version of DSP-JS (v4) which follows the breaking changes from DSP-API.
