### PR TITLE
chore(dockerfile): add dependabot config to keep base image up-to-date (INFRA-13)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "node"


### PR DESCRIPTION
Part of [INFRA-13](https://dasch.atlassian.net/browse/INFRA-13)

This enables dependabot for this Dockerfile's base image `daschswiss/nginx-server`, so that we automatically get a pull request when a new version is available.