### PR TITLE
fix(docs): resolve dead links to documentation

### DIFF
--- a/src/app/main/action/hint/hint.component.ts
+++ b/src/app/main/action/hint/hint.component.ts
@@ -39,7 +39,7 @@ export class HintComponent implements OnInit {
     private _getHint(topic: string): string {
         switch(topic) {
             case 'search':
-                this.documentation = 'https://docs.dasch.swiss/DSP-APP/user-guide/data/#search-and-browse';
+                this.documentation = 'https://docs.dasch.swiss/latest/DSP-APP/user-guide/data/#search-and-browse';
                 return `<p>Use special syntax:</p>
                 <ul>
                     <li>question mark<strong>?</strong> can be used as wildcard symbol for a single character.<br>
@@ -54,7 +54,7 @@ export class HintComponent implements OnInit {
                 </ul>`;
                 break;
             case 'ontology':
-                this.documentation = 'https://docs.dasch.swiss/DSP-APP/user-guide/project/#data-model';
+                this.documentation = 'https://docs.dasch.swiss/latest/DSP-APP/user-guide/project/#data-model';
                 return `<p>Data Model</p>
                 <p>
                     The definition of the data model (ontology) is the most important step.
@@ -65,7 +65,7 @@ export class HintComponent implements OnInit {
                 </p>`;
                 break;
             case 'list':
-                this.documentation = '';
+                this.documentation = 'https://docs.dasch.swiss/latest/DSP-APP/user-guide/project/#define-lists';
                 return `<p>List Data</p>
                 <p>
                 Lists are very useful if you want to use controlled vocabulary to describe something.

--- a/src/app/main/help/help.component.ts
+++ b/src/app/main/help/help.component.ts
@@ -30,21 +30,21 @@ export class HelpComponent implements OnInit {
             icon: 'assignment',
             title: 'Project administration',
             text: 'Read more about project administration and how to manage project members.',
-            url: 'https://docs.dasch.swiss/DSP-APP/user-guide/project',
+            url: 'https://docs.dasch.swiss/latest/DSP-APP/user-guide/project',
             urlText: 'Open Documentation'
         },
         {
             icon: 'bubble_chart',
             title: 'Data model creation',
             text: 'Find everything about data modelling and how to setup the project database.',
-            url: 'https://docs.dasch.swiss/DSP-APP/user-guide/project/#data-model',
+            url: 'https://docs.dasch.swiss/latest/DSP-APP/user-guide/project/#data-model',
             urlText: 'Open Documentation'
         },
         {
             icon: 'image_search',
             title: 'Research tools',
             text: 'Get more information about data handling, search methods and how to use the research tools.',
-            url: 'https://docs.dasch.swiss/DSP-APP/user-guide/',
+            url: 'https://docs.dasch.swiss/latest/DSP-APP/user-guide/',
             urlText: 'Open Documentation'
         }
     ];

--- a/src/app/main/services/session.service.ts
+++ b/src/app/main/services/session.service.ts
@@ -164,7 +164,7 @@ export class SessionService {
             // store session information in browser's localstorage
             // todo: jwt will be removed, when we have a better cookie solution (DSP-261)
             // --> no it can't be removed because the token is needed in sipi upload:
-            // https://docs.dasch.swiss/DSP-API/03-apis/api-v2/editing-values/#upload-files-to-sipi
+            // https://docs.dasch.swiss/latest/DSP-API/03-apis/api-v2/editing-values/#upload-files-to-sipi
             session = {
                 id: this._setTimestamp(),
                 user: {

--- a/src/app/workspace/resource/permission-info/permission-info.component.ts
+++ b/src/app/workspace/resource/permission-info/permission-info.component.ts
@@ -38,7 +38,7 @@ export class PermissionInfoComponent implements OnInit {
     isOpen = false;
 
     // default premission values based on DSP-API permissions concept:
-    // https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/?h=unknown#permissions
+    // https://docs.dasch.swiss/latest/DSP-API/02-knora-ontologies/knora-base/?h=unknown#permissions
     defaultPermissions: PermissionObj[] = [
         {
             name: 'RV',
@@ -68,7 +68,7 @@ export class PermissionInfoComponent implements OnInit {
     ];
 
     // default user groups based on DSP-API users and groups concept:
-    // https://docs.dasch.swiss/DSP-API/02-knora-ontologies/knora-base/?h=unknown#users-and-groups
+    // https://docs.dasch.swiss/latest/DSP-API/02-knora-ontologies/knora-base/?h=unknown#users-and-groups
     defaultGroups: string[] = [
         'knora-admin:SystemAdmin',
         'knora-admin:ProjectAdmin',


### PR DESCRIPTION
Since I've updated the docs.dasch.swiss page with versioning, we have dead links in DSP-App. 