### PR TITLE
style(ontology): crop loooong ontology labels (DEV-493)

### DIFF
--- a/src/app/project/ontology/ontology.component.html
+++ b/src/app/project/ontology/ontology.component.html
@@ -58,8 +58,8 @@
         <mat-toolbar class="ontology-editor-header">
             <mat-toolbar-row>
                 <span class="ontology-info">
-                    <h3 class="mat-title space-reducer"
-                        [matTooltip]="ontology.comment ? ontology.comment : ontology.id"
+                    <h3 class="mat-title"
+                        [matTooltip]="ontology.label + (ontology.comment ? ' &mdash; ' + ontology.comment : '')"
                         matTooltipPosition="above">
                         {{ontology?.label}}
                     </h3>

--- a/src/app/project/ontology/ontology.component.scss
+++ b/src/app/project/ontology/ontology.component.scss
@@ -33,6 +33,23 @@ $width: 340px;
   .ontology-editor-header {
     z-index: 2;
     top: 121px;
+
+    .ontology-info {
+      width: calc(100% - 176px - 32px);
+
+      h3, p {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 100%;
+        margin: 0;
+        padding: 0;
+      }
+
+      h3 {
+        margin-top: 6px;
+      }
+    }
     .mat-toolbar-row {
       padding-right: 0;
 


### PR DESCRIPTION
resolves DEV-493

<img width="895" alt="Screen Shot 2022-05-03 at 17 20 25" src="https://user-images.githubusercontent.com/4253580/166483282-f468bc1f-5093-415e-8f0b-ece6729d1e2e.png">

The full label will be shown in the tooltip:
<img width="897" alt="Screen Shot 2022-05-03 at 17 20 59" src="https://user-images.githubusercontent.com/4253580/166483382-77e7dc4e-c772-417b-9f78-d509c004252e.png">

