### PR TITLE
fix(permission-info): close permission info on scrolling (DEV-552)

### DIFF
--- a/src/app/workspace/resource/permission-info/permission-info.component.html
+++ b/src/app/workspace/resource/permission-info/permission-info.component.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="infoBoxPositions"
     [cdkConnectedOverlayOrigin]="infoButton"
     [cdkConnectedOverlayOpen]="isOpen"
+    (detach)="isOpen = false"
     (backdropClick)="isOpen = false">
     <div class="overlay-info-box">
         <table>

--- a/src/app/workspace/resource/permission-info/permission-info.component.ts
+++ b/src/app/workspace/resource/permission-info/permission-info.component.ts
@@ -98,7 +98,8 @@ export class PermissionInfoComponent implements OnInit {
     constructor(
         private _sso: ScrollStrategyOptions
     ) {
-        this.scrollStrategy = this._sso.noop();
+        // close the info box on scrolling
+        this.scrollStrategy = this._sso.close();
     }
 
     ngOnInit(): void {
@@ -158,7 +159,7 @@ export class PermissionInfoComponent implements OnInit {
      */
     toggleMenu() {
         this.isOpen = !this.isOpen;
-        // console.log(this.infoButton)
+
         const pos: ConnectionPositionPair = new ConnectionPositionPair(
             this._originPos,
             this._overlayPos,

--- a/src/app/workspace/results/results.component.html
+++ b/src/app/workspace/results/results.component.html
@@ -7,7 +7,7 @@
             (selectedResources)="openSelectedResources($event)">
             </app-list-view>
         </as-split-area>
-        <as-split-area [size]="60" *ngIf="selectedResources?.count > 0">
+        <as-split-area [size]="60" *ngIf="selectedResources?.count > 0" cdkScrollable>
             <div [ngSwitch]="viewMode">
                 <!-- single resource view -->
                 <app-resource *ngSwitchCase="'single'" [resourceIri]="selectedResources.resInfo[0].id"></app-resource>


### PR DESCRIPTION
The cdk-overlay-scrollstrategy was not working correctly. The `reposition` attribute was not useful. With this PR it will close the info box as soon the user scrolls (in Safari). There is one bad behaviour which I was not able to resolve. The the scroll event closes the info box, the user has to click twice on the permission button, because the `isOpen` status is still set to true. I couldn't find a good example to resolve this.