### PR TITLE
chore: bump nginx-server version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN npm run build-prod
 
 ### STAGE 2: Setup ###
 
-FROM daschswiss/nginx-server:1.1.2
+FROM daschswiss/nginx-server:1.1.3
 
 LABEL maintainer="400790+subotic@users.noreply.github.com"
 


### PR DESCRIPTION
Bumping nginx-server version to newest version that brings in [cache-control headers that turn off caching](https://github.com/dasch-swiss/docker-nginx-server/commit/5d51c33c6f2daca73ba8ccf9ad80c7aa4aa27e20)