### PR TITLE
feat(resource): better progress indicator handling in resource viewer (DEV-638)

### DIFF
--- a/src/app/workspace/resource/representation/archive/archive.component.ts
+++ b/src/app/workspace/resource/representation/archive/archive.component.ts
@@ -1,7 +1,17 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { Constants, UpdateFileValue, UpdateResource, UpdateValue, WriteValueResponse, ReadResource, ApiResponseError, KnoraApiConnection, ReadArchiveFileValue } from '@dasch-swiss/dsp-js';
+import {
+    ApiResponseError,
+    Constants,
+    KnoraApiConnection,
+    ReadArchiveFileValue,
+    ReadResource,
+    UpdateFileValue,
+    UpdateResource,
+    UpdateValue,
+    WriteValueResponse
+} from '@dasch-swiss/dsp-js';
 import { mergeMap } from 'rxjs/operators';
 import { DspApiConnectionToken } from 'src/app/main/declarations/dsp-api-tokens';
 import { DialogComponent } from 'src/app/main/dialog/dialog.component';
@@ -14,10 +24,13 @@ import { FileRepresentation } from '../file-representation';
     templateUrl: './archive.component.html',
     styleUrls: ['./archive.component.scss']
 })
-export class ArchiveComponent implements OnInit {
+export class ArchiveComponent implements OnInit, AfterViewInit {
 
     @Input() src: FileRepresentation;
+
     @Input() parentResource: ReadResource;
+
+    @Output() loaded = new EventEmitter<boolean>();
 
     originalFilename: string;
 
@@ -31,6 +44,10 @@ export class ArchiveComponent implements OnInit {
 
     ngOnInit(): void {
         this._getOriginalFilename();
+    }
+
+    ngAfterViewInit() {
+        this.loaded.emit(true);
     }
 
     // https://stackoverflow.com/questions/66986983/angular-10-download-file-from-firebase-link-without-opening-into-new-tab

--- a/src/app/workspace/resource/representation/audio/audio.component.ts
+++ b/src/app/workspace/resource/representation/audio/audio.component.ts
@@ -1,24 +1,37 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
-import { UpdateFileValue, UpdateResource, Constants, UpdateValue, WriteValueResponse, ReadResource, ApiResponseError, KnoraApiConnection, ReadAudioFileValue } from '@dasch-swiss/dsp-js';
+import {
+    ApiResponseError,
+    Constants,
+    KnoraApiConnection,
+    ReadAudioFileValue,
+    ReadResource,
+    UpdateFileValue,
+    UpdateResource,
+    UpdateValue,
+    WriteValueResponse
+} from '@dasch-swiss/dsp-js';
 import { mergeMap } from 'rxjs/operators';
 import { DspApiConnectionToken } from 'src/app/main/declarations/dsp-api-tokens';
 import { DialogComponent } from 'src/app/main/dialog/dialog.component';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
 import { EmitEvent, Events, UpdatedFileEventValue, ValueOperationEventService } from '../../services/value-operation-event.service';
-
 import { FileRepresentation } from '../file-representation';
+
 
 @Component({
     selector: 'app-audio',
     templateUrl: './audio.component.html',
     styleUrls: ['./audio.component.scss']
 })
-export class AudioComponent implements OnInit {
+export class AudioComponent implements OnInit, AfterViewInit {
 
     @Input() src: FileRepresentation;
+
     @Input() parentResource: ReadResource;
+
+    @Output() loaded = new EventEmitter<boolean>();
 
     audio: SafeUrl;
 
@@ -32,6 +45,10 @@ export class AudioComponent implements OnInit {
 
     ngOnInit(): void {
         this.audio = this._sanitizer.bypassSecurityTrustUrl(this.src.fileValue.fileUrl);
+    }
+
+    ngAfterViewInit() {
+        this.loaded.emit(true);
     }
 
     openReplaceFileDialog(){

--- a/src/app/workspace/resource/representation/document/document.component.ts
+++ b/src/app/workspace/resource/representation/document/document.component.ts
@@ -1,6 +1,16 @@
-import { Component, Inject, Input, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Inject, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { ApiResponseError, Constants, KnoraApiConnection, ReadDocumentFileValue, ReadResource, UpdateFileValue, UpdateResource, UpdateValue, WriteValueResponse } from '@dasch-swiss/dsp-js';
+import {
+    ApiResponseError,
+    Constants,
+    KnoraApiConnection,
+    ReadDocumentFileValue,
+    ReadResource,
+    UpdateFileValue,
+    UpdateResource,
+    UpdateValue,
+    WriteValueResponse
+} from '@dasch-swiss/dsp-js';
 import { PdfViewerComponent } from 'ng2-pdf-viewer';
 import { mergeMap } from 'rxjs/operators';
 import { DspApiConnectionToken } from 'src/app/main/declarations/dsp-api-tokens';
@@ -14,10 +24,13 @@ import { FileRepresentation } from '../file-representation';
     templateUrl: './document.component.html',
     styleUrls: ['./document.component.scss']
 })
-export class DocumentComponent implements OnInit {
+export class DocumentComponent implements OnInit, AfterViewInit {
 
     @Input() src: FileRepresentation;
+
     @Input() parentResource: ReadResource;
+
+    @Output() loaded = new EventEmitter<boolean>();
 
     @ViewChild(PdfViewerComponent) private _pdfComponent: PdfViewerComponent;
 
@@ -34,6 +47,10 @@ export class DocumentComponent implements OnInit {
 
     ngOnInit(): void {
 
+    }
+
+    ngAfterViewInit() {
+        this.loaded.emit(true);
     }
 
     searchQueryChanged(newQuery: string) {

--- a/src/app/workspace/resource/representation/still-image/still-image.component.html
+++ b/src/app/workspace/resource/representation/still-image/still-image.component.html
@@ -89,5 +89,5 @@
             </button>
         </span>
     </div>
-    <!-- /openseadragon (osd) -->
 </div>
+<!-- /openseadragon (osd) -->

--- a/src/app/workspace/resource/representation/still-image/still-image.component.ts
+++ b/src/app/workspace/resource/representation/still-image/still-image.component.ts
@@ -1,10 +1,13 @@
 import {
+    AfterViewInit,
     Component,
     ElementRef,
-    EventEmitter, Inject,
+    EventEmitter,
+    Inject,
     Input,
     OnChanges,
-    OnDestroy, Output,
+    OnDestroy,
+    Output,
     Renderer2,
     SimpleChanges
 } from '@angular/core';
@@ -110,7 +113,7 @@ interface PolygonsForRegion {
     templateUrl: './still-image.component.html',
     styleUrls: ['./still-image.component.scss']
 })
-export class StillImageComponent implements OnChanges, OnDestroy {
+export class StillImageComponent implements OnChanges, OnDestroy, AfterViewInit {
 
     @Input() images: FileRepresentation[];
     @Input() imageCaption?: string;
@@ -127,7 +130,10 @@ export class StillImageComponent implements OnChanges, OnDestroy {
     @Output() regionClicked = new EventEmitter<string>();
 
     @Output() regionAdded = new EventEmitter<string>();
-    regionDrawMode: Boolean = false; // stores whether viewer is currently drawing a region
+
+    @Output() loaded = new EventEmitter<boolean>();
+
+    regionDrawMode = false; // stores whether viewer is currently drawing a region
     private _regionDragInfo; // stores the information of the first click for drawing a region
     private _viewer: OpenSeadragon.Viewer;
     private _regions: PolygonsForRegion = {};
@@ -193,6 +199,10 @@ export class StillImageComponent implements OnChanges, OnDestroy {
         if (changes['activateRegion']) {
             this._unhighlightAllRegions();
         }
+    }
+
+    ngAfterViewInit() {
+        this.loaded.emit(true);
     }
 
     ngOnDestroy() {

--- a/src/app/workspace/resource/representation/video/video.component.ts
+++ b/src/app/workspace/resource/representation/video/video.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, Inject, Input, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, EventEmitter, HostListener, Inject, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import {
@@ -16,12 +16,7 @@ import { mergeMap } from 'rxjs/operators';
 import { DspApiConnectionToken } from 'src/app/main/declarations/dsp-api-tokens';
 import { DialogComponent } from 'src/app/main/dialog/dialog.component';
 import { ErrorHandlerService } from 'src/app/main/error/error-handler.service';
-import {
-    EmitEvent,
-    Events,
-    UpdatedFileEventValue,
-    ValueOperationEventService
-} from '../../services/value-operation-event.service';
+import { EmitEvent, Events, UpdatedFileEventValue, ValueOperationEventService } from '../../services/value-operation-event.service';
 import { PointerValue } from '../av-timeline/av-timeline.component';
 import { FileRepresentation } from '../file-representation';
 
@@ -30,13 +25,15 @@ import { FileRepresentation } from '../file-representation';
     templateUrl: './video.component.html',
     styleUrls: ['./video.component.scss']
 })
-export class VideoComponent implements OnInit {
+export class VideoComponent implements OnInit, AfterViewInit {
 
     @Input() src: FileRepresentation;
 
     @Input() start?= 0;
 
     @Input() parentResource: ReadResource;
+
+    @Output() loaded = new EventEmitter<boolean>();
 
     @ViewChild('videoEle') videoEle: ElementRef;
 
@@ -114,6 +111,10 @@ export class VideoComponent implements OnInit {
     ngOnInit(): void {
         this.video = this._sanitizer.bypassSecurityTrustUrl(this.src.fileValue.fileUrl);
         this.fileHasChanged = false;
+    }
+
+    ngAfterViewInit() {
+        this.loaded.emit(true);
     }
 
     /**

--- a/src/app/workspace/resource/resource.component.html
+++ b/src/app/workspace/resource/resource.component.html
@@ -1,11 +1,11 @@
 <div class="content large middle">
-    <div class="resource-view" *ngIf="resource && !loading">
+    <div class="resource-view">
 
         <!-- dsp-resource-representation -->
         <div class="representation-container center" *ngIf="representationsToDisplay.length && representationsToDisplay[0].fileValue"
             [ngSwitch]="representationsToDisplay[0].fileValue?.type">
             <!-- still image view -->
-            <app-still-image #stillImage class="dsp-representation" *ngSwitchCase="representationConstants.stillImage"
+            <app-still-image #stillImage class="dsp-representation stillimage" *ngSwitchCase="representationConstants.stillImage"
                 [images]="representationsToDisplay"
                 [imageCaption]="(incomingResource ? resource.res.label + ': ' + incomingResource.res.label : resource.res.label)"
                 [iiifUrl]="iiifUrl"
@@ -14,78 +14,103 @@
                 [project]="resource.res.attachedToProject"
                 [currentTab]="selectedTabLabel"
                 [parentResource]="resource.res"
+                (loaded)="representationLoaded($event)"
                 (goToPage)="compoundNavigation($event)"
                 (regionClicked)="openRegion($event)"
                 (regionAdded)="updateRegions($event)">
             </app-still-image>
 
-            <app-document class="dsp-representation document" *ngSwitchCase="representationConstants.document" [src]="representationsToDisplay[0]" [parentResource]="resource.res">
+            <app-document #document class="dsp-representation document" *ngSwitchCase="representationConstants.document"
+                [src]="representationsToDisplay[0]"
+                [parentResource]="resource.res"
+                (loaded)="representationLoaded($event)">
             </app-document>
 
-            <app-audio class="dsp-representation audio" *ngSwitchCase="representationConstants.audio" [src]="representationsToDisplay[0]" [parentResource]="resource.res"></app-audio>
+            <app-audio #audio class="dsp-representation audio" *ngSwitchCase="representationConstants.audio"
+                [src]="representationsToDisplay[0]"
+                [parentResource]="resource.res"
+                (loaded)="representationLoaded($event)">
+            </app-audio>
 
-            <app-video class="dsp-representation video" *ngSwitchCase="representationConstants.movingImage" [src]="representationsToDisplay[0]" [parentResource]="resource.res"></app-video>
+            <app-video #video class="dsp-representation video" *ngSwitchCase="representationConstants.movingImage"
+                [src]="representationsToDisplay[0]"
+                [parentResource]="resource.res"
+                (loaded)="representationLoaded($event)">
+            </app-video>
 
-            <app-archive class="dsp-representation archive" *ngSwitchCase="representationConstants.archive" [src]="representationsToDisplay[0]" [parentResource]="resource.res"></app-archive>
+            <app-archive #archive class="dsp-representation archive" *ngSwitchCase="representationConstants.archive"
+                [src]="representationsToDisplay[0]"
+                [parentResource]="resource.res"
+                (loaded)="representationLoaded($event)">
+            </app-archive>
 
             <span *ngSwitchDefault>
                 The file representation type "{{representationsToDisplay[0].fileValue.type}}" is not yet implemented
             </span>
 
             <!-- TODO: here we'll add more viewers and players dsp-moving-image, dsp-audio etc. -->
-
         </div>
+        <div class="data-container" *ngIf="!loading">
 
-        <!-- tabs -->
-        <mat-tab-group *ngIf="!resource.res.isDeleted; else deletedResource" animationDuration="0ms" [(selectedIndex)]="selectedTab" (selectedTabChange)="tabChanged($event)">
-            <!-- first tab for the main resource e.g. book -->
-            <mat-tab [label]="resource.res.entityInfo?.classes[resource.res.type].label">
-                <app-properties *ngIf="resource.res" [resource]="resource" [displayProjectInfo]="true"
-                [adminPermissions]="adminPermissions" [editPermissions]="editPermissions" [valueUuidToHighlight]="valueUuid">
-                </app-properties>
-            </mat-tab>
-
-            <!-- incoming resource -->
-            <mat-tab *ngIf="incomingResource"
-                [label]="incomingResource.res.entityInfo?.classes[incomingResource.res.type].label">
-                <app-properties *ngIf="incomingResource.res" [resource]="incomingResource" [displayProjectInfo]="false"
-                [adminPermissions]="adminPermissions" [editPermissions]="editPermissions" [valueUuidToHighlight]="valueUuid">
-                </app-properties>
-            </mat-tab>
-
-            <!-- annotations -->
-            <mat-tab label="annotations"
-                *ngIf="representationsToDisplay.length && representationsToDisplay[0].fileValue && representationsToDisplay[0].fileValue.type === representationConstants.stillImage">
-                <ng-template matTabLabel class="annotations">
-                    <span [matBadge]="representationsToDisplay[0]?.annotations.length"
-                        [matBadgeHidden]="representationsToDisplay[0]?.annotations.length === 0" matBadgeColor="primary"
-                        matBadgeOverlap="false">
-                        Annotations
-                    </span>
-                </ng-template>
-                <div class="region-property" *ngFor="let annotation of annotationResources" [id]="annotation.res.id"
-                    [class.active]="annotation.res.id === selectedRegion">
-                    <app-properties
-                        [resource]="annotation"
-                        [displayProjectInfo]="false"
-                        [isAnnotation]="true"
+            <!-- tabs -->
+            <mat-tab-group *ngIf="!resource.res.isDeleted; else deletedResource" animationDuration="0ms" [(selectedIndex)]="selectedTab" (selectedTabChange)="tabChanged($event)">
+                <!-- first tab for the main resource e.g. book -->
+                <mat-tab [label]="resource.res.entityInfo?.classes[resource.res.type].label">
+                    <app-properties *ngIf="resource.res"
+                        [resource]="resource"
+                        [displayProjectInfo]="true"
                         [adminPermissions]="adminPermissions"
                         [editPermissions]="editPermissions"
-                        [valueUuidToHighlight]="valueUuid"
-                        (regionChanged)="updateRegion()">
+                        [valueUuidToHighlight]="valueUuid">
                     </app-properties>
-                </div>
+                </mat-tab>
 
-            </mat-tab>
-        </mat-tab-group>
-        <ng-template #deletedResource>
-            <app-properties *ngIf="resource.res" [resource]="resource" [displayProjectInfo]="true"
-                [adminPermissions]="adminPermissions" [editPermissions]="editPermissions" [valueUuidToHighlight]="valueUuid">
-            </app-properties>
-        </ng-template>
+                <!-- incoming resource -->
+                <mat-tab *ngIf="incomingResource"
+                    [label]="incomingResource.res.entityInfo?.classes[incomingResource.res.type].label">
+                    <app-properties *ngIf="incomingResource.res"
+                        [resource]="incomingResource"
+                        [displayProjectInfo]="false"
+                        [adminPermissions]="adminPermissions"
+                        [editPermissions]="editPermissions"
+                        [valueUuidToHighlight]="valueUuid">
+                    </app-properties>
+                </mat-tab>
+
+                <!-- annotations -->
+                <mat-tab label="annotations"
+                    *ngIf="representationsToDisplay.length && representationsToDisplay[0].fileValue && representationsToDisplay[0].fileValue.type === representationConstants.stillImage">
+                    <ng-template matTabLabel class="annotations">
+                        <span [matBadge]="representationsToDisplay[0]?.annotations.length"
+                            [matBadgeHidden]="representationsToDisplay[0]?.annotations.length === 0" matBadgeColor="primary"
+                            matBadgeOverlap="false">
+                            Annotations
+                        </span>
+                    </ng-template>
+                    <div class="region-property" *ngFor="let annotation of annotationResources" [id]="annotation.res.id"
+                        [class.active]="annotation.res.id === selectedRegion">
+                        <app-properties
+                            [resource]="annotation"
+                            [displayProjectInfo]="false"
+                            [isAnnotation]="true"
+                            [adminPermissions]="adminPermissions"
+                            [editPermissions]="editPermissions"
+                            [valueUuidToHighlight]="valueUuid"
+                            (regionChanged)="updateRegion()">
+                        </app-properties>
+                    </div>
+
+                </mat-tab>
+            </mat-tab-group>
+            <ng-template #deletedResource>
+                <app-properties *ngIf="resource.res" [resource]="resource" [displayProjectInfo]="true"
+                    [adminPermissions]="adminPermissions" [editPermissions]="editPermissions" [valueUuidToHighlight]="valueUuid">
+                </app-properties>
+            </ng-template>
+        </div>
+        <!-- progress indicator -->
+        <app-progress-indicator *ngIf="loading"></app-progress-indicator>
     </div>
-    <!-- progress indicator -->
-    <app-progress-indicator *ngIf="!resource && loading"></app-progress-indicator>
 
     <!-- resource not found  -->
     <div *ngIf="!resource && !loading" class="no-results">


### PR DESCRIPTION
resolves DEV-638

Especially in case of a book, where the incoming file representations have to be loaded first, it makes sense to display the whole resource when everything is ready.

https://user-images.githubusercontent.com/4253580/166705598-b29e402b-4762-4528-9877-36e99d54ea26.mov
