### PR TITLE
fix(property-form): App changes "salsah-gui:List" to "salsah-gui:Pulldown" (DEV-1089)

### DIFF
--- a/src/app/project/ontology/property-form/property-form.component.ts
+++ b/src/app/project/ontology/property-form/property-form.component.ts
@@ -455,7 +455,12 @@ export class PropertyFormComponent implements OnInit {
                                 (propertyCommentResponse: ResourcePropertyDefinitionWithAllLanguages) => {
                                     this.lastModificationDate = propertyCommentResponse.lastModificationDate;
 
-                                    if (!this.unsupportedPropertyType) {
+                                    // if property type is supported and is of type TextValue and the guiElement is different from its initial value, call replaceGuiElement() to update the guiElement
+                                    // this only works for the TextValue object type currently
+                                    // https://docs.dasch.swiss/latest/DSP-API/03-apis/api-v2/ontology-information/#changing-the-gui-element-and-gui-attributes-of-a-property
+                                    if (!this.unsupportedPropertyType &&
+                                        this.propertyInfo.propDef.objectType === Constants.TextValue &&
+                                        this.propertyInfo.propDef.guiElement !== this.propertyForm.controls['propType'].value.guiEle) {
                                         this.replaceGuiElement();
                                     } else {
                                         this.loading = false;
@@ -478,7 +483,12 @@ export class PropertyFormComponent implements OnInit {
                                 (deleteCommentResponse: ResourcePropertyDefinitionWithAllLanguages) => {
                                     this.lastModificationDate = deleteCommentResponse.lastModificationDate;
 
-                                    if (!this.unsupportedPropertyType) {
+                                    // if property type is supported and is of type TextValue and the guiElement is different from its initial value, call replaceGuiElement() to update the guiElement
+                                    // this only works for the TextValue object type currently
+                                    // https://docs.dasch.swiss/latest/DSP-API/03-apis/api-v2/ontology-information/#changing-the-gui-element-and-gui-attributes-of-a-property
+                                    if (!this.unsupportedPropertyType &&
+                                        this.propertyInfo.propDef.objectType === Constants.TextValue &&
+                                        this.propertyInfo.propDef.guiElement !== this.propertyForm.controls['propType'].value.guiEle) {
                                         this.replaceGuiElement();
                                     } else {
                                         this.loading = false;


### PR DESCRIPTION
resolves DEV-1089

The property form currently calls the `replaceGuiElement()` method any time a label or comment on a property is changed and since `salsah-gui:List` is no longer supported in the app as of https://github.com/dasch-swiss/dsp-app/pull/643, the `guiElement` of ListValue object types was always changed to `salsah-gui:Pulldown`. However, in the [API](https://docs.dasch.swiss/2022.07.02/DSP-API/03-apis/api-v2/ontology-information/#changing-the-gui-element-and-gui-attributes-of-a-property) (not specifically stated in the docs, see screenshot below), it's only possible to change the `guiElement` of a TextValue object type so we should only call `replaceGuiElement()` if the property is a TextValue and the `guiElement` is different from it's initial value.

screenshot from old Youtrack task:
<img width="1192" alt="Screen Shot 2022-07-29 at 10 44 33" src="https://user-images.githubusercontent.com/60604010/181721121-df9581cd-0e11-4573-b6c8-65cf62517775.png">

