### PR TITLE
feat (still image component): view stays within image borders, instant drag, no delay, double click and flick enabled

### DIFF
--- a/src/app/workspace/resource/representation/still-image/still-image.component.ts
+++ b/src/app/workspace/resource/representation/still-image/still-image.component.ts
@@ -614,8 +614,12 @@ export class StillImageComponent implements OnChanges, OnDestroy, AfterViewInit 
             navigatorHeight: '120px',
             navigatorWidth: '120px',
             gestureSettingsMouse: {
-                clickToZoom: false // do not zoom in on click
-            }
+                clickToZoom: false, // do not zoom in on click
+                dblClickToZoom: true, // but zoom on double click
+                flickEnabled: true, // perform a flick gesture to drag image
+                animationTime: 0.1, // direct and instant drag performance
+            },
+            visibilityRatio: 1.0 // viewers focus limited to the image borders; no more cutting the image on zooming out
         };
         this._viewer = new OpenSeadragon.Viewer(osdOptions);
 


### PR DESCRIPTION
Resolves DEV-1554.

Introduce new features:

- the viewers focus is limited to the image borders (no more zooming into black background). On zooming in and out the view got stuck sometimes and cut the image. The view now sticks to the images borders and centers back on zooming out.
- improve drag behaviour: direct/instant. No delay, no slow animations
- double click zooms in
- flick gestures are possible to drag the image