### PR TITLE
fix(resource): resource viewer is broken if fileRepresentation has restricted view (DEV-455)

### DIFF
--- a/src/app/workspace/resource/permission-info/permission-info.component.scss
+++ b/src/app/workspace/resource/permission-info/permission-info.component.scss
@@ -5,6 +5,7 @@
   background: white;
   padding: 8px 16px;
   @include mat-box-shadow();
+  border-radius: $border-radius;
 
   table {
     border-collapse: collapse;

--- a/src/app/workspace/resource/resource.component.html
+++ b/src/app/workspace/resource/resource.component.html
@@ -2,8 +2,8 @@
     <div class="resource-view" *ngIf="resource && !loading">
 
         <!-- dsp-resource-representation -->
-        <div class="representation-container center" *ngIf="representationsToDisplay.length"
-            [ngSwitch]="representationsToDisplay[0].fileValue.type">
+        <div class="representation-container center" *ngIf="representationsToDisplay.length && representationsToDisplay[0].fileValue"
+            [ngSwitch]="representationsToDisplay[0].fileValue?.type">
             <!-- still image view -->
             <app-still-image #stillImage class="dsp-representation" *ngSwitchCase="representationConstants.stillImage"
                 [images]="representationsToDisplay"
@@ -52,7 +52,7 @@
 
             <!-- annotations -->
             <mat-tab label="annotations"
-                *ngIf="representationsToDisplay.length && representationsToDisplay[0].fileValue.type === representationConstants.stillImage">
+                *ngIf="representationsToDisplay.length && representationsToDisplay[0].fileValue && representationsToDisplay[0].fileValue.type === representationConstants.stillImage">
                 <ng-template matTabLabel class="annotations">
                     <span [matBadge]="representationsToDisplay[0]?.annotations.length"
                         [matBadgeHidden]="representationsToDisplay[0]?.annotations.length === 0" matBadgeColor="primary"

--- a/src/app/workspace/resource/resource.component.ts
+++ b/src/app/workspace/resource/resource.component.ts
@@ -299,7 +299,7 @@ export class ResourceComponent implements OnInit, OnChanges, OnDestroy {
 
                 this.collectRepresentationsAndAnnotations(this.incomingResource);
 
-                if (this.representationsToDisplay.length && this.compoundPosition) {
+                if (this.representationsToDisplay.length && this.representationsToDisplay[0].fileValue && this.compoundPosition) {
                     this.getIncomingRegions(this.incomingResource, 0);
                 }
             },
@@ -340,7 +340,6 @@ export class ResourceComponent implements OnInit, OnChanges, OnDestroy {
                         ];
 
                         this.representationsToDisplay = stillImageRepresentations;
-
                         // --> TODO: get regions here
 
                         break;


### PR DESCRIPTION
resolves DEV-455

Resource viewer (and app) is broken if user doesn't have the necessary permission on still image file representation. In this case the representationsToDisplay fileValue is undefined. This PR resolves this issue.
