### PR TITLE
fix(error): improve the current error handler in DSP-APP (DSP-1911)

### DIFF
--- a/src/app/main/error/error-handler.service.ts
+++ b/src/app/main/error/error-handler.service.ts
@@ -21,7 +21,7 @@ export class ErrorHandlerService {
     showMessage(error: ApiResponseError) {
 
         // in case of (internal) server error
-        const apiServerError = (error.error['response'] === null);
+        const apiServerError = (error.error && error.error['response'] && error.error['response'] === null);
 
         if ((error.status > 499 && error.status < 600) || apiServerError) {
 

--- a/src/app/main/error/error-handler.service.ts
+++ b/src/app/main/error/error-handler.service.ts
@@ -20,8 +20,7 @@ export class ErrorHandlerService {
 
     showMessage(error: ApiResponseError) {
         // in case of (internal) server error
-        if (error.status === 0 || (error.status > 499 && error.status < 600)) {
-            const status = (error.status === 0 ? 503 : error.status);
+        if (error.status > 499 && error.status < 600) {
 
             // open error message in full size view
             const dialogConfig: MatDialogConfig = {
@@ -32,7 +31,7 @@ export class ErrorHandlerService {
                 position: {
                     top: '0'
                 },
-                data: { mode: 'error', id: status },
+                data: { mode: 'error', id: error.status },
                 disableClose: true
             };
 

--- a/src/app/main/error/error-handler.service.ts
+++ b/src/app/main/error/error-handler.service.ts
@@ -19,8 +19,13 @@ export class ErrorHandlerService {
     ) { }
 
     showMessage(error: ApiResponseError) {
+
         // in case of (internal) server error
-        if (error.status > 499 && error.status < 600) {
+        const apiServerError = (error.error['response'] === null);
+
+        if ((error.status > 499 && error.status < 600) || apiServerError) {
+
+            const status = (apiServerError ? 503 : error.status);
 
             // open error message in full size view
             const dialogConfig: MatDialogConfig = {
@@ -31,7 +36,7 @@ export class ErrorHandlerService {
                 position: {
                     top: '0'
                 },
-                data: { mode: 'error', id: error.status },
+                data: { mode: 'error', id: status },
                 disableClose: true
             };
 

--- a/src/app/main/services/notification.service.ts
+++ b/src/app/main/services/notification.service.ts
@@ -22,7 +22,7 @@ export class NotificationService {
         let panelClass: string;
 
         if (notification instanceof ApiResponseError) {
-            if (notification.error && notification.error['message']) {
+            if (notification.error && !notification.error['message'].startsWith('ajax error')) {
                 // the Api response error contains a complex error message from dsp-js-lib
                 message = notification.error['message'];
                 duration = undefined;

--- a/src/app/main/services/notification.service.ts
+++ b/src/app/main/services/notification.service.ts
@@ -17,14 +17,19 @@ export class NotificationService {
     // action: string = 'x', duration: number = 4200
     // and / or type: 'note' | 'warning' | 'error' | 'success'; which can be used for the panelClass
     openSnackBar(notification: string | ApiResponseError): void {
-        const duration = 5000;
+        let duration = 5000;
         let message: string;
         let panelClass: string;
 
         if (notification instanceof ApiResponseError) {
-            const status = (notification.status === 0 ? 503 : notification.status);
-            const defaultStatusMsg = this._statusMsg.default;
-            message = `${defaultStatusMsg[status].message} (${status}): ${defaultStatusMsg[status].description}`;
+            if (notification.error && notification.error['message']) {
+                // the Api response error contains a complex error message from dsp-js-lib
+                message = notification.error['message'];
+                duration = undefined;
+            } else {
+                const defaultStatusMsg = this._statusMsg.default;
+                message = `${defaultStatusMsg[notification.status].message} (${notification.status}): ${defaultStatusMsg[notification.status].description}`;
+            }
             panelClass = 'error';
         } else {
             message = notification;

--- a/src/app/workspace/resource/resource.component.html
+++ b/src/app/workspace/resource/resource.component.html
@@ -76,6 +76,7 @@
         <p>Reasons:</p>
         <ul>
             <li>It could be a deleted resource and does not exist anymore.</li>
+            <li>You don't have the permissions to open this resource.</li>
             <li>The identifier or the ARK URL is wrong.</li>
         </ul>
     </div>


### PR DESCRIPTION
resolves DSP-1911

You can test it as follows:

- Start the app with the test-server configuration
- Open the following page: <http://0.0.0.0:4200/search/fulltext/Stygimoloch>
- If you're logged-in, you should see the correct error message from JS-Lib instead the 503 error mentioned in DSP-1910

![Screen Shot 2021-09-20 at 22 42 55](https://user-images.githubusercontent.com/4253580/134072818-963d64c7-d774-4187-bab8-e003f163c14e.png)

Or

- Start the app with your local api stack environment
- Turn off the API
- You should see the 503 server error

