### PR TITLE
feat: advanced search filter bar prototype

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,33 @@
+# Temporary commands for prototype development
+
+# Serve the prototype on port 4201
+proto-serve:
+    lsof -ti:4201 | xargs kill 2>/dev/null || true
+    sleep 1
+    npx nx serve prototype --port 4201
+
+# Build the prototype
+proto-build:
+    npx nx build prototype
+
+# Build and show only errors
+proto-check:
+    npx nx build prototype 2>&1 | grep -E "error TS|Error:" | head -20
+
+# Kill the prototype server
+proto-kill:
+    lsof -ti:4201 | xargs kill 2>/dev/null || true
+
+# Full restart: kill, reset Nx cache, serve fresh
+proto-restart:
+    lsof -ti:4201 | xargs kill 2>/dev/null || true
+    npx nx reset
+    npx nx serve prototype --port 4201
+
+# Take a screenshot with agent-browser
+proto-screenshot name:
+    agent-browser screenshot "../dasch-specs/specs/2026-03-19-advanced-search-redesign/assets/{{name}}.png"
+
+# Navigate agent-browser to a path
+proto-goto path:
+    agent-browser goto "http://localhost:4201{{path}}"

--- a/apps/prototype/fixtures/filter-bar.fixture.json
+++ b/apps/prototype/fixtures/filter-bar.fixture.json
@@ -1,0 +1,56 @@
+{
+  "component": "FilterBarPrototype",
+  "ontologies": [
+    { "iri": "http://www.knora.org/ontology/0803/incunabula", "label": "Incunabula" }
+  ],
+  "resourceClasses": [
+    { "iri": "http://www.knora.org/ontology/0803/incunabula#book", "label": "Book" },
+    { "iri": "http://www.knora.org/ontology/0803/incunabula#page", "label": "Page" },
+    { "iri": "http://www.knora.org/ontology/0803/incunabula#person", "label": "Person" }
+  ],
+  "properties": {
+    "Book": [
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#title", "label": "Title", "valueType": "TextValue" },
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#hasAuthor", "label": "Author", "valueType": "LinkValue", "linkedResourceClass": "Person" },
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#pubdate", "label": "Publication Date", "valueType": "DateValue" },
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#publisher", "label": "Publisher", "valueType": "TextValue" },
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#publoc", "label": "Publication Location", "valueType": "TextValue" }
+    ],
+    "Page": [
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#pagenum", "label": "Page Number", "valueType": "TextValue" },
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#partOfValue", "label": "Part of", "valueType": "LinkValue", "linkedResourceClass": "Book" }
+    ],
+    "Person": [
+      { "iri": "http://www.knora.org/ontology/0803/incunabula#personName", "label": "Name", "valueType": "TextValue" }
+    ]
+  },
+  "operators": {
+    "TextValue": ["equals", "does not equal", "contains", "is like", "exists", "does not exist"],
+    "DateValue": ["equals", "does not equal", "greater than", "less than", "exists", "does not exist"],
+    "IntValue": ["equals", "does not equal", "greater than", "less than", "exists", "does not exist"],
+    "LinkValue": ["equals", "does not equal", "exists", "does not exist", "matches"],
+    "BooleanValue": ["equals", "exists", "does not exist"]
+  },
+  "searchResults": [
+    { "iri": "http://rdfh.ch/0803/001", "label": "Zeitglöcklein des Lebens und Leidens Christi", "resourceClass": "Book" },
+    { "iri": "http://rdfh.ch/0803/002", "label": "Narrenschiff", "resourceClass": "Book" },
+    { "iri": "http://rdfh.ch/0803/003", "label": "Das Lied der Nibelungen", "resourceClass": "Book" },
+    { "iri": "http://rdfh.ch/0803/004", "label": "Heilsspiegel", "resourceClass": "Book" },
+    { "iri": "http://rdfh.ch/0803/005", "label": "Von der Arznei beider Glück", "resourceClass": "Book" }
+  ],
+  "i18n": {
+    "en": {
+      "advancedSearch.selectOntology": "Select ontology",
+      "advancedSearch.selectResourceClass": "Select resource class",
+      "advancedSearch.addCondition": "Add condition",
+      "advancedSearch.search": "Search",
+      "advancedSearch.noResults": "No resources found. Try broadening your search by removing conditions.",
+      "advancedSearch.buildQuery": "Build your query and click Search.",
+      "advancedSearch.sortBy": "Sort by"
+    }
+  },
+  "meta": {
+    "generatedAt": "2026-03-19T12:00:00Z",
+    "purpose": "Advanced search filter bar prototype"
+  }
+}

--- a/apps/prototype/project.json
+++ b/apps/prototype/project.json
@@ -1,0 +1,55 @@
+{
+  "name": "prototype",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/prototype/src",
+  "projectType": "application",
+  "prefix": "proto",
+  "targets": {
+    "build": {
+      "executor": "@angular-devkit/build-angular:browser",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/prototype",
+        "index": "apps/prototype/src/index.html",
+        "main": "apps/prototype/src/main.ts",
+        "tsConfig": "apps/prototype/tsconfig.app.json",
+        "inlineStyleLanguage": "scss",
+        "assets": [
+          {
+            "glob": "**/*",
+            "input": "apps/dsp-app/src/assets",
+            "output": "/assets"
+          }
+        ],
+        "styles": ["apps/prototype/src/styles.scss"],
+        "stylePreprocessorOptions": {
+          "includePaths": ["apps/dsp-app/src/styles"]
+        },
+        "scripts": []
+      },
+      "configurations": {
+        "development": {
+          "buildOptimizer": false,
+          "optimization": false,
+          "vendorChunk": true,
+          "extractLicenses": false,
+          "sourceMap": true,
+          "namedChunks": true
+        }
+      },
+      "defaultConfiguration": "development"
+    },
+    "serve": {
+      "executor": "@angular-devkit/build-angular:dev-server",
+      "options": {
+        "buildTarget": "prototype:build",
+        "port": 4201
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "prototype:build:development"
+        }
+      }
+    }
+  }
+}

--- a/apps/prototype/src/components/filter-bar-b.component.html
+++ b/apps/prototype/src/components/filter-bar-b.component.html
@@ -1,0 +1,457 @@
+<div class="filter-bar" role="listbox" aria-label="Active search filters">
+  <!-- Ontology chip -->
+  <button mat-stroked-button class="filter-chip foundation-chip" [matMenuTriggerFor]="ontologyMenu"
+          [class.placeholder]="!selectedOntology">
+    <mat-icon class="chip-icon">lan</mat-icon>
+    {{ selectedOntology?.label || 'Select ontology' }}
+    <mat-icon iconPositionEnd>arrow_drop_down</mat-icon>
+  </button>
+  <mat-menu #ontologyMenu="matMenu">
+    @for (onto of ontologies; track onto.iri) {
+      <button mat-menu-item (click)="ontologySelected.emit(onto)">
+        <mat-icon>lan</mat-icon>
+        {{ onto.label }}
+      </button>
+    }
+  </mat-menu>
+
+  <span class="chip-divider"></span>
+
+  <!-- Resource class chip -->
+  <button mat-stroked-button class="filter-chip foundation-chip" [matMenuTriggerFor]="rcMenu"
+          [disabled]="!selectedOntology"
+          [class.placeholder]="!selectedResourceClass">
+    @if (selectedResourceClass?.icon) { <mat-icon class="chip-icon">{{ selectedResourceClass.icon }}</mat-icon> }
+    {{ selectedResourceClass?.label || 'Select class' }}
+    <mat-icon iconPositionEnd>arrow_drop_down</mat-icon>
+  </button>
+  <mat-menu #rcMenu="matMenu">
+    <button mat-menu-item (click)="resourceClassSelected.emit(null)">
+      <em>All resource classes</em>
+    </button>
+    @for (rc of resourceClasses; track rc.iri) {
+      <button mat-menu-item (click)="resourceClassSelected.emit(rc)">
+        @if (rc.icon) { <mat-icon>{{ rc.icon }}</mat-icon> }
+        {{ rc.label }}
+      </button>
+    }
+  </mat-menu>
+
+  <span class="chip-divider"></span>
+
+  <!-- Property condition chips — segmented: each part is independently clickable -->
+  @for (condition of conditions; track condition.id; let i = $index) {
+    @if (i > 0) {
+      <span class="logic-operator">AND</span>
+    }
+    <div class="condition-wrapper" role="option">
+      @if (isMatchesCondition(condition)) {
+        <!-- Matches condition: wrapping container with sub-conditions -->
+        <div class="matches-chip">
+          <div class="matches-header">
+            <mat-icon class="chip-icon link-icon">link</mat-icon>
+            <span class="chip-part chip-segment" [matMenuTriggerFor]="matchPropMenu">{{ condition.property?.label }}</span>
+            <mat-menu #matchPropMenu="matMenu">
+              @for (prop of properties; track prop.iri) {
+                <button mat-menu-item (click)="onChangeProperty(condition, prop)">
+                  <mat-icon>{{ getPropertyIcon(prop) }}</mat-icon>
+                  {{ prop.label }}
+                </button>
+              }
+            </mat-menu>
+            <span class="chip-sep"></span>
+            <span class="chip-part chip-operator chip-segment" [matMenuTriggerFor]="matchOpMenu">matches</span>
+            <mat-menu #matchOpMenu="matMenu">
+              @for (op of getOperators(condition.property); track op) {
+                <button mat-menu-item (click)="onChangeOperator(condition, op)">{{ op }}</button>
+              }
+            </mat-menu>
+            <span class="chip-sep"></span>
+            <span class="chip-part">{{ condition.linkedResourceClass?.label || 'Select class...' }}</span>
+            <span class="matches-spacer"></span>
+            <span class="chip-remove"
+                  (click)="conditionRemoved.emit(condition); $event.stopPropagation()"
+                  matTooltip="Remove filter">
+              <mat-icon>close</mat-icon>
+            </span>
+          </div>
+          @if (condition.linkedResourceClass) {
+            <div class="matches-body">
+              @for (sub of condition.subConditions; track sub.id; let j = $index) {
+                @if (j > 0) {
+                  <span class="logic-operator">AND</span>
+                }
+                <div class="filter-chip condition-chip sub-chip"
+                     [class.incomplete]="!sub.property || !sub.operator">
+                  <span class="chip-label">
+                    @if (sub.property) {
+                      <!-- Property segment — cascading into operators -->
+                      <span class="chip-part chip-segment" [matMenuTriggerFor]="subPropMenu">{{ sub.property.label }}</span>
+                      <mat-menu #subPropMenu="matMenu">
+                        @for (prop of getLinkedClassProperties(condition.linkedResourceClass!); track prop.iri) {
+                          <button mat-menu-item [matMenuTriggerFor]="subChangePropOpMenu"
+                                  (click)="sub.property = prop; sub.operator = null; sub.value = null">
+                            <mat-icon>{{ getPropertyIcon(prop) }}</mat-icon>
+                            {{ prop.label }}
+                          </button>
+                          <mat-menu #subChangePropOpMenu="matMenu">
+                            @for (op of getOperators(prop); track op) {
+                              @if (needsValueInput(op)) {
+                                <button mat-menu-item [matMenuTriggerFor]="subChangeValMenu"
+                                        (menuOpened)="subValInput.focus()">{{ op }}</button>
+                                <mat-menu #subChangeValMenu="matMenu" class="value-input-menu">
+                                  <div class="cascade-value-panel" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                                    <input class="cascade-value-input" placeholder="Enter value..." #subValInput
+                                           (keydown.enter)="sub.property = prop; sub.operator = op; sub.value = subValInput.value; $event.preventDefault(); $event.stopPropagation()" />
+                                    <button mat-flat-button color="primary" class="cascade-value-confirm"
+                                            (click)="sub.property = prop; sub.operator = op; sub.value = subValInput.value">
+                                      <mat-icon>check</mat-icon>
+                                    </button>
+                                  </div>
+                                </mat-menu>
+                              } @else {
+                                <button mat-menu-item (click)="sub.property = prop; sub.operator = op; sub.value = null">{{ op }}</button>
+                              }
+                            }
+                          </mat-menu>
+                        }
+                      </mat-menu>
+                    }
+                    @if (sub.operator) {
+                      <span class="chip-sep"></span>
+                      <span class="chip-part chip-operator chip-segment" [matMenuTriggerFor]="subOpMenu">{{ sub.operator }}</span>
+                      <mat-menu #subOpMenu="matMenu">
+                        @for (op of getOperators(sub.property); track op) {
+                          @if (needsValueInput(op)) {
+                            <button mat-menu-item [matMenuTriggerFor]="subOpValMenu"
+                                    (menuOpened)="subOpValInput.focus()">{{ op }}</button>
+                            <mat-menu #subOpValMenu="matMenu" class="value-input-menu">
+                              <div class="cascade-value-panel" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                                <input class="cascade-value-input" placeholder="Enter value..." #subOpValInput
+                                       (keydown.enter)="sub.operator = op; sub.value = subOpValInput.value; $event.preventDefault(); $event.stopPropagation()" />
+                                <button mat-flat-button color="primary" class="cascade-value-confirm"
+                                        (click)="sub.operator = op; sub.value = subOpValInput.value">
+                                  <mat-icon>check</mat-icon>
+                                </button>
+                              </div>
+                            </mat-menu>
+                          } @else {
+                            <button mat-menu-item (click)="sub.operator = op; sub.value = null">{{ op }}</button>
+                          }
+                        }
+                      </mat-menu>
+                    }
+                    @if (sub.value) {
+                      <span class="chip-sep"></span>
+                      <span class="chip-part chip-value chip-segment" (click)="openValueEdit(sub)">{{ sub.value }}</span>
+                    }
+                    @if (!sub.property) {
+                      <!-- New sub-condition: full cascade property → operator → value -->
+                      <span class="chip-part chip-placeholder chip-segment" [matMenuTriggerFor]="subNewPropMenu">condition...</span>
+                      <mat-menu #subNewPropMenu="matMenu">
+                        @for (prop of getLinkedClassProperties(condition.linkedResourceClass!); track prop.iri) {
+                          <button mat-menu-item [matMenuTriggerFor]="subNewOpMenu">
+                            <mat-icon>{{ getPropertyIcon(prop) }}</mat-icon>
+                            {{ prop.label }}
+                          </button>
+                          <mat-menu #subNewOpMenu="matMenu">
+                            @for (op of getOperators(prop); track op) {
+                              @if (needsValueInput(op)) {
+                                <button mat-menu-item [matMenuTriggerFor]="subNewValMenu"
+                                        (menuOpened)="subNewValInput.focus()">{{ op }}</button>
+                                <mat-menu #subNewValMenu="matMenu" class="value-input-menu">
+                                  <div class="cascade-value-panel" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                                    <input class="cascade-value-input" placeholder="Enter value..." #subNewValInput
+                                           (keydown.enter)="sub.property = prop; sub.operator = op; sub.value = subNewValInput.value; $event.preventDefault(); $event.stopPropagation()" />
+                                    <button mat-flat-button color="primary" class="cascade-value-confirm"
+                                            (click)="sub.property = prop; sub.operator = op; sub.value = subNewValInput.value">
+                                      <mat-icon>check</mat-icon>
+                                    </button>
+                                  </div>
+                                </mat-menu>
+                              } @else {
+                                <button mat-menu-item (click)="sub.property = prop; sub.operator = op; sub.value = null">{{ op }}</button>
+                              }
+                            }
+                          </mat-menu>
+                        }
+                      </mat-menu>
+                    }
+                  </span>
+                  <span class="chip-remove"
+                        (click)="removeSubCondition(condition, sub); $event.stopPropagation()"
+                        matTooltip="Remove">
+                    <mat-icon>close</mat-icon>
+                  </span>
+                </div>
+              }
+              <button mat-stroked-button class="add-btn sub-add-btn"
+                      (click)="addSubCondition(condition)" matTooltip="Add sub-condition">
+                <mat-icon>add</mat-icon>
+              </button>
+            </div>
+          }
+        </div>
+      } @else {
+      <div class="filter-chip condition-chip"
+              [class.linked]="condition.property?.isLinkedResourceProperty">
+        @if (condition.property?.isLinkedResourceProperty) {
+          <mat-icon class="chip-icon link-icon">link</mat-icon>
+        }
+        <span class="chip-label">
+          <!-- Property segment — click opens property menu -->
+          @if (condition.property) {
+            <span class="chip-part chip-segment" [matMenuTriggerFor]="propMenu">
+              {{ condition.property.label }}
+            </span>
+            <mat-menu #propMenu="matMenu">
+              @for (prop of properties; track prop.iri) {
+                <button mat-menu-item (click)="onChangeProperty(condition, prop)">
+                  <mat-icon>{{ getPropertyIcon(prop) }}</mat-icon>
+                  {{ prop.label }}
+                </button>
+              }
+            </mat-menu>
+          }
+
+          <!-- Operator segment — click opens operator menu -->
+          @if (condition.operator) {
+            <span class="chip-sep"></span>
+            <span class="chip-part chip-operator chip-segment" [matMenuTriggerFor]="opMenu">
+              {{ condition.operator }}
+            </span>
+            <mat-menu #opMenu="matMenu">
+              @for (op of getOperators(condition.property); track op) {
+                <button mat-menu-item (click)="onChangeOperator(condition, op)">{{ op }}</button>
+              }
+            </mat-menu>
+          }
+
+          <!-- Value segment — type-specific editing -->
+          @if (needsValueInputForProperty(condition.operator, condition.property)) {
+            <span class="chip-sep"></span>
+            @switch (getValueType(condition.property)) {
+              @case ('boolean') {
+                <span class="chip-part chip-value chip-segment" [matMenuTriggerFor]="boolValMenu">
+                  {{ condition.value || 'select...' }}
+                </span>
+                <mat-menu #boolValMenu="matMenu">
+                  <button mat-menu-item (click)="onSegmentValueChanged(condition, 'True')">True</button>
+                  <button mat-menu-item (click)="onSegmentValueChanged(condition, 'False')">False</button>
+                </mat-menu>
+              }
+              @case ('list') {
+                <span class="chip-part chip-value chip-segment" [matMenuTriggerFor]="listValMenu">
+                  {{ condition.value || 'select...' }}
+                </span>
+                <mat-menu #listValMenu="matMenu">
+                  @for (node of getListNodes(condition.property); track node.iri) {
+                    <button mat-menu-item (click)="onSegmentValueChanged(condition, node.label)">{{ node.label }}</button>
+                  }
+                </mat-menu>
+              }
+              @case ('date') {
+                <span class="chip-part chip-value chip-segment" (click)="chipDatePicker.open()">
+                  {{ condition.value || 'select date...' }}
+                </span>
+                <input [matDatepicker]="chipDatePicker" class="hidden-date-input"
+                       (dateChange)="onSegmentValueChanged(condition, $event.value?.toLocaleDateString() || '')" />
+                <mat-datepicker #chipDatePicker></mat-datepicker>
+              }
+              @case ('color') {
+                <span class="chip-part chip-value chip-segment" style="display: inline-flex; align-items: center; gap: 4px; cursor: pointer;"
+                      [colorPicker]="condition.value || '#ff0000'"
+                      [cpOutputFormat]="'hex'"
+                      (colorPickerChange)="onSegmentValueChanged(condition, $event)">
+                  <span class="color-swatch" [style.background]="condition.value || '#ff0000'"></span>
+                  {{ condition.value || 'select color...' }}
+                </span>
+              }
+              @default {
+                <!-- Text, number, URI — inline text edit -->
+                @if (editingValueConditionId !== condition.id) {
+                  <span class="chip-part chip-value chip-segment"
+                        [class.chip-placeholder]="!condition.value"
+                        (click)="openValueEdit(condition)">
+                    {{ condition.value || 'enter value...' }}
+                  </span>
+                } @else {
+                  <span class="chip-part chip-value-edit">
+                    <input class="inline-value-input"
+                           [type]="getValueType(condition.property) === 'integer' || getValueType(condition.property) === 'decimal' ? 'number' : 'text'"
+                           [placeholder]="getValueType(condition.property) === 'date' ? 'JULIAN:1492' : getValueType(condition.property) === 'uri' ? 'https://...' : 'Enter value...'"
+                           [(ngModel)]="editingValueText"
+                           (keydown.enter)="confirmValueEdit(condition)"
+                           (keydown.escape)="cancelValueEdit()"
+                           (blur)="confirmValueEdit(condition)"
+                           autofocus />
+                  </span>
+                }
+              }
+            }
+          }
+        </span>
+        <span class="chip-remove"
+              (click)="conditionRemoved.emit(condition); $event.stopPropagation()"
+              [attr.aria-label]="'Remove filter: ' + formatChipLabel(condition)"
+              matTooltip="Remove filter">
+          <mat-icon>close</mat-icon>
+        </span>
+      </div>
+      }
+    </div>
+  }
+
+  <!-- Add condition button — cascading menu: property → operator → (value) -->
+  <button mat-stroked-button class="add-btn" [disabled]="!selectedOntology"
+          [matMenuTriggerFor]="addPropMenu" #addMenuTrigger="matMenuTrigger" matTooltip="Add condition">
+    <mat-icon>add</mat-icon>
+  </button>
+  <mat-menu #addPropMenu="matMenu">
+    @for (prop of properties; track prop.iri) {
+      <button mat-menu-item [matMenuTriggerFor]="operatorSubMenu">
+        <mat-icon>{{ getPropertyIcon(prop) }}</mat-icon>
+        {{ prop.label }}
+      </button>
+      <mat-menu #operatorSubMenu="matMenu">
+        @for (op of getOperators(prop); track op) {
+          @if (needsValueInputForProperty(op, prop)) {
+            @switch (getValueType(prop)) {
+              @case ('boolean') {
+                <!-- Boolean: submenu with True/False -->
+                <button mat-menu-item [matMenuTriggerFor]="boolSubMenu">{{ op }}</button>
+                <mat-menu #boolSubMenu="matMenu">
+                  <button mat-menu-item (click)="onCascadeCompleteWithValue(prop, op, 'True')">True</button>
+                  <button mat-menu-item (click)="onCascadeCompleteWithValue(prop, op, 'False')">False</button>
+                </mat-menu>
+              }
+              @case ('list') {
+                <!-- List: submenu with list nodes -->
+                <button mat-menu-item [matMenuTriggerFor]="listSubMenu">{{ op }}</button>
+                <mat-menu #listSubMenu="matMenu">
+                  @for (node of getListNodes(prop); track node.iri) {
+                    <button mat-menu-item (click)="onCascadeCompleteWithValue(prop, op, node.label)">{{ node.label }}</button>
+                  }
+                </mat-menu>
+              }
+              @case ('integer') {
+                <!-- Integer: text input -->
+                <button mat-menu-item [matMenuTriggerFor]="valueSubMenu"
+                        (menuOpened)="valueInput.focus()">{{ op }}</button>
+                <mat-menu #valueSubMenu="matMenu" class="value-input-menu">
+                  <div class="cascade-value-panel" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                    <input class="cascade-value-input" type="number" step="1"
+                           placeholder="Integer..."
+                           #valueInput
+                           (keydown.enter)="onCascadeCompleteWithValue(prop, op, valueInput.value); $event.preventDefault(); $event.stopPropagation()" />
+                    <button mat-flat-button color="primary" class="cascade-value-confirm"
+                            (click)="onCascadeCompleteWithValue(prop, op, valueInput.value)">
+                      <mat-icon>check</mat-icon>
+                    </button>
+                  </div>
+                </mat-menu>
+              }
+              @case ('date') {
+                <!-- Date: button that opens datepicker in submenu -->
+                <button mat-menu-item [matMenuTriggerFor]="dateSubMenu">{{ op }}</button>
+                <mat-menu #dateSubMenu="matMenu" class="value-input-menu">
+                  <div class="cascade-value-panel" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                    <button mat-stroked-button class="cascade-date-btn" (click)="cascadeDatePicker.open()">
+                      <mat-icon>calendar_today</mat-icon>
+                      Select date
+                    </button>
+                    <input [matDatepicker]="cascadeDatePicker" class="hidden-date-input"
+                           #cascadeDateInput
+                           (dateChange)="onCascadeCompleteWithValue(prop, op, $event.value?.toLocaleDateString() || '')" />
+                    <mat-datepicker #cascadeDatePicker></mat-datepicker>
+                  </div>
+                </mat-menu>
+              }
+              @case ('uri') {
+                <!-- URI: text input -->
+                <button mat-menu-item [matMenuTriggerFor]="valueSubMenu"
+                        (menuOpened)="valueInput.focus()">{{ op }}</button>
+                <mat-menu #valueSubMenu="matMenu" class="value-input-menu">
+                  <div class="cascade-value-panel" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                    <input class="cascade-value-input"
+                           placeholder="https://..."
+                           #valueInput
+                           (keydown.enter)="onCascadeCompleteWithValue(prop, op, valueInput.value); $event.preventDefault(); $event.stopPropagation()" />
+                    <button mat-flat-button color="primary" class="cascade-value-confirm"
+                            (click)="onCascadeCompleteWithValue(prop, op, valueInput.value)">
+                      <mat-icon>check</mat-icon>
+                    </button>
+                  </div>
+                </mat-menu>
+              }
+              @case ('color') {
+                <!-- Color: submenu with color picker button -->
+                <button mat-menu-item [matMenuTriggerFor]="colorSubMenu">{{ op }}</button>
+                <mat-menu #colorSubMenu="matMenu" class="value-input-menu">
+                  <div class="cascade-value-panel" (click)="$event.stopPropagation()">
+                    <button mat-stroked-button class="cascade-color-btn"
+                            [colorPicker]="'#ff0000'"
+                            [cpOutputFormat]="'hex'"
+                            (colorPickerChange)="onCascadeCompleteWithValue(prop, op, $event)">
+                      <mat-icon>palette</mat-icon>
+                      Select color
+                    </button>
+                  </div>
+                </mat-menu>
+              }
+              @default {
+                <!-- Text / other: free text input -->
+                <button mat-menu-item [matMenuTriggerFor]="valueSubMenu"
+                        (menuOpened)="valueInput.focus()">{{ op }}</button>
+                <mat-menu #valueSubMenu="matMenu" class="value-input-menu">
+                  <div class="cascade-value-panel" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                    <input class="cascade-value-input"
+                           placeholder="Enter value..."
+                           #valueInput
+                           (keydown.enter)="onCascadeCompleteWithValue(prop, op, valueInput.value); $event.preventDefault(); $event.stopPropagation()" />
+                    <button mat-flat-button color="primary" class="cascade-value-confirm"
+                            (click)="onCascadeCompleteWithValue(prop, op, valueInput.value)">
+                      <mat-icon>check</mat-icon>
+                    </button>
+                  </div>
+                </mat-menu>
+              }
+            }
+          } @else {
+            <!-- Operator without value (exists/not exists) → complete immediately -->
+            <button mat-menu-item (click)="onCascadeComplete(prop, op)">{{ op }}</button>
+          }
+        }
+      </mat-menu>
+    }
+  </mat-menu>
+
+  <!-- Spacer pushes sort + search to right -->
+  <span class="spacer"></span>
+
+  <!-- Sort by -->
+  <button mat-stroked-button class="filter-chip sort-chip" [disabled]="!selectedOntology"
+          [matMenuTriggerFor]="sortMenu">
+    <mat-icon class="chip-icon">sort</mat-icon>
+    {{ sortBy || 'Sort by' }}
+    <mat-icon iconPositionEnd>arrow_drop_down</mat-icon>
+  </button>
+  <mat-menu #sortMenu="matMenu">
+    <button mat-menu-item (click)="sortByChanged.emit(null)"><em>No sorting</em></button>
+    @for (prop of properties; track prop.iri) {
+      <button mat-menu-item (click)="sortByChanged.emit(prop.label)">
+        <mat-icon>{{ getPropertyIcon(prop) }}</mat-icon>
+        {{ prop.label }}
+      </button>
+    }
+  </mat-menu>
+
+  <!-- Search button -->
+  <button mat-flat-button color="primary" class="search-btn"
+          [disabled]="!canSearch"
+          [class.stale]="isStale"
+          (click)="searchTriggered.emit()">
+    <mat-icon>search</mat-icon>
+    Search
+  </button>
+</div>

--- a/apps/prototype/src/components/filter-bar-b.component.scss
+++ b/apps/prototype/src/components/filter-bar-b.component.scss
@@ -1,0 +1,590 @@
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  background: #fafafa;
+  border-bottom: 1px solid #e0e0e0;
+  min-height: 48px;
+}
+
+.filter-chip {
+  height: 30px;
+  border-radius: 6px;
+  font-size: 13px;
+  line-height: 30px;
+  padding: 0 10px;
+  min-width: auto;
+  color: rgba(0, 0, 0, 0.72);
+
+  .chip-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+    vertical-align: middle;
+    color: rgba(0, 0, 0, 0.54);
+  }
+
+  mat-icon:not(.chip-icon) {
+    color: rgba(0, 0, 0, 0.54);
+  }
+
+  &.placeholder {
+    color: #9e9e9e;
+    border-style: dashed;
+  }
+}
+
+.foundation-chip {
+  font-weight: 500;
+  background: white;
+}
+
+.chip-divider {
+  width: 1px;
+  height: 24px;
+  background: #e0e0e0;
+  margin: 0 4px;
+}
+
+.logic-operator {
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.36);
+  letter-spacing: 0.05em;
+  padding: 0 2px;
+  user-select: none;
+}
+
+.condition-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+.condition-chip {
+  background: white;
+  border: 1px solid #bdbdbd;
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+  padding-right: 4px;
+
+  .chip-content {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .chip-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+    max-width: 300px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .chip-part {
+    flex-shrink: 0;
+  }
+
+  .chip-operator {
+    color: #757575;
+  }
+
+  .chip-value {
+    color: #336790;
+    font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 2px;
+  }
+
+  .chip-placeholder {
+    color: #9e9e9e;
+  }
+
+  .chip-segment {
+    cursor: pointer;
+    padding: 2px 3px;
+    border-radius: 3px;
+    transition: background-color 0.15s;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.06);
+    }
+  }
+
+  .chip-value-edit {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .inline-value-input {
+    border: none;
+    outline: none;
+    font-size: 13px;
+    font-style: italic;
+    color: #336790;
+    background: rgba(51, 103, 144, 0.08);
+    border-radius: 3px;
+    padding: 1px 4px;
+    width: 80px;
+    font-family: inherit;
+  }
+
+  .chip-sep {
+    width: 1px;
+    height: 14px;
+    background: #ccc;
+    margin: 0 6px;
+    flex-shrink: 0;
+  }
+
+  &.incomplete {
+    border-style: dashed;
+    color: #9e9e9e;
+  }
+
+  &.linked {
+    border-color: #7986cb;
+    background: #e8eaf6;
+
+    .link-icon {
+      color: #5c6bc0;
+    }
+  }
+
+  &.editing {
+    border-color: #336790;
+    box-shadow: 0 0 0 1px #336790;
+  }
+}
+
+// Matches condition
+.matches-chip {
+  border: 1px solid #C1D1DD;
+  border-radius: 6px;
+  background: #EAEFF3;
+  display: inline-flex;
+  flex-direction: column;
+  overflow: visible;
+}
+
+.matches-header {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.72);
+  background: #D6E0E8;
+  border-radius: 5px 5px 0 0;
+
+  .chip-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    color: #336790;
+  }
+
+  .chip-part {
+    padding: 0 3px;
+  }
+
+  .chip-sep {
+    width: 1px;
+    height: 14px;
+    background: #A3B8CA;
+    margin: 0 4px;
+    flex-shrink: 0;
+  }
+
+  .inline-dropdown-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: rgba(0, 0, 0, 0.54);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+}
+
+.matches-spacer {
+  flex: 1;
+}
+
+.matches-body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+}
+
+.sub-chip {
+  font-size: 12px;
+  height: 26px;
+  line-height: 26px;
+}
+
+.sub-add-btn {
+  min-width: 24px !important;
+  width: 24px !important;
+  height: 24px !important;
+  border-radius: 4px;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 100%;
+  margin-left: 6px;
+  border-left: 1px solid #e0e0e0;
+  padding-left: 3px;
+  padding-right: 0;
+  cursor: pointer;
+  color: rgba(0, 0, 0, 0.38);
+  border-radius: 0 5px 5px 0;
+  transition: color 0.15s, background-color 0.15s;
+
+  &:hover {
+    color: rgba(0, 0, 0, 0.72);
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+}
+
+// No popover in variant B — uses cascading menus and inline editing instead
+
+.popover-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 1000;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  padding: 10px 12px 12px;
+  min-width: 260px;
+
+  .popover-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #616161;
+
+    button {
+      width: 24px;
+      height: 24px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      ::ng-deep {
+        .mat-mdc-button-touch-target {
+          width: 24px;
+          height: 24px;
+        }
+      }
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+
+  mat-form-field {
+    width: 100%;
+
+    ::ng-deep {
+      .mat-mdc-form-field-infix {
+        min-height: 34px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+      }
+
+      .mat-mdc-floating-label:not(.mdc-floating-label--float-above) {
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      .mat-mdc-text-field-wrapper {
+        font-size: 13px;
+      }
+
+      .mat-mdc-floating-label {
+        font-size: 13px;
+      }
+
+      .mdc-text-field--outlined {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+
+      input.mat-mdc-input-element {
+        font-size: 13px;
+      }
+
+      .mat-mdc-select-value,
+      .mat-mdc-select-trigger {
+        font-size: 13px;
+      }
+    }
+  }
+
+  .option-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    vertical-align: middle;
+    color: rgba(0, 0, 0, 0.54);
+  }
+
+  .popover-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 2px;
+
+    button {
+      font-size: 13px;
+      height: 30px;
+      line-height: 30px;
+    }
+  }
+}
+
+.add-btn {
+  min-width: 30px;
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  padding: 0;
+  border-style: dashed;
+  color: rgba(0, 0, 0, 0.54);
+
+  mat-icon {
+    margin: 0;
+    font-size: 18px;
+    color: rgba(0, 0, 0, 0.54);
+  }
+}
+
+// Compact menu and select items to match chip sizing
+::ng-deep .mat-mdc-select-panel .mat-mdc-option {
+  min-height: 34px;
+  font-size: 13px;
+  padding: 0 12px;
+
+  .mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    color: rgba(0, 0, 0, 0.54);
+  }
+}
+
+::ng-deep .value-input-menu {
+  overflow: visible;
+}
+
+.cascade-value-panel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  min-width: 200px;
+}
+
+.color-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.hidden-date-input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.cascade-color-btn {
+  font-size: 12px;
+  height: 28px;
+  border-radius: 4px;
+  color: rgba(0, 0, 0, 0.72);
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    margin-right: 4px;
+    color: rgba(0, 0, 0, 0.54);
+  }
+}
+
+.cascade-date-btn {
+  font-size: 12px;
+  height: 28px;
+  border-radius: 4px;
+  color: rgba(0, 0, 0, 0.72);
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    margin-right: 4px;
+    color: rgba(0, 0, 0, 0.54);
+  }
+}
+
+.cascade-date-panel {
+  app-date-input {
+    flex: 1;
+
+    ::ng-deep {
+      .date-input-field {
+        font-size: 13px;
+
+        .mat-mdc-form-field-infix {
+          min-height: 28px;
+          padding-top: 4px;
+          padding-bottom: 4px;
+        }
+
+        .mat-mdc-text-field-wrapper {
+          font-size: 13px;
+        }
+
+        .mat-mdc-floating-label {
+          font-size: 13px;
+        }
+
+        .mat-mdc-floating-label:not(.mdc-floating-label--float-above) {
+          top: 50%;
+          transform: translateY(-50%);
+        }
+
+        input.mat-mdc-input-element {
+          font-size: 13px;
+        }
+
+        button[matsuffix] {
+          width: 24px;
+          height: 24px;
+          padding: 0;
+
+          .mat-icon {
+            font-size: 16px;
+            width: 16px;
+            height: 16px;
+          }
+        }
+      }
+    }
+  }
+}
+
+.cascade-value-input {
+  flex: 1;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  height: 28px;
+  box-sizing: border-box;
+
+  &:focus {
+    border-color: #336790;
+  }
+}
+
+.cascade-value-confirm {
+  min-width: 20px !important;
+  width: 20px !important;
+  height: 20px !important;
+  padding: 0 !important;
+  border-radius: 3px;
+  line-height: 20px;
+
+  ::ng-deep .mat-mdc-button-touch-target {
+    width: 20px;
+    height: 20px;
+  }
+
+  mat-icon {
+    font-size: 13px;
+    width: 13px;
+    height: 13px;
+    margin: 0;
+  }
+}
+
+::ng-deep .mat-mdc-menu-panel {
+  .mat-mdc-menu-item {
+    min-height: 30px;
+    font-size: 12px;
+    padding: 0 12px;
+    color: rgba(0, 0, 0, 0.72);
+
+    .mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      margin-right: 8px;
+      color: rgba(0, 0, 0, 0.54);
+    }
+  }
+}
+
+.spacer {
+  flex: 1;
+}
+
+.search-btn {
+  height: 30px;
+  border-radius: 6px;
+  font-size: 13px;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    margin-right: 4px;
+  }
+
+  &.stale {
+    outline: 2px solid rgba(51, 103, 144, 0.5);
+    outline-offset: 1px;
+  }
+}

--- a/apps/prototype/src/components/filter-bar-b.component.ts
+++ b/apps/prototype/src/components/filter-bar-b.component.ts
@@ -1,0 +1,273 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { ColorPickerDirective } from 'ngx-color-picker';
+import { MockProperty, MockResourceClass, MockOntology, MockListNode, getOperatorsForType, getIconForProperty, LIST_NODES_BY_PROPERTY, PROPERTIES_BY_CLASS, RESOURCE_CLASSES } from '../mock-data';
+
+export interface FilterCondition {
+  id: string;
+  property: MockProperty | null;
+  operator: string | null;
+  value: string | null;
+  linkedResourceClass?: MockResourceClass | null;
+  subConditions?: FilterCondition[];
+}
+
+@Component({
+  selector: 'proto-filter-bar-b',
+  standalone: true,
+  imports: [
+    CommonModule, FormsModule,
+    MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule,
+    MatMenuModule, MatSelectModule, MatTooltipModule,
+    MatDatepickerModule, MatNativeDateModule, ColorPickerDirective,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './filter-bar-b.component.html',
+  styleUrls: ['./filter-bar-b.component.scss'],
+})
+export class FilterBarVariantBComponent implements OnChanges {
+  @Input() ontologies: MockOntology[] = [];
+  @Input() resourceClasses: MockResourceClass[] = [];
+  @Input() properties: MockProperty[] = [];
+  @Input() selectedOntology: MockOntology | null = null;
+  @Input() selectedResourceClass: MockResourceClass | null = null;
+  @Input() conditions: FilterCondition[] = [];
+  @Input() sortBy: string | null = null;
+  @Input() isStale = false;
+  @Input() canSearch = false;
+
+  @Output() ontologySelected = new EventEmitter<MockOntology>();
+  @Output() resourceClassSelected = new EventEmitter<MockResourceClass | null>();
+  @Output() conditionAdded = new EventEmitter<void>();
+  @Output() conditionRemoved = new EventEmitter<FilterCondition>();
+  @Output() conditionPropertyChanged = new EventEmitter<{ condition: FilterCondition; property: MockProperty }>();
+  @Output() conditionOperatorChanged = new EventEmitter<{ condition: FilterCondition; operator: string }>();
+  @Output() conditionValueChanged = new EventEmitter<{ condition: FilterCondition; value: string }>();
+  @Output() sortByChanged = new EventEmitter<string | null>();
+  @Output() searchTriggered = new EventEmitter<void>();
+
+  private _cdr = inject(ChangeDetectorRef);
+  private _elRef = inject(ElementRef);
+
+  @ViewChild('addMenuTrigger') addMenuTrigger!: MatMenuTrigger;
+
+  // For inline value editing
+  editingValueConditionId: string | null = null;
+  editingValueText: string = '';
+
+  private _previousConditionCount = 0;
+
+  // Pending value from cascade — the cascade creates a condition via add+property+operator,
+  // then if a value is needed, we auto-open the value editor
+  private _pendingValueConditionId: string | null = null;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['conditions']) {
+      const newConditions: FilterCondition[] = changes['conditions'].currentValue;
+      // If a condition was just completed by cascade and needs a value, open value editor
+      if (this._pendingValueConditionId) {
+        const cond = newConditions.find(c => c.id === this._pendingValueConditionId);
+        if (cond && cond.operator && this.needsValueInput(cond.operator)) {
+          this.editingValueConditionId = cond.id;
+          this.editingValueText = cond.value || '';
+        }
+        this._pendingValueConditionId = null;
+      }
+      this._previousConditionCount = newConditions.length;
+    }
+  }
+
+  getOperators(property: MockProperty | null): string[] {
+    if (!property) return [];
+    return getOperatorsForType(property.objectType);
+  }
+
+  getPropertyIcon(prop: MockProperty): string {
+    return getIconForProperty(prop);
+  }
+
+  needsValueInput(operator: string | null): boolean {
+    return !!operator && operator !== 'exists' && operator !== 'does not exist';
+  }
+
+  needsValueInputForProperty(operator: string | null, property: MockProperty | null): boolean {
+    if (!operator) return false;
+    if (operator === 'matches' && property?.isLinkedResourceProperty) return false;
+    return this.needsValueInput(operator);
+  }
+
+  formatChipLabel(condition: FilterCondition): string {
+    const parts: string[] = [];
+    if (condition.property) parts.push(condition.property.label);
+    if (condition.operator) parts.push(condition.operator);
+    if (condition.value) parts.push(condition.value);
+    return parts.join(' ') || 'New condition...';
+  }
+
+  getValueType(property: MockProperty | null): string {
+    if (!property) return 'text';
+    const t = property.objectType;
+    if (t.includes('TextValue')) return 'text';
+    if (t.includes('IntValue')) return 'integer';
+    if (t.includes('DecimalValue')) return 'decimal';
+    if (t.includes('BooleanValue')) return 'boolean';
+    if (t.includes('DateValue')) return 'date';
+    if (t.includes('ListValue')) return 'list';
+    if (t.includes('UriValue')) return 'uri';
+    if (t.includes('ColorValue')) return 'color';
+    if (property.isLinkedResourceProperty) return 'link';
+    return 'text';
+  }
+
+  getListNodes(property: MockProperty | null): MockListNode[] {
+    if (!property) return [];
+    return LIST_NODES_BY_PROPERTY[property.iri] || [];
+  }
+
+  getLinkedResourceClasses(property: MockProperty | null): MockResourceClass[] {
+    if (!property || !property.isLinkedResourceProperty) return [];
+    const targetClass = RESOURCE_CLASSES.find(rc => rc.iri === property.objectType);
+    return targetClass ? [targetClass] : RESOURCE_CLASSES;
+  }
+
+  getLinkedClassProperties(resourceClass: MockResourceClass | null): MockProperty[] {
+    if (!resourceClass) return [];
+    return PROPERTIES_BY_CLASS[resourceClass.iri] || [];
+  }
+
+  isMatchesCondition(condition: FilterCondition): boolean {
+    return condition.operator === 'matches' && condition.property?.isLinkedResourceProperty === true;
+  }
+
+  private _subConditionId = 0;
+
+  addSubCondition(condition: FilterCondition): void {
+    if (!condition.subConditions) condition.subConditions = [];
+    const newSub: FilterCondition = {
+      id: `sub${++this._subConditionId}`,
+      property: null,
+      operator: null,
+      value: null,
+    };
+    condition.subConditions = [...condition.subConditions, newSub];
+    this._cdr.markForCheck();
+    // Auto-open the property menu on the new sub-condition after it renders
+    setTimeout(() => {
+      const placeholder = this._elRef.nativeElement.querySelector(`.matches-body .chip-placeholder`) as HTMLElement;
+      if (placeholder) placeholder.click();
+    }, 150);
+  }
+
+  removeSubCondition(condition: FilterCondition, sub: FilterCondition): void {
+    if (!condition.subConditions) return;
+    condition.subConditions = condition.subConditions.filter(s => s.id !== sub.id);
+  }
+
+  // --- Cascading add via nested menus ---
+
+  onCascadeSelectProperty(prop: MockProperty): void {
+    // Step 1 done — property selected. Operators submenu opens automatically via [matMenuTriggerFor].
+    // We store the property temporarily; actual condition is created after operator selection.
+  }
+
+  onCascadeComplete(prop: MockProperty, operator: string): void {
+    // Create the condition with property + operator in one shot
+    this.conditionAdded.emit();
+    setTimeout(() => {
+      const newCond = this.conditions[this.conditions.length - 1];
+      if (newCond) {
+        this.conditionPropertyChanged.emit({ condition: newCond, property: prop });
+        setTimeout(() => {
+          const updated = this.conditions[this.conditions.length - 1];
+          if (updated) {
+            this.conditionOperatorChanged.emit({ condition: updated, operator });
+            // If value is needed, mark for auto-open
+            if (this.needsValueInput(operator)) {
+              this._pendingValueConditionId = updated.id;
+            }
+            // For matches on link properties, auto-add a sub-condition
+            if (operator === 'matches' && prop.isLinkedResourceProperty) {
+              setTimeout(() => {
+                const matched = this.conditions.find(c => c.id === updated.id);
+                if (matched && matched.subConditions?.length === 0) {
+                  this.addSubCondition(matched);
+                  this._cdr.markForCheck();
+                }
+              }, 100);
+            }
+          }
+        });
+      }
+    });
+  }
+
+  onCascadeCompleteWithValue(prop: MockProperty, operator: string, value: string): void {
+    if (!value) return;
+    this.addMenuTrigger.closeMenu();
+    this.conditionAdded.emit();
+    setTimeout(() => {
+      const newCond = this.conditions[this.conditions.length - 1];
+      if (newCond) {
+        this.conditionPropertyChanged.emit({ condition: newCond, property: prop });
+        setTimeout(() => {
+          const updated = this.conditions[this.conditions.length - 1];
+          if (updated) {
+            this.conditionOperatorChanged.emit({ condition: updated, operator });
+            setTimeout(() => {
+              const final = this.conditions[this.conditions.length - 1];
+              if (final) {
+                this.conditionValueChanged.emit({ condition: final, value });
+              }
+            });
+          }
+        });
+      }
+    });
+  }
+
+  // --- Inline segment editing (click on chip segments) ---
+
+  onPropertySegmentClick(condition: FilterCondition, menu: any): void {
+    // The mat-menu is triggered via [matMenuTriggerFor] on the element
+  }
+
+  onChangeProperty(condition: FilterCondition, prop: MockProperty): void {
+    this.conditionPropertyChanged.emit({ condition, property: prop });
+  }
+
+  onChangeOperator(condition: FilterCondition, operator: string): void {
+    this.conditionOperatorChanged.emit({ condition, operator });
+  }
+
+  onSegmentValueChanged(condition: FilterCondition, value: string): void {
+    this.conditionValueChanged.emit({ condition, value });
+  }
+
+  openValueEdit(condition: FilterCondition): void {
+    this.editingValueConditionId = condition.id;
+    this.editingValueText = condition.value || '';
+  }
+
+  confirmValueEdit(condition: FilterCondition): void {
+    if (this.editingValueText) {
+      this.conditionValueChanged.emit({ condition, value: this.editingValueText });
+    }
+    this.editingValueConditionId = null;
+    this.editingValueText = '';
+  }
+
+  cancelValueEdit(): void {
+    this.editingValueConditionId = null;
+    this.editingValueText = '';
+  }
+}

--- a/apps/prototype/src/components/filter-bar.component.html
+++ b/apps/prototype/src/components/filter-bar.component.html
@@ -1,0 +1,351 @@
+<div class="filter-bar" role="listbox" aria-label="Active search filters">
+  <!-- Ontology chip -->
+  <button mat-stroked-button class="filter-chip foundation-chip" [matMenuTriggerFor]="ontologyMenu"
+          [class.placeholder]="!selectedOntology">
+    <mat-icon class="chip-icon">lan</mat-icon>
+    {{ selectedOntology?.label || 'Select ontology' }}
+    <mat-icon iconPositionEnd>arrow_drop_down</mat-icon>
+  </button>
+  <mat-menu #ontologyMenu="matMenu">
+    @for (onto of ontologies; track onto.iri) {
+      <button mat-menu-item (click)="ontologySelected.emit(onto)">
+        <mat-icon>lan</mat-icon>
+        {{ onto.label }}
+      </button>
+    }
+  </mat-menu>
+
+  <span class="chip-divider"></span>
+
+  <!-- Resource class chip -->
+  <button mat-stroked-button class="filter-chip foundation-chip" [matMenuTriggerFor]="rcMenu"
+          [disabled]="!selectedOntology"
+          [class.placeholder]="!selectedResourceClass">
+    @if (selectedResourceClass?.icon) { <mat-icon class="chip-icon">{{ selectedResourceClass.icon }}</mat-icon> }
+    {{ selectedResourceClass?.label || 'Select class' }}
+    <mat-icon iconPositionEnd>arrow_drop_down</mat-icon>
+  </button>
+  <mat-menu #rcMenu="matMenu">
+    <button mat-menu-item (click)="resourceClassSelected.emit(null)">
+      <em>All resource classes</em>
+    </button>
+    @for (rc of resourceClasses; track rc.iri) {
+      <button mat-menu-item (click)="resourceClassSelected.emit(rc)">
+        @if (rc.icon) { <mat-icon>{{ rc.icon }}</mat-icon> }
+        {{ rc.label }}
+      </button>
+    }
+  </mat-menu>
+
+  <span class="chip-divider"></span>
+
+  <!-- Property condition chips -->
+  @for (condition of conditions; track condition.id; let i = $index) {
+    @if (i > 0) {
+      <span class="logic-operator">AND</span>
+    }
+    <div class="condition-wrapper" role="option">
+      @if (isMatchesCondition(condition)) {
+        <!-- Matches condition: wrapping container with sub-conditions -->
+        <div class="matches-chip">
+          <div class="matches-header">
+            <mat-icon class="chip-icon link-icon">link</mat-icon>
+            <span class="chip-part">{{ condition.property?.label }}</span>
+            <span class="chip-sep"></span>
+            <span class="chip-part chip-operator">matches</span>
+            <span class="chip-sep"></span>
+            <span class="chip-part" [matMenuTriggerFor]="matchClassMenu">
+              {{ condition.linkedResourceClass?.label || 'Select class...' }}
+              <mat-icon class="inline-dropdown-icon">arrow_drop_down</mat-icon>
+            </span>
+            <mat-menu #matchClassMenu="matMenu">
+              @for (rc of getLinkedResourceClasses(condition.property); track rc.iri) {
+                <button mat-menu-item (click)="condition.linkedResourceClass = rc; condition.subConditions = []">
+                  @if (rc.icon) { <mat-icon>{{ rc.icon }}</mat-icon> }
+                  {{ rc.label }}
+                </button>
+              }
+            </mat-menu>
+            <span class="matches-spacer"></span>
+            <span class="chip-remove"
+                  (click)="conditionRemoved.emit(condition); $event.stopPropagation()"
+                  matTooltip="Remove filter">
+              <mat-icon>close</mat-icon>
+            </span>
+          </div>
+          @if (condition.linkedResourceClass) {
+            <div class="matches-body">
+              @for (sub of condition.subConditions; track sub.id; let j = $index) {
+                @if (j > 0) {
+                  <span class="logic-operator">AND</span>
+                }
+                <div class="sub-condition-wrapper">
+                  <div class="filter-chip condition-chip sub-chip"
+                       [class.incomplete]="!sub.property || !sub.operator"
+                       (click)="toggleEdit(sub)" style="cursor: pointer">
+                    <span class="chip-content">
+                      <span class="chip-label">
+                        @if (sub.property) {
+                          <span class="chip-part">{{ sub.property.label }}</span>
+                        }
+                        @if (sub.operator) {
+                          <span class="chip-sep"></span>
+                          <span class="chip-part chip-operator">{{ sub.operator }}</span>
+                        }
+                        @if (sub.value) {
+                          <span class="chip-sep"></span>
+                          <span class="chip-part chip-value">{{ sub.value }}</span>
+                        }
+                        @if (!sub.property) {
+                          <span class="chip-part chip-placeholder">condition...</span>
+                        }
+                      </span>
+                    </span>
+                    <span class="chip-remove"
+                          (click)="removeSubCondition(condition, sub); $event.stopPropagation()"
+                          matTooltip="Remove">
+                      <mat-icon>close</mat-icon>
+                    </span>
+                  </div>
+                  <!-- Sub-condition popover -->
+                  @if (editingConditionId === sub.id) {
+                    <div class="popover-backdrop" (click)="closeEdit()"></div>
+                    <div class="popover-panel sub-popover">
+                      <div class="popover-header">
+                        <span>Edit sub-condition</span>
+                        <button mat-icon-button (click)="closeEdit()"><mat-icon>close</mat-icon></button>
+                      </div>
+                      <mat-form-field appearance="outline">
+                        <mat-label>Property</mat-label>
+                        <mat-select [value]="sub.property?.iri"
+                                    (selectionChange)="sub.property = $any($event.value); sub.operator = null; sub.value = null">
+                          @for (prop of getLinkedClassProperties(condition.linkedResourceClass!); track prop.iri) {
+                            <mat-option [value]="prop">
+                              <mat-icon class="option-icon">{{ getPropertyIcon(prop) }}</mat-icon>
+                              {{ prop.label }}
+                            </mat-option>
+                          }
+                        </mat-select>
+                      </mat-form-field>
+                      @if (sub.property) {
+                        <mat-form-field appearance="outline">
+                          <mat-label>Operator</mat-label>
+                          <mat-select [value]="sub.operator"
+                                      (selectionChange)="sub.operator = $event.value; sub.value = null">
+                            @for (op of getOperators(sub.property); track op) {
+                              <mat-option [value]="op">{{ op }}</mat-option>
+                            }
+                          </mat-select>
+                        </mat-form-field>
+                      }
+                      @if (sub.operator && needsValueInput(sub.operator)) {
+                        <mat-form-field appearance="outline">
+                          <mat-label>Value</mat-label>
+                          <input matInput [value]="sub.value || ''"
+                                 (input)="sub.value = $any($event.target).value" />
+                        </mat-form-field>
+                      }
+                      <div class="popover-footer">
+                        <button mat-flat-button color="primary" (click)="closeEdit()">Done</button>
+                      </div>
+                    </div>
+                  }
+                </div>
+              }
+              <button mat-stroked-button class="add-btn sub-add-btn"
+                      (click)="addSubCondition(condition)" matTooltip="Add sub-condition">
+                <mat-icon>add</mat-icon>
+              </button>
+            </div>
+          }
+        </div>
+      } @else {
+        <!-- Regular condition chip -->
+        <div class="filter-chip condition-chip"
+                [class.incomplete]="!condition.property || !condition.operator"
+                [class.linked]="condition.property?.isLinkedResourceProperty"
+                [class.editing]="editingConditionId === condition.id">
+          <span class="chip-content" (click)="toggleEdit(condition)">
+            @if (condition.property?.isLinkedResourceProperty) {
+              <mat-icon class="chip-icon link-icon">link</mat-icon>
+            }
+            <span class="chip-label">
+              @if (condition.property) {
+                <span class="chip-part">{{ condition.property.label }}</span>
+              }
+              @if (condition.operator) {
+                <span class="chip-sep"></span>
+                <span class="chip-part chip-operator">{{ condition.operator }}</span>
+              }
+              @if (condition.value) {
+                <span class="chip-sep"></span>
+                <span class="chip-part chip-value">{{ condition.value }}</span>
+              }
+              @if (!condition.property) {
+                <span class="chip-part chip-placeholder">New condition...</span>
+              }
+            </span>
+          </span>
+          <span class="chip-remove"
+                (click)="conditionRemoved.emit(condition); $event.stopPropagation()"
+                [attr.aria-label]="'Remove filter: ' + formatChipLabel(condition)"
+                matTooltip="Remove filter">
+            <mat-icon>close</mat-icon>
+          </span>
+        </div>
+      }
+
+      <!-- Inline popover editor -->
+      @if (editingConditionId === condition.id) {
+        <div class="popover-backdrop" (click)="closeEdit()"></div>
+        <div class="popover-panel">
+          <div class="popover-header">
+            <span>Edit condition</span>
+            <button mat-icon-button (click)="closeEdit()"><mat-icon>close</mat-icon></button>
+          </div>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Property</mat-label>
+            <mat-select [value]="condition.property?.iri"
+                        (selectionChange)="conditionPropertyChanged.emit({ condition, property: $any($event.value) })">
+              @for (prop of properties; track prop.iri) {
+                <mat-option [value]="prop">
+                  <mat-icon class="option-icon">{{ getPropertyIcon(prop) }}</mat-icon>
+                  {{ prop.label }}
+                </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          @if (condition.property) {
+            <mat-form-field appearance="outline">
+              <mat-label>Operator</mat-label>
+              <mat-select [value]="condition.operator"
+                          (selectionChange)="onOperatorSelected(condition, $event.value)">
+                @for (op of getOperators(condition.property); track op) {
+                  <mat-option [value]="op">{{ op }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          }
+
+          @if (needsValueInputForCondition(condition)) {
+            @switch (getValueType(condition.property)) {
+              @case ('boolean') {
+                <mat-form-field appearance="outline">
+                  <mat-label>Value</mat-label>
+                  <mat-select [value]="condition.value"
+                              (selectionChange)="conditionValueChanged.emit({ condition, value: $event.value })">
+                    <mat-option value="true">True</mat-option>
+                    <mat-option value="false">False</mat-option>
+                  </mat-select>
+                </mat-form-field>
+              }
+              @case ('list') {
+                <mat-form-field appearance="outline">
+                  <mat-label>Value</mat-label>
+                  <mat-select [value]="condition.value"
+                              (selectionChange)="conditionValueChanged.emit({ condition, value: $event.value })">
+                    @for (node of getListNodes(condition.property); track node.iri) {
+                      <mat-option [value]="node.label">{{ node.label }}</mat-option>
+                    }
+                  </mat-select>
+                </mat-form-field>
+              }
+              @case ('integer') {
+                <mat-form-field appearance="outline">
+                  <mat-label>Integer Value</mat-label>
+                  <input matInput type="number" step="1" [value]="condition.value || ''"
+                         (input)="conditionValueChanged.emit({ condition, value: $any($event.target).value })" />
+                </mat-form-field>
+              }
+              @case ('decimal') {
+                <mat-form-field appearance="outline">
+                  <mat-label>Decimal Value</mat-label>
+                  <input matInput type="number" step="0.01" [value]="condition.value || ''"
+                         (input)="conditionValueChanged.emit({ condition, value: $any($event.target).value })" />
+                </mat-form-field>
+              }
+              @case ('date') {
+                <div class="date-picker-row">
+                  <button mat-stroked-button class="date-picker-btn" (click)="datePicker.open()">
+                    <mat-icon>calendar_today</mat-icon>
+                    {{ condition.value || 'Select date' }}
+                  </button>
+                  <input [matDatepicker]="datePicker" class="hidden-date-input"
+                         (dateChange)="conditionValueChanged.emit({ condition, value: $event.value?.toLocaleDateString() || '' })" />
+                  <mat-datepicker #datePicker></mat-datepicker>
+                </div>
+              }
+              @case ('uri') {
+                <mat-form-field appearance="outline">
+                  <mat-label>URI</mat-label>
+                  <input matInput type="url" [value]="condition.value || ''"
+                         placeholder="https://..."
+                         (input)="conditionValueChanged.emit({ condition, value: $any($event.target).value })" />
+                </mat-form-field>
+              }
+              @case ('color') {
+                <div class="color-picker-row">
+                  <button mat-stroked-button class="color-picker-btn"
+                          [colorPicker]="condition.value || '#ff0000'"
+                          [cpOutputFormat]="'hex'"
+                          (colorPickerChange)="conditionValueChanged.emit({ condition, value: $event })">
+                    <span class="color-swatch" [style.background]="condition.value || '#ff0000'"></span>
+                    {{ condition.value || 'Select color' }}
+                  </button>
+                </div>
+              }
+              @default {
+                <mat-form-field appearance="outline">
+                  <mat-label>Value</mat-label>
+                  <input matInput [value]="condition.value || ''"
+                         (input)="conditionValueChanged.emit({ condition, value: $any($event.target).value })" />
+                </mat-form-field>
+              }
+            }
+          }
+
+          <div class="popover-footer">
+            <button mat-flat-button color="primary" (click)="closeEdit()">Done</button>
+          </div>
+        </div>
+      }
+    </div>
+  }
+
+  <!-- Add condition button -->
+  <button mat-stroked-button class="add-btn" [disabled]="!selectedOntology"
+          (click)="conditionAdded.emit()" matTooltip="Add condition">
+    <mat-icon>add</mat-icon>
+  </button>
+
+  <!-- Spacer pushes sort + search to right -->
+  <span class="spacer"></span>
+
+  <!-- Sort by -->
+  <button mat-stroked-button class="filter-chip sort-chip" [disabled]="!selectedOntology"
+          [matMenuTriggerFor]="sortMenu">
+    <mat-icon class="chip-icon">sort</mat-icon>
+    {{ sortBy || 'Sort by' }}
+    <mat-icon iconPositionEnd>arrow_drop_down</mat-icon>
+  </button>
+  <mat-menu #sortMenu="matMenu">
+    <button mat-menu-item (click)="sortByChanged.emit(null)"><em>No sorting</em></button>
+    @for (prop of properties; track prop.iri) {
+      <button mat-menu-item (click)="sortByChanged.emit(prop.label)">
+        <mat-icon>{{ getPropertyIcon(prop) }}</mat-icon>
+        {{ prop.label }}
+      </button>
+    }
+  </mat-menu>
+
+  <!-- Search button -->
+  <button mat-flat-button color="primary" class="search-btn"
+          [disabled]="!canSearch"
+          [class.stale]="isStale"
+          (click)="searchTriggered.emit()">
+    <mat-icon>search</mat-icon>
+    Search
+  </button>
+</div>

--- a/apps/prototype/src/components/filter-bar.component.scss
+++ b/apps/prototype/src/components/filter-bar.component.scss
@@ -1,0 +1,545 @@
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  background: #fafafa;
+  border-bottom: 1px solid #e0e0e0;
+  min-height: 48px;
+}
+
+.filter-chip {
+  height: 30px;
+  border-radius: 6px;
+  font-size: 13px;
+  line-height: 30px;
+  padding: 0 10px;
+  min-width: auto;
+  color: rgba(0, 0, 0, 0.72);
+
+  .chip-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+    vertical-align: middle;
+    color: rgba(0, 0, 0, 0.54);
+  }
+
+  mat-icon:not(.chip-icon) {
+    color: rgba(0, 0, 0, 0.54);
+  }
+
+  &.placeholder {
+    color: #9e9e9e;
+    border-style: dashed;
+  }
+}
+
+.foundation-chip {
+  font-weight: 500;
+  background: white;
+}
+
+.chip-divider {
+  width: 1px;
+  height: 24px;
+  background: #e0e0e0;
+  margin: 0 4px;
+}
+
+.logic-operator {
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.36);
+  letter-spacing: 0.05em;
+  padding: 0 2px;
+  user-select: none;
+}
+
+.condition-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+.condition-chip {
+  background: white;
+  border: 1px solid #bdbdbd;
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+  padding-right: 4px;
+
+  .chip-content {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .chip-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+    max-width: 300px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .chip-part {
+    flex-shrink: 0;
+  }
+
+  .chip-operator {
+    color: #757575;
+  }
+
+  .chip-value {
+    color: #336790;
+    font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 2px;
+  }
+
+  .chip-placeholder {
+    color: #9e9e9e;
+  }
+
+  .chip-sep {
+    width: 1px;
+    height: 14px;
+    background: #ccc;
+    margin: 0 6px;
+    flex-shrink: 0;
+  }
+
+  &.incomplete {
+    border-style: dashed;
+    color: #9e9e9e;
+  }
+
+  &.linked {
+    border-color: #7986cb;
+    background: #e8eaf6;
+
+    .link-icon {
+      color: #5c6bc0;
+    }
+  }
+
+  &.editing {
+    border-color: #336790;
+    box-shadow: 0 0 0 1px #336790;
+  }
+}
+
+// Matches condition (link property with nested sub-conditions)
+.matches-chip {
+  border: 1px solid #C1D1DD;
+  border-radius: 6px;
+  background: #EAEFF3;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  overflow: visible;
+}
+
+.matches-header {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.72);
+  background: #D6E0E8;
+  border-radius: 5px 5px 0 0;
+  gap: 0;
+
+  .chip-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    color: #336790;
+  }
+
+  .chip-part {
+    padding: 0 3px;
+  }
+
+  .chip-sep {
+    width: 1px;
+    height: 14px;
+    background: #A3B8CA;
+    margin: 0 4px;
+    flex-shrink: 0;
+  }
+
+  .inline-dropdown-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: rgba(0, 0, 0, 0.54);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+}
+
+.matches-spacer {
+  flex: 1;
+}
+
+.matches-body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+}
+
+.sub-chip {
+  font-size: 12px;
+  height: 26px;
+  line-height: 26px;
+}
+
+.sub-add-btn {
+  min-width: 24px !important;
+  width: 24px !important;
+  height: 24px !important;
+  border-radius: 4px;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.sub-condition-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.sub-popover {
+  min-width: 240px;
+}
+
+.chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 100%;
+  margin-left: 6px;
+  border-left: 1px solid #e0e0e0;
+  padding-left: 3px;
+  padding-right: 0;
+  cursor: pointer;
+  color: rgba(0, 0, 0, 0.38);
+  border-radius: 0 5px 5px 0;
+  transition: color 0.15s, background-color 0.15s;
+
+  &:hover {
+    color: rgba(0, 0, 0, 0.72);
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+}
+
+// Popover
+.popover-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 999;
+}
+
+.popover-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 1000;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  padding: 10px 12px 12px;
+  min-width: 260px;
+
+  .popover-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #616161;
+
+    button {
+      width: 24px;
+      height: 24px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      ::ng-deep {
+        .mat-mdc-button-touch-target {
+          width: 24px;
+          height: 24px;
+        }
+      }
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+
+  mat-form-field {
+    width: 100%;
+
+    ::ng-deep {
+      .mat-mdc-form-field-infix {
+        min-height: 34px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+      }
+
+      .mat-mdc-floating-label:not(.mdc-floating-label--float-above) {
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      .mat-mdc-text-field-wrapper {
+        font-size: 13px;
+      }
+
+      .mat-mdc-floating-label {
+        font-size: 13px;
+      }
+
+      .mdc-text-field--outlined {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+
+      input.mat-mdc-input-element {
+        font-size: 13px;
+      }
+
+      .mat-mdc-select-value,
+      .mat-mdc-select-trigger {
+        font-size: 13px;
+      }
+    }
+  }
+
+  .option-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    vertical-align: middle;
+    color: rgba(0, 0, 0, 0.54);
+  }
+
+  .date-picker-row {
+    display: flex;
+    align-items: center;
+    position: relative;
+  }
+
+  .color-picker-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .color-picker-btn {
+    font-size: 13px;
+    height: 34px;
+    border-radius: 6px;
+    color: rgba(0, 0, 0, 0.72);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .color-swatch {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .date-picker-btn {
+    font-size: 13px;
+    height: 34px;
+    border-radius: 6px;
+    color: rgba(0, 0, 0, 0.72);
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      margin-right: 6px;
+      color: rgba(0, 0, 0, 0.54);
+    }
+  }
+
+  .hidden-date-input {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  app-date-input {
+    ::ng-deep {
+      .date-input-field {
+        font-size: 13px;
+
+        .mat-mdc-form-field-infix {
+          min-height: 34px;
+          padding-top: 6px;
+          padding-bottom: 6px;
+        }
+
+        .mat-mdc-text-field-wrapper {
+          font-size: 13px;
+        }
+
+        .mat-mdc-floating-label {
+          font-size: 13px;
+        }
+
+        .mat-mdc-floating-label:not(.mdc-floating-label--float-above) {
+          top: 50%;
+          transform: translateY(-50%);
+        }
+
+        input.mat-mdc-input-element {
+          font-size: 13px;
+        }
+
+        button[matsuffix] {
+          width: 28px;
+          height: 28px;
+          padding: 0;
+
+          .mat-icon {
+            font-size: 16px;
+            width: 16px;
+            height: 16px;
+          }
+        }
+      }
+    }
+  }
+
+  app-color-picker {
+    ::ng-deep {
+      .color-picker-fieldset {
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-size: 12px;
+      }
+    }
+  }
+
+  .popover-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 2px;
+
+    button {
+      font-size: 13px;
+      height: 30px;
+      line-height: 30px;
+    }
+  }
+}
+
+.add-btn {
+  min-width: 30px;
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  padding: 0;
+  border-style: dashed;
+  color: rgba(0, 0, 0, 0.54);
+
+  mat-icon {
+    margin: 0;
+    font-size: 18px;
+    color: rgba(0, 0, 0, 0.54);
+  }
+}
+
+// Compact menu and select items to match chip sizing
+::ng-deep .mat-mdc-select-panel .mat-mdc-option {
+  min-height: 34px;
+  font-size: 13px;
+  padding: 0 12px;
+
+  .mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    color: rgba(0, 0, 0, 0.54);
+  }
+}
+
+::ng-deep .mat-mdc-menu-panel {
+  .mat-mdc-menu-item {
+    min-height: 34px;
+    font-size: 13px;
+    padding: 0 12px;
+    color: rgba(0, 0, 0, 0.72);
+
+    .mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      margin-right: 8px;
+      color: rgba(0, 0, 0, 0.54);
+    }
+  }
+}
+
+.spacer {
+  flex: 1;
+}
+
+.search-btn {
+  height: 30px;
+  border-radius: 6px;
+  font-size: 13px;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    margin-right: 4px;
+  }
+
+  &.stale {
+    outline: 2px solid rgba(51, 103, 144, 0.5);
+    outline-offset: 1px;
+  }
+}

--- a/apps/prototype/src/components/filter-bar.component.ts
+++ b/apps/prototype/src/components/filter-bar.component.ts
@@ -1,0 +1,199 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { ColorPickerDirective } from 'ngx-color-picker';
+import { MockProperty, MockResourceClass, MockOntology, MockListNode, getOperatorsForType, getIconForProperty, LIST_NODES_BY_PROPERTY, PROPERTIES_BY_CLASS, RESOURCE_CLASSES } from '../mock-data';
+
+export interface FilterCondition {
+  id: string;
+  property: MockProperty | null;
+  operator: string | null;
+  value: string | null;
+  /** For "matches" on link properties: the linked resource class */
+  linkedResourceClass?: MockResourceClass | null;
+  /** For "matches" on link properties: nested sub-conditions */
+  subConditions?: FilterCondition[];
+}
+
+@Component({
+  selector: 'proto-filter-bar',
+  standalone: true,
+  imports: [
+    CommonModule, FormsModule,
+    MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule,
+    MatMenuModule, MatSelectModule, MatTooltipModule,
+    MatDatepickerModule, MatNativeDateModule, ColorPickerDirective,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './filter-bar.component.html',
+  styleUrls: ['./filter-bar.component.scss'],
+})
+export class FilterBarComponent implements OnChanges {
+  @Input() ontologies: MockOntology[] = [];
+  @Input() resourceClasses: MockResourceClass[] = [];
+  @Input() properties: MockProperty[] = [];
+  @Input() selectedOntology: MockOntology | null = null;
+  @Input() selectedResourceClass: MockResourceClass | null = null;
+  @Input() conditions: FilterCondition[] = [];
+  @Input() sortBy: string | null = null;
+  @Input() isStale = false;
+  @Input() canSearch = false;
+
+  @Output() ontologySelected = new EventEmitter<MockOntology>();
+  @Output() resourceClassSelected = new EventEmitter<MockResourceClass | null>();
+  @Output() conditionAdded = new EventEmitter<void>();
+  @Output() conditionRemoved = new EventEmitter<FilterCondition>();
+  @Output() conditionPropertyChanged = new EventEmitter<{ condition: FilterCondition; property: MockProperty }>();
+  @Output() conditionOperatorChanged = new EventEmitter<{ condition: FilterCondition; operator: string }>();
+  @Output() conditionValueChanged = new EventEmitter<{ condition: FilterCondition; value: string }>();
+  @Output() sortByChanged = new EventEmitter<string | null>();
+  @Output() searchTriggered = new EventEmitter<void>();
+
+  private _cdr = inject(ChangeDetectorRef);
+
+  editingConditionId: string | null = null;
+  private _previousConditionCount = 0;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['conditions']) {
+      const newConditions: FilterCondition[] = changes['conditions'].currentValue;
+      // Auto-open popover when a new condition is added
+      if (newConditions.length > this._previousConditionCount && newConditions.length > 0) {
+        this.editingConditionId = newConditions[newConditions.length - 1].id;
+      }
+      this._previousConditionCount = newConditions.length;
+    }
+  }
+
+  getOperators(property: MockProperty | null): string[] {
+    if (!property) return [];
+    return getOperatorsForType(property.objectType);
+  }
+
+  toggleEdit(condition: FilterCondition): void {
+    this.editingConditionId = this.editingConditionId === condition.id ? null : condition.id;
+  }
+
+  closeEdit(): void {
+    this.editingConditionId = null;
+  }
+
+  formatChipLabel(condition: FilterCondition): string {
+    const parts: string[] = [];
+    if (condition.property) parts.push(condition.property.label);
+    if (condition.operator) parts.push(condition.operator);
+    if (condition.value) parts.push(`"${condition.value}"`);
+    return parts.join(' ') || 'New condition...';
+  }
+
+  getPropertyIcon(prop: MockProperty): string {
+    return getIconForProperty(prop);
+  }
+
+  needsValueInput(operator: string | null): boolean {
+    return !!operator && operator !== 'exists' && operator !== 'does not exist';
+  }
+
+  /** Whether this operator+property combo needs a value (matches on link properties doesn't) */
+  needsValueInputForCondition(condition: FilterCondition): boolean {
+    if (!condition.operator) return false;
+    if (condition.operator === 'matches' && condition.property?.isLinkedResourceProperty) return false;
+    return this.needsValueInput(condition.operator);
+  }
+
+  onOperatorSelected(condition: FilterCondition, operator: string): void {
+    this.conditionOperatorChanged.emit({ condition, operator });
+    const isMatchesOnLink = operator === 'matches' && condition.property?.isLinkedResourceProperty;
+    if (isMatchesOnLink || operator === 'exists' || operator === 'does not exist') {
+      this.closeEdit();
+      if (isMatchesOnLink) {
+        setTimeout(() => {
+          const updated = this.conditions.find(c => c.id === condition.id);
+          if (updated && updated.subConditions?.length === 0) {
+            this.addSubCondition(updated);
+            this._cdr.markForCheck();
+          }
+        }, 100);
+      }
+    }
+  }
+
+  getValueType(property: MockProperty | null): string {
+    if (!property) return 'text';
+    const t = property.objectType;
+    if (t.includes('TextValue')) return 'text';
+    if (t.includes('IntValue')) return 'integer';
+    if (t.includes('DecimalValue')) return 'decimal';
+    if (t.includes('BooleanValue')) return 'boolean';
+    if (t.includes('DateValue')) return 'date';
+    if (t.includes('ListValue')) return 'list';
+    if (t.includes('UriValue')) return 'uri';
+    if (t.includes('ColorValue')) return 'color';
+    if (property.isLinkedResourceProperty) return 'link';
+    return 'text';
+  }
+
+  getListNodes(property: MockProperty | null): MockListNode[] {
+    if (!property) return [];
+    return LIST_NODES_BY_PROPERTY[property.iri] || [];
+  }
+
+  /** For link properties: get the target resource classes */
+  getLinkedResourceClasses(property: MockProperty | null): MockResourceClass[] {
+    if (!property || !property.isLinkedResourceProperty) return [];
+    // The objectType of a link property is the target class IRI
+    const targetClass = RESOURCE_CLASSES.find(rc => rc.iri === property.objectType);
+    return targetClass ? [targetClass] : RESOURCE_CLASSES;
+  }
+
+  /** Get properties available for a linked resource class */
+  getLinkedClassProperties(resourceClass: MockResourceClass | null): MockProperty[] {
+    if (!resourceClass) return [];
+    return PROPERTIES_BY_CLASS[resourceClass.iri] || [];
+  }
+
+  /** Get properties for a condition — either parent properties or linked class properties */
+  getPropertiesForCondition(condition: FilterCondition): MockProperty[] {
+    // Check if this condition is a sub-condition of a matches parent
+    for (const c of this.conditions) {
+      if (c.subConditions?.some(s => s.id === condition.id)) {
+        return this.getLinkedClassProperties(c.linkedResourceClass || null);
+      }
+    }
+    return this.properties;
+  }
+
+  isMatchesCondition(condition: FilterCondition): boolean {
+    return condition.operator === 'matches' && condition.property?.isLinkedResourceProperty === true;
+  }
+
+  private _subConditionId = 0;
+
+  addSubCondition(condition: FilterCondition): void {
+    if (!condition.subConditions) condition.subConditions = [];
+    const newSub: FilterCondition = {
+      id: `sub${++this._subConditionId}`,
+      property: null,
+      operator: null,
+      value: null,
+    };
+    condition.subConditions = [...condition.subConditions, newSub];
+    // Auto-open the popover for the new sub-condition
+    this.editingConditionId = newSub.id;
+    this._cdr.markForCheck();
+  }
+
+  removeSubCondition(condition: FilterCondition, sub: FilterCondition): void {
+    if (!condition.subConditions) return;
+    condition.subConditions = condition.subConditions.filter(s => s.id !== sub.id);
+  }
+}

--- a/apps/prototype/src/index.html
+++ b/apps/prototype/src/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Advanced Search Filter Bar — Prototype</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/apps/prototype/src/main.ts
+++ b/apps/prototype/src/main.ts
@@ -1,0 +1,229 @@
+import 'zone.js';
+
+import { APP_INITIALIZER, ErrorHandler, inject, LOCALE_ID } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, withComponentInputBinding, withRouterConfig } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { KnoraApiConfig, KnoraApiConnection, ReadProject, ReadResource } from '@dasch-swiss/dsp-js';
+import {
+  AppConfigService,
+  AppConfigToken,
+  BuildTagToken,
+  DspApiConfigToken,
+  DspApiConnectionToken,
+  DspAppConfigToken,
+  DspInstrumentationToken,
+  RouteConstants,
+} from '@dasch-swiss/vre/core/config';
+import { AuthService, AutoLoginService, LocalStorageWatcherService, UserService } from '@dasch-swiss/vre/core/session';
+import { AdminAPIApiService, BASE_PATH } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { GrafanaFaroService } from '@dasch-swiss/vre/3rd-party-services/analytics';
+import { ProjectApiService, UserApiService } from '@dasch-swiss/vre/3rd-party-services/api';
+import { NotificationService } from '@dasch-swiss/vre/ui/notification';
+import { LocalizationService, ProjectService } from '@dasch-swiss/vre/shared/app-helper-services';
+import { ProjectPageService, ProjectPageComponent, ProjectPageGuard } from '@dasch-swiss/vre/pages/project/project';
+import { provideTranslateService, TranslateService } from '@ngx-translate/core';
+import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
+import { BehaviorSubject, firstValueFrom, Observable, of } from 'rxjs';
+import { Routes } from '@angular/router';
+
+import { AppComponent } from '@dsp-app/src/app/app.component';
+import { FilterBarSearchPageComponent } from './pages/filter-bar-search-page.component';
+import { FilterBarSearchPageBComponent } from './pages/filter-bar-search-page-b.component';
+
+// --- Mock config ---
+const mockApiConfig = new KnoraApiConfig('http', '0.0.0.0', 3333, '', '', false);
+const mockApiConnection = new KnoraApiConnection(mockApiConfig);
+
+// --- Monkey-patch getResource to return mock data for the detail panel ---
+const mockResourcesByIri: Record<string, any> = {};
+// Label lookup from our mock data
+import { MOCK_SEARCH_RESULTS } from './mock-data';
+const mockLabelsByIri = Object.fromEntries(MOCK_SEARCH_RESULTS.map(r => [r.iri, r.label]));
+
+function getMockReadResource(iri: string): ReadResource {
+  if (!mockResourcesByIri[iri]) {
+    const res = new ReadResource();
+    res.id = iri;
+    res.label = mockLabelsByIri[iri] || 'Unknown Resource';
+    res.type = 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#book';
+    res.attachedToProject = 'http://rdfh.ch/projects/0803';
+    res.attachedToUser = 'http://rdfh.ch/users/root';
+    res.creationDate = '2020-01-01T00:00:00Z';
+    res.properties = {};
+    const resType = res.type;
+    res.entityInfo = {
+      classes: {
+        [resType]: {
+          getResourcePropertiesList: () => [],
+        },
+      },
+      properties: {},
+      getPropertyDefinitionsByType: () => [],
+    } as any;
+    res.userHasPermission = 'M';
+    mockResourcesByIri[iri] = res;
+  }
+  return mockResourcesByIri[iri];
+}
+
+// Override v2.res.getResource to return mock data
+(mockApiConnection.v2.res as any).getResource = (iri: string, _version?: string) => {
+  return of(getMockReadResource(iri));
+};
+// Override v2.search.doExtendedSearch (used by results page)
+(mockApiConnection.v2.search as any).doExtendedSearch = () => {
+  return of({ resources: [] });
+};
+
+// --- Fake ReadProject for Incunabula ---
+const mockProject = new ReadProject();
+mockProject.id = 'http://rdfh.ch/projects/0803';
+mockProject.shortname = 'incunabula';
+mockProject.shortcode = '0803';
+mockProject.longname = 'Incunabula';
+mockProject.description = [{ language: 'en', value: 'A collection of early printed books (incunabula)' }] as any;
+mockProject.status = true;
+
+// --- Mock ProjectPageService ---
+class MockProjectPageService {
+  private _currentProjectSubject = new BehaviorSubject<ReadProject>(mockProject);
+  currentProject$ = this._currentProjectSubject.asObservable();
+  hasProjectAdminRights$ = of(false);
+  hasProjectMemberRights$ = of(true);
+  ontologiesMetadata$ = of([]);
+  ontologies$ = of([]);
+
+  get currentProject(): ReadProject {
+    return mockProject;
+  }
+
+  get currentProjectUuid(): string {
+    return '0803';
+  }
+
+  setup(_projectUuid: string): void {
+    // no-op, project is hardcoded
+  }
+
+  reloadProject(): void {}
+}
+
+// --- Mock ProjectPageGuard that always allows ---
+class MockProjectPageGuard {
+  canActivate(): Observable<boolean> {
+    return of(true);
+  }
+}
+
+// --- Routes: real ProjectPageComponent with swapped search page ---
+const protoRoutes: Routes = [
+  {
+    path: RouteConstants.projectUuidRelative,
+    component: ProjectPageComponent,
+    canActivate: [ProjectPageGuard],
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: RouteConstants.advancedSearch,
+      },
+      {
+        path: RouteConstants.advancedSearch,
+        component: FilterBarSearchPageComponent,
+      },
+      {
+        path: 'advanced-search-b',
+        component: FilterBarSearchPageBComponent,
+      },
+      // Stub routes so navigation tabs don't break
+      { path: RouteConstants.data, component: FilterBarSearchPageComponent },
+      { path: RouteConstants.dataModels, component: FilterBarSearchPageComponent },
+      { path: RouteConstants.search, component: FilterBarSearchPageComponent },
+      { path: RouteConstants.settings, component: FilterBarSearchPageComponent },
+    ],
+  },
+  // Redirect root to a project page
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: '/project/0803',
+  },
+  { path: '**', redirectTo: '/project/0803' },
+];
+
+// --- Bootstrap ---
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideRouter(protoRoutes, withComponentInputBinding(), withRouterConfig({ onSameUrlNavigation: 'reload' })),
+    provideAnimations(),
+    provideHttpClient(),
+    { provide: LOCALE_ID, useValue: 'en-GB' },
+
+    // Translation — use the real i18n files from dsp-app assets
+    provideTranslateService({
+      defaultLanguage: 'en',
+      loader: provideTranslateHttpLoader({ prefix: 'assets/i18n/', suffix: '.json' }),
+    }),
+    // Trigger translation loading before app renders
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => {
+        const translate = inject(TranslateService);
+        return () => firstValueFrom(translate.use('en'));
+      },
+      multi: true,
+    },
+
+    // Config tokens
+    {
+      provide: AppConfigToken,
+      useValue: {
+        dspRelease: 'prototype-0.1.0',
+        apiProtocol: 'http', apiHost: '0.0.0.0', apiPort: 3333, apiPath: '',
+        iiifProtocol: 'http', iiifHost: '0.0.0.0', iiifPort: 1024, iiifPath: '',
+        ingestUrl: 'http://0.0.0.0:3340',
+        geonameToken: 'mock', jsonWebToken: '', logErrors: false, iriBase: 'http://rdfh.ch',
+        instrumentation: {
+          environment: 'prototype',
+          rollbar: { enabled: false, accessToken: '' },
+          faro: { enabled: false, collectorUrl: '', appName: 'prototype', sessionTracking: { enabled: false, persistent: false, samplingRate: 1 }, console: { enabled: false, disabledLevels: [] }, tracingCorsUrls: [] },
+        },
+        featureFlags: { allowEraseProjects: false },
+      },
+    },
+    AppConfigService,
+    { provide: DspApiConfigToken, useValue: mockApiConfig },
+    { provide: DspApiConnectionToken, useValue: mockApiConnection },
+    { provide: DspAppConfigToken, useValue: { geonameToken: 'mock', iriBase: 'http://rdfh.ch' } },
+    { provide: DspInstrumentationToken, useValue: { environment: 'prototype', rollbar: { enabled: false, accessToken: '' }, faro: { enabled: false } } },
+    { provide: BuildTagToken, useValue: 'prototype-0.1.0' },
+    { provide: BASE_PATH, useValue: 'http://0.0.0.0:3333' },
+
+    // Override root-provided services with mocks
+    { provide: ProjectPageService, useClass: MockProjectPageService },
+    { provide: ProjectPageGuard, useClass: MockProjectPageGuard },
+    { provide: AutoLoginService, useValue: { setup: () => {}, hasCheckedCredentials$: new BehaviorSubject(true) } },
+    { provide: LocalStorageWatcherService, useValue: { watchAccessToken: () => {} } },
+    {
+      provide: UserService,
+      useValue: {
+        user$: of(null),
+        isLoggedIn$: of(false),
+        isSysAdmin$: of(false),
+        loadUser: () => of(null),
+      },
+    },
+    { provide: AuthService, useValue: { logout: () => {}, afterSuccessfulLogin$: () => of(null) } },
+    { provide: LocalizationService, useValue: { init: () => {}, getCurrentLanguage: () => 'en', currentLanguage$: of('en'), setLanguage: () => {} } },
+    { provide: GrafanaFaroService, useValue: { setup: () => Promise.resolve() } },
+    { provide: ProjectApiService, useValue: { get: () => of({ project: mockProject }) } },
+    { provide: ProjectService, useValue: { uuidToIri: (uuid: string) => `http://rdfh.ch/projects/${uuid}` } },
+    { provide: NotificationService, useValue: { open: () => {}, openSnackBar: () => {} } },
+    { provide: ErrorHandler, useValue: { handleError: (err: any) => console.error('[Proto]', err) } },
+    // Mock OpenAPI services used by ResourceFetcherService and ProjectShortnameService
+    { provide: AdminAPIApiService, useValue: { getAdminProjectsIriProjectiri: () => of({ project: mockProject }) } },
+    { provide: UserApiService, useValue: { get: () => of({ user: { id: 'http://rdfh.ch/users/root', email: 'root@example.com', givenName: 'Root', familyName: 'User', username: 'root', status: true, lang: 'en' } }) } },
+  ],
+}).catch(err => console.error(err));

--- a/apps/prototype/src/mock-data.ts
+++ b/apps/prototype/src/mock-data.ts
@@ -1,0 +1,269 @@
+/**
+ * Realistic fixture data based on the Incunabula test project.
+ * Uses real ontology IRIs and property structures from the DSP test data.
+ */
+
+export interface MockOntology {
+  iri: string;
+  label: string;
+}
+
+export interface MockResourceClass {
+  iri: string;
+  label: string;
+  icon?: string;
+}
+
+export interface MockProperty {
+  iri: string;
+  label: string;
+  objectType: string;
+  isLinkedResourceProperty: boolean;
+  icon?: string;
+  listIri?: string;
+}
+
+/** Map objectType to icon, based on DefaultProperties in default-properties.ts */
+const PROPERTY_TYPE_ICONS: Record<string, string> = {
+  'http://api.knora.org/ontology/knora-api/v2#TextValue': 'short_text',
+  'http://api.knora.org/ontology/knora-api/v2#DateValue': 'calendar_today',
+  'http://api.knora.org/ontology/knora-api/v2#IntValue': '60fps',
+  'http://api.knora.org/ontology/knora-api/v2#DecimalValue': 'functions',
+  'http://api.knora.org/ontology/knora-api/v2#BooleanValue': 'toggle_off',
+  'http://api.knora.org/ontology/knora-api/v2#ListValue': 'arrow_drop_down_circle',
+  'http://api.knora.org/ontology/knora-api/v2#UriValue': 'language',
+  'http://api.knora.org/ontology/knora-api/v2#ColorValue': 'palette',
+  'http://api.knora.org/ontology/knora-api/v2#GeonameValue': 'place',
+  'http://api.knora.org/ontology/knora-api/v2#TimeValue': 'access_time',
+  'http://api.knora.org/ontology/knora-api/v2#IntervalValue': 'timelapse',
+};
+
+export function getIconForProperty(prop: MockProperty): string {
+  if (prop.isLinkedResourceProperty) return 'link';
+  return PROPERTY_TYPE_ICONS[prop.objectType] || 'data_object';
+}
+
+/** Mock list nodes for the Language list property */
+export interface MockListNode {
+  iri: string;
+  label: string;
+  children?: MockListNode[];
+}
+
+export const LANGUAGE_LIST_NODES: MockListNode[] = [
+  { iri: 'http://rdfh.ch/lists/0803/lang-latin', label: 'Latin' },
+  { iri: 'http://rdfh.ch/lists/0803/lang-german', label: 'German' },
+  { iri: 'http://rdfh.ch/lists/0803/lang-french', label: 'French' },
+  { iri: 'http://rdfh.ch/lists/0803/lang-italian', label: 'Italian' },
+  { iri: 'http://rdfh.ch/lists/0803/lang-dutch', label: 'Dutch' },
+  { iri: 'http://rdfh.ch/lists/0803/lang-hebrew', label: 'Hebrew' },
+];
+
+/** Map list property IRIs to their list nodes */
+export const LIST_NODES_BY_PROPERTY: Record<string, MockListNode[]> = {
+  'http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLanguage': LANGUAGE_LIST_NODES,
+};
+
+export interface MockSearchResult {
+  iri: string;
+  label: string;
+  resourceClassLabel: string;
+  properties: Record<string, string>;
+}
+
+export const INCUNABULA_ONTOLOGY: MockOntology = {
+  iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2',
+  label: 'Incunabula',
+};
+
+export const RESOURCE_CLASSES: MockResourceClass[] = [
+  { iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#book', label: 'Book', icon: 'insert_drive_file' },
+  { iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#page', label: 'Page', icon: 'photo' },
+];
+
+export const BOOK_PROPERTIES: MockProperty[] = [
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#title',
+    label: 'Title',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasAuthor',
+    label: 'Creator',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#publisher',
+    label: 'Publisher',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#publoc',
+    label: 'Publication Location',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#pubdate',
+    label: 'Publication Date',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#DateValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#description',
+    label: 'Description',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#book_comment',
+    label: 'Comment',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#physical_desc',
+    label: 'Physical Description',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLanguage',
+    label: 'Language',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#ListValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasColor',
+    label: 'Binding Color',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#ColorValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasUrl',
+    label: 'URL',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#UriValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#isPublished',
+    label: 'Is Published',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#BooleanValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasPageCount',
+    label: 'Page Count',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#IntValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#references',
+    label: 'References',
+    objectType: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#book',
+    isLinkedResourceProperty: true,
+  },
+];
+
+export const PAGE_PROPERTIES: MockProperty[] = [
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#pagenum',
+    label: 'Page Number',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#TextValue',
+    isLinkedResourceProperty: false,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#partOf',
+    label: 'Part of',
+    objectType: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#book',
+    isLinkedResourceProperty: true,
+  },
+  {
+    iri: 'http://0.0.0.0:3333/ontology/0803/incunabula/v2#seqnum',
+    label: 'Sequence Number',
+    objectType: 'http://api.knora.org/ontology/knora-api/v2#IntValue',
+    isLinkedResourceProperty: false,
+  },
+];
+
+export const PROPERTIES_BY_CLASS: Record<string, MockProperty[]> = {
+  'http://0.0.0.0:3333/ontology/0803/incunabula/v2#book': BOOK_PROPERTIES,
+  'http://0.0.0.0:3333/ontology/0803/incunabula/v2#page': PAGE_PROPERTIES,
+};
+
+/** All properties across all classes, deduped by IRI */
+export const ALL_PROPERTIES: MockProperty[] = Object.values(PROPERTIES_BY_CLASS)
+  .flat()
+  .filter((prop, index, self) => self.findIndex(p => p.iri === prop.iri) === index);
+
+export const TEXT_OPERATORS = ['equals', 'does not equal', 'is like', 'matches', 'exists', 'does not exist'];
+export const DATE_OPERATORS = ['equals', 'does not equal', 'greater than', 'greater than or equal to', 'less than', 'less than or equal to', 'exists', 'does not exist'];
+export const INT_OPERATORS = ['equals', 'does not equal', 'greater than', 'greater than or equal to', 'less than', 'less than or equal to', 'exists', 'does not exist'];
+export const BOOLEAN_OPERATORS = ['equals', 'exists', 'does not exist'];
+export const LIST_OPERATORS = ['equals', 'does not equal', 'exists', 'does not exist'];
+export const URI_OPERATORS = ['equals', 'does not equal', 'exists', 'does not exist'];
+export const COLOR_OPERATORS = ['equals', 'does not equal', 'exists', 'does not exist'];
+export const EXISTENCE_ONLY_OPERATORS = ['exists', 'does not exist'];
+export const LINK_OPERATORS = ['equals', 'does not equal', 'exists', 'does not exist', 'matches'];
+
+export function getOperatorsForType(objectType: string): string[] {
+  if (objectType.includes('TextValue')) return TEXT_OPERATORS;
+  if (objectType.includes('DateValue')) return DATE_OPERATORS;
+  if (objectType.includes('IntValue') || objectType.includes('DecimalValue')) return INT_OPERATORS;
+  if (objectType.includes('BooleanValue')) return BOOLEAN_OPERATORS;
+  if (objectType.includes('ListValue')) return LIST_OPERATORS;
+  if (objectType.includes('UriValue')) return URI_OPERATORS;
+  if (objectType.includes('ColorValue')) return COLOR_OPERATORS;
+  if (objectType.includes('GeonameValue') || objectType.includes('GeomValue')) return EXISTENCE_ONLY_OPERATORS;
+  if (objectType.includes('LinkValue')) return LINK_OPERATORS;
+  // Linked resource property (objectType is a class IRI, not a value type)
+  return LINK_OPERATORS;
+}
+
+export const MOCK_SEARCH_RESULTS: MockSearchResult[] = [
+  {
+    iri: 'http://rdfh.ch/0803/c5058f3a',
+    label: 'Zeitglöcklein des Lebens und Leidens Christi',
+    resourceClassLabel: 'Book',
+    properties: { 'Creator': 'Berthold, der Bruder', 'Publication Location': 'Basel', 'Publication Date': 'JULIAN:1492' },
+  },
+  {
+    iri: 'http://rdfh.ch/0803/ff17e5ef9601',
+    label: 'Narrenschiff',
+    resourceClassLabel: 'Book',
+    properties: { 'Creator': 'Sebastian Brant', 'Publication Location': 'Basel', 'Publication Date': 'JULIAN:1494' },
+  },
+  {
+    iri: 'http://rdfh.ch/0803/7e4cfc5b02',
+    label: 'Lied der Nibelungen',
+    resourceClassLabel: 'Book',
+    properties: { 'Creator': 'Unknown', 'Publication Location': 'Strassburg', 'Publication Date': 'JULIAN:1485' },
+  },
+  {
+    iri: 'http://rdfh.ch/0803/482a33d65602',
+    label: 'Heilsspiegel (Speculum humanae salvationis)',
+    resourceClassLabel: 'Book',
+    properties: { 'Creator': 'Unknown', 'Publication Location': 'Basel', 'Publication Date': 'JULIAN:1476' },
+  },
+  {
+    iri: 'http://rdfh.ch/0803/7bbb8e59bc04',
+    label: 'Von der Arznei beider Glück',
+    resourceClassLabel: 'Book',
+    properties: { 'Creator': 'Petrarca, Francesco', 'Publication Location': 'Augsburg', 'Publication Date': 'JULIAN:1532' },
+  },
+  {
+    iri: 'http://rdfh.ch/0803/318a29c41a05',
+    label: 'Chronica. Dt.',
+    resourceClassLabel: 'Book',
+    properties: { 'Creator': 'Rolevinck, Werner', 'Publication Location': 'Lübeck', 'Publication Date': 'JULIAN:1474' },
+  },
+  {
+    iri: 'http://rdfh.ch/0803/5e77e98d02',
+    label: 'Margarita Philosophica',
+    resourceClassLabel: 'Book',
+    properties: { 'Creator': 'Gregor Reisch', 'Publication Location': 'Freiburg', 'Publication Date': 'JULIAN:1503' },
+  },
+];

--- a/apps/prototype/src/pages/filter-bar-search-page-b.component.ts
+++ b/apps/prototype/src/pages/filter-bar-search-page-b.component.ts
@@ -1,0 +1,311 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { Router, ActivatedRoute } from '@angular/router';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ReadResource } from '@dasch-swiss/dsp-js';
+import { ResourceBrowserComponent } from '@dasch-swiss/vre/pages/data-browser';
+import { ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
+import { CenteredLayoutComponent, CenteredBoxComponent, CenteredMessageComponent } from '@dasch-swiss/vre/ui/ui';
+import { FilterBarVariantBComponent, FilterCondition } from '../components/filter-bar-b.component';
+import {
+  INCUNABULA_ONTOLOGY,
+  RESOURCE_CLASSES,
+  PROPERTIES_BY_CLASS,
+  BOOK_PROPERTIES,
+  MOCK_SEARCH_RESULTS,
+  ALL_PROPERTIES,
+  MockOntology,
+  MockProperty,
+  MockResourceClass,
+} from '../mock-data';
+
+/** Create mock ReadResource instances from our fixture data */
+function createMockReadResources(): ReadResource[] {
+  return MOCK_SEARCH_RESULTS.map(mock => {
+    const res = new ReadResource();
+    res.id = mock.iri;
+    res.label = mock.label;
+    res.type = `http://0.0.0.0:3333/ontology/0803/incunabula/v2#${mock.resourceClassLabel.toLowerCase()}`;
+    res.attachedToProject = 'http://rdfh.ch/projects/0803';
+    res.properties = {};
+    return res;
+  });
+}
+
+@Component({
+  selector: 'proto-filter-bar-b-search-page-b',
+  standalone: true,
+  imports: [
+    CommonModule,
+    CenteredBoxComponent,
+    CenteredLayoutComponent,
+    CenteredMessageComponent,
+    FilterBarVariantBComponent,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    ResourceBrowserComponent,
+  ],
+  providers: [ResourceResultService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <!-- Variant toggle — floating in top-right near version badge -->
+    <div class="variant-switch">
+      <a class="variant-label" (click)="onVariantChange('a')">A: Popover</a>
+      <span class="variant-divider">|</span>
+      <span class="variant-label active">B: Cascading</span>
+    </div>
+
+    <!-- Filter bar — full width, above the centered content -->
+    <proto-filter-bar-b
+      [ontologies]="ontologies"
+      [resourceClasses]="resourceClasses"
+      [properties]="availableProperties"
+      [selectedOntology]="selectedOntology"
+      [selectedResourceClass]="selectedResourceClass"
+      [conditions]="conditions"
+      [sortBy]="sortBy"
+      [isStale]="isStale"
+      [canSearch]="canSearch"
+      (ontologySelected)="onOntologySelected($event)"
+      (resourceClassSelected)="onResourceClassSelected($event)"
+      (conditionAdded)="onConditionAdded()"
+      (conditionRemoved)="onConditionRemoved($event)"
+      (conditionPropertyChanged)="onConditionPropertyChanged($event)"
+      (conditionOperatorChanged)="onConditionOperatorChanged($event)"
+      (conditionValueChanged)="onConditionValueChanged($event)"
+      (sortByChanged)="onSortByChanged($event)"
+      (searchTriggered)="onSearch()">
+    </proto-filter-bar-b>
+
+    <!-- Results area -->
+    <div class="results-area">
+      @if (isLoading) {
+        <app-centered-box>
+          <mat-spinner diameter="36"></mat-spinner>
+        </app-centered-box>
+      } @else if (hasSearched && readResources.length === 0) {
+        <app-centered-box>
+          <app-centered-message
+            icon="search_off"
+            title="No results found"
+            message="No resources found matching your search criteria. Try broadening your search by removing conditions." />
+        </app-centered-box>
+      } @else if (!hasSearched) {
+        <app-centered-box>
+          <app-centered-message
+            icon="filter_list"
+            title="Build your query"
+            message="Select an ontology and resource class, then add property conditions and click Search." />
+        </app-centered-box>
+      } @else {
+        <!-- Real ResourceBrowserComponent with split view -->
+        <app-resource-browser
+          [data]="{ resources: readResources, selectFirstResource: true }"
+          [showBackToFormButton]="false" />
+      }
+    </div>
+
+    <!-- Screen reader live region -->
+    <div aria-live="polite" class="sr-only">{{ announcement }}</div>
+  `,
+  styles: [`
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    .variant-switch {
+      position: fixed;
+      top: 12px;
+      right: 420px;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      padding: 3px 8px;
+    }
+
+    .variant-label {
+      color: rgba(0, 0, 0, 0.5);
+      cursor: pointer;
+      text-decoration: none;
+
+      &.active {
+        font-weight: 600;
+        color: rgba(0, 0, 0, 0.8);
+        cursor: default;
+      }
+
+      &:not(.active):hover {
+        color: #336790;
+      }
+    }
+
+    .variant-divider {
+      color: rgba(0, 0, 0, 0.2);
+    }
+
+    .results-area {
+      flex: 1;
+      overflow: hidden;
+    }
+
+    app-resource-browser {
+      display: block;
+      height: 100%;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0;
+    }
+  `],
+})
+export class FilterBarSearchPageBComponent {
+  // State
+  ontologies: MockOntology[] = [INCUNABULA_ONTOLOGY];
+  resourceClasses: MockResourceClass[] = [];
+  availableProperties: MockProperty[] = [];
+  selectedOntology: MockOntology | null = null;
+  selectedResourceClass: MockResourceClass | null = null;
+  conditions: FilterCondition[] = [];
+  readResources: ReadResource[] = [];
+  sortBy: string | null = null;
+  isStale = false;
+  isLoading = false;
+  hasSearched = false;
+  announcement = '';
+
+  private _conditionId = 0;
+
+  get canSearch(): boolean {
+    if (!this.selectedOntology) return false;
+    if (!this.selectedResourceClass && this.conditions.length === 0) return false;
+    return true;
+  }
+
+  constructor(private _cdr: ChangeDetectorRef, private _router: Router, private _route: ActivatedRoute) {
+    if (this.ontologies.length === 1) {
+      this.onOntologySelected(this.ontologies[0]);
+    }
+  }
+
+  onVariantChange(variant: string): void {
+    if (variant === 'a') {
+      this._router.navigate(['../advanced-search'], { relativeTo: this._route });
+    }
+  }
+
+  onOntologySelected(onto: MockOntology): void {
+    this.selectedOntology = onto;
+    this.selectedResourceClass = null;
+    this.conditions = [];
+    this.resourceClasses = RESOURCE_CLASSES;
+    this.availableProperties = ALL_PROPERTIES;
+    this._markStale();
+    this._announce(`Ontology "${onto.label}" selected`);
+  }
+
+  onResourceClassSelected(rc: MockResourceClass | null): void {
+    this.selectedResourceClass = rc;
+    this.conditions = [];
+    this.availableProperties = rc ? (PROPERTIES_BY_CLASS[rc.iri] || []) : ALL_PROPERTIES;
+    this._markStale();
+    this._announce(rc ? `Resource class "${rc.label}" selected` : 'All resource classes selected');
+  }
+
+  onConditionAdded(): void {
+    const condition: FilterCondition = {
+      id: `c${++this._conditionId}`,
+      property: null,
+      operator: null,
+      value: null,
+    };
+    this.conditions = [...this.conditions, condition];
+    this._markStale();
+    this._announce(`New condition added. ${this.conditions.length} active filters.`);
+  }
+
+  onConditionRemoved(condition: FilterCondition): void {
+    this.conditions = this.conditions.filter(c => c.id !== condition.id);
+    this._markStale();
+    this._announce(`Filter removed. ${this.conditions.length} active filters.`);
+  }
+
+  onConditionPropertyChanged(event: { condition: FilterCondition; property: MockProperty }): void {
+    this.conditions = this.conditions.map(c =>
+      c.id === event.condition.id
+        ? { ...c, property: event.property, operator: null, value: null }
+        : c
+    );
+    this._markStale();
+  }
+
+  onConditionOperatorChanged(event: { condition: FilterCondition; operator: string }): void {
+    this.conditions = this.conditions.map(c => {
+      if (c.id !== event.condition.id) return c;
+      const updated = { ...c, operator: event.operator, value: null };
+      if (event.operator === 'matches' && c.property?.isLinkedResourceProperty) {
+        const targetClass = RESOURCE_CLASSES.find(rc => rc.iri === c.property!.objectType);
+        updated.linkedResourceClass = targetClass || null;
+        updated.subConditions = [];
+      } else {
+        updated.linkedResourceClass = undefined;
+        updated.subConditions = undefined;
+      }
+      return updated;
+    });
+    this._markStale();
+  }
+
+  onConditionValueChanged(event: { condition: FilterCondition; value: string }): void {
+    this.conditions = this.conditions.map(c =>
+      c.id === event.condition.id ? { ...c, value: event.value } : c
+    );
+    this._markStale();
+  }
+
+  onSortByChanged(label: string | null): void {
+    this.sortBy = label;
+    this._markStale();
+  }
+
+  onSearch(): void {
+    this.isLoading = true;
+    this.hasSearched = true;
+    this.isStale = false;
+    this._cdr.markForCheck();
+
+    // Simulate API latency, then return mock ReadResource objects
+    setTimeout(() => {
+      this.readResources = createMockReadResources();
+      this.isLoading = false;
+      this._cdr.markForCheck();
+      this._announce(`${this.readResources.length} results found.`);
+    }, 600);
+  }
+
+  private _markStale(): void {
+    if (this.hasSearched) this.isStale = true;
+  }
+
+  private _announce(msg: string): void {
+    this.announcement = '';
+    setTimeout(() => {
+      this.announcement = msg;
+      this._cdr.markForCheck();
+    }, 50);
+  }
+}

--- a/apps/prototype/src/pages/filter-bar-search-page.component.ts
+++ b/apps/prototype/src/pages/filter-bar-search-page.component.ts
@@ -1,0 +1,312 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { Router, ActivatedRoute } from '@angular/router';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ReadResource } from '@dasch-swiss/dsp-js';
+import { ResourceBrowserComponent } from '@dasch-swiss/vre/pages/data-browser';
+import { ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
+import { CenteredLayoutComponent, CenteredBoxComponent, CenteredMessageComponent } from '@dasch-swiss/vre/ui/ui';
+import { FilterBarComponent, FilterCondition } from '../components/filter-bar.component';
+import {
+  INCUNABULA_ONTOLOGY,
+  RESOURCE_CLASSES,
+  PROPERTIES_BY_CLASS,
+  BOOK_PROPERTIES,
+  MOCK_SEARCH_RESULTS,
+  ALL_PROPERTIES,
+  MockOntology,
+  MockProperty,
+  MockResourceClass,
+} from '../mock-data';
+
+/** Create mock ReadResource instances from our fixture data */
+function createMockReadResources(): ReadResource[] {
+  return MOCK_SEARCH_RESULTS.map(mock => {
+    const res = new ReadResource();
+    res.id = mock.iri;
+    res.label = mock.label;
+    res.type = `http://0.0.0.0:3333/ontology/0803/incunabula/v2#${mock.resourceClassLabel.toLowerCase()}`;
+    res.attachedToProject = 'http://rdfh.ch/projects/0803';
+    res.properties = {};
+    return res;
+  });
+}
+
+@Component({
+  selector: 'proto-filter-bar-search-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    CenteredBoxComponent,
+    CenteredLayoutComponent,
+    CenteredMessageComponent,
+    FilterBarComponent,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    ResourceBrowserComponent,
+  ],
+  providers: [ResourceResultService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <!-- Variant toggle — floating in top-right near version badge -->
+    <div class="variant-switch">
+      <span class="variant-label active">A: Popover</span>
+      <span class="variant-divider">|</span>
+      <a class="variant-label" (click)="onVariantChange('b')">B: Cascading</a>
+    </div>
+
+    <!-- Filter bar — full width, above the centered content -->
+    <proto-filter-bar
+      [ontologies]="ontologies"
+      [resourceClasses]="resourceClasses"
+      [properties]="availableProperties"
+      [selectedOntology]="selectedOntology"
+      [selectedResourceClass]="selectedResourceClass"
+      [conditions]="conditions"
+      [sortBy]="sortBy"
+      [isStale]="isStale"
+      [canSearch]="canSearch"
+      (ontologySelected)="onOntologySelected($event)"
+      (resourceClassSelected)="onResourceClassSelected($event)"
+      (conditionAdded)="onConditionAdded()"
+      (conditionRemoved)="onConditionRemoved($event)"
+      (conditionPropertyChanged)="onConditionPropertyChanged($event)"
+      (conditionOperatorChanged)="onConditionOperatorChanged($event)"
+      (conditionValueChanged)="onConditionValueChanged($event)"
+      (sortByChanged)="onSortByChanged($event)"
+      (searchTriggered)="onSearch()">
+    </proto-filter-bar>
+
+    <!-- Results area -->
+    <div class="results-area">
+      @if (isLoading) {
+        <app-centered-box>
+          <mat-spinner diameter="36"></mat-spinner>
+        </app-centered-box>
+      } @else if (hasSearched && readResources.length === 0) {
+        <app-centered-box>
+          <app-centered-message
+            icon="search_off"
+            title="No results found"
+            message="No resources found matching your search criteria. Try broadening your search by removing conditions." />
+        </app-centered-box>
+      } @else if (!hasSearched) {
+        <app-centered-box>
+          <app-centered-message
+            icon="filter_list"
+            title="Build your query"
+            message="Select an ontology and resource class, then add property conditions and click Search." />
+        </app-centered-box>
+      } @else {
+        <!-- Real ResourceBrowserComponent with split view -->
+        <app-resource-browser
+          [data]="{ resources: readResources, selectFirstResource: true }"
+          [showBackToFormButton]="false" />
+      }
+    </div>
+
+    <!-- Screen reader live region -->
+    <div aria-live="polite" class="sr-only">{{ announcement }}</div>
+  `,
+  styles: [`
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    .variant-switch {
+      position: fixed;
+      top: 12px;
+      right: 420px;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      padding: 3px 8px;
+    }
+
+    .variant-label {
+      color: rgba(0, 0, 0, 0.5);
+      cursor: pointer;
+      text-decoration: none;
+
+      &.active {
+        font-weight: 600;
+        color: rgba(0, 0, 0, 0.8);
+        cursor: default;
+      }
+
+      &:not(.active):hover {
+        color: #336790;
+      }
+    }
+
+    .variant-divider {
+      color: rgba(0, 0, 0, 0.2);
+    }
+
+    .results-area {
+      flex: 1;
+      overflow: hidden;
+    }
+
+    app-resource-browser {
+      display: block;
+      height: 100%;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0;
+    }
+  `],
+})
+export class FilterBarSearchPageComponent {
+  // State
+  ontologies: MockOntology[] = [INCUNABULA_ONTOLOGY];
+  resourceClasses: MockResourceClass[] = [];
+  availableProperties: MockProperty[] = [];
+  selectedOntology: MockOntology | null = null;
+  selectedResourceClass: MockResourceClass | null = null;
+  conditions: FilterCondition[] = [];
+  readResources: ReadResource[] = [];
+  sortBy: string | null = null;
+  isStale = false;
+  isLoading = false;
+  hasSearched = false;
+  announcement = '';
+
+  private _conditionId = 0;
+
+  get canSearch(): boolean {
+    if (!this.selectedOntology) return false;
+    if (!this.selectedResourceClass && this.conditions.length === 0) return false;
+    return true;
+  }
+
+  constructor(private _cdr: ChangeDetectorRef, private _router: Router, private _route: ActivatedRoute) {
+    if (this.ontologies.length === 1) {
+      this.onOntologySelected(this.ontologies[0]);
+    }
+  }
+
+  onVariantChange(variant: string): void {
+    if (variant === 'b') {
+      this._router.navigate(['../advanced-search-b'], { relativeTo: this._route });
+    }
+  }
+
+  onOntologySelected(onto: MockOntology): void {
+    this.selectedOntology = onto;
+    this.selectedResourceClass = null;
+    this.conditions = [];
+    this.resourceClasses = RESOURCE_CLASSES;
+    this.availableProperties = ALL_PROPERTIES;
+    this._markStale();
+    this._announce(`Ontology "${onto.label}" selected`);
+  }
+
+  onResourceClassSelected(rc: MockResourceClass | null): void {
+    this.selectedResourceClass = rc;
+    this.conditions = [];
+    this.availableProperties = rc ? (PROPERTIES_BY_CLASS[rc.iri] || []) : ALL_PROPERTIES;
+    this._markStale();
+    this._announce(rc ? `Resource class "${rc.label}" selected` : 'All resource classes selected');
+  }
+
+  onConditionAdded(): void {
+    const condition: FilterCondition = {
+      id: `c${++this._conditionId}`,
+      property: null,
+      operator: null,
+      value: null,
+    };
+    this.conditions = [...this.conditions, condition];
+    this._markStale();
+    this._announce(`New condition added. ${this.conditions.length} active filters.`);
+  }
+
+  onConditionRemoved(condition: FilterCondition): void {
+    this.conditions = this.conditions.filter(c => c.id !== condition.id);
+    this._markStale();
+    this._announce(`Filter removed. ${this.conditions.length} active filters.`);
+  }
+
+  onConditionPropertyChanged(event: { condition: FilterCondition; property: MockProperty }): void {
+    this.conditions = this.conditions.map(c =>
+      c.id === event.condition.id
+        ? { ...c, property: event.property, operator: null, value: null }
+        : c
+    );
+    this._markStale();
+  }
+
+  onConditionOperatorChanged(event: { condition: FilterCondition; operator: string }): void {
+    this.conditions = this.conditions.map(c => {
+      if (c.id !== event.condition.id) return c;
+      const updated = { ...c, operator: event.operator, value: null };
+      // When "matches" is selected on a link property, initialize sub-conditions
+      if (event.operator === 'matches' && c.property?.isLinkedResourceProperty) {
+        const targetClass = RESOURCE_CLASSES.find(rc => rc.iri === c.property!.objectType);
+        updated.linkedResourceClass = targetClass || null;
+        updated.subConditions = [];
+      } else {
+        updated.linkedResourceClass = undefined;
+        updated.subConditions = undefined;
+      }
+      return updated;
+    });
+    this._markStale();
+  }
+
+  onConditionValueChanged(event: { condition: FilterCondition; value: string }): void {
+    this.conditions = this.conditions.map(c =>
+      c.id === event.condition.id ? { ...c, value: event.value } : c
+    );
+    this._markStale();
+  }
+
+  onSortByChanged(label: string | null): void {
+    this.sortBy = label;
+    this._markStale();
+  }
+
+  onSearch(): void {
+    this.isLoading = true;
+    this.hasSearched = true;
+    this.isStale = false;
+    this._cdr.markForCheck();
+
+    // Simulate API latency, then return mock ReadResource objects
+    setTimeout(() => {
+      this.readResources = createMockReadResources();
+      this.isLoading = false;
+      this._cdr.markForCheck();
+      this._announce(`${this.readResources.length} results found.`);
+    }, 600);
+  }
+
+  private _markStale(): void {
+    if (this.hasSearched) this.isStale = true;
+  }
+
+  private _announce(msg: string): void {
+    this.announcement = '';
+    setTimeout(() => {
+      this.announcement = msg;
+      this._cdr.markForCheck();
+    }, 50);
+  }
+}

--- a/apps/prototype/src/styles.scss
+++ b/apps/prototype/src/styles.scss
@@ -1,0 +1,27 @@
+@use '@angular/material' as mat;
+@use 'config';
+@use 'layout';
+@use 'elements';
+@use 'typography' as t;
+@use 'responsive';
+
+@include mat.elevation-classes();
+@include mat.app-background();
+@include mat.all-component-typographies(t.$dsp-typography-config);
+
+$primary: mat.m2-define-palette(config.$blue_palette, 700, 500, 900);
+$accent: mat.m2-define-palette(config.$light_blue_palette, 900, 600, 900);
+$warn: mat.m2-define-palette(config.$velvet_red_palette, 700, 500, 900);
+
+$theme: mat.m2-define-light-theme((
+  color: (primary: $primary, accent: $accent, warn: $warn),
+  typography: t.$dsp-typography-config,
+  density: 0
+));
+
+@include mat.all-component-themes($theme);
+
+body {
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  margin: 0;
+}

--- a/apps/prototype/tsconfig.app.json
+++ b/apps/prototype/tsconfig.app.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [],
+    "useDefineForClassFields": false
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "../../apps/dsp-app/src/app/**/*.ts"],
+  "exclude": ["../../apps/dsp-app/src/app/**/*.spec.ts"]
+}


### PR DESCRIPTION
## Summary

- Ephemeral prototype for the advanced search redesign
- Bootstraps real dsp-app shell with mocked services and Incunabula test data
- Two interaction variants: Popover form (A) and Cascading menus (B)
- Type-specific value inputs (boolean, list, date picker, color picker, number)
- Nested sub-query chips for link property "matches" operator

## How to run

```sh
cd dsp-app
npm install
just proto-serve   # serves on port 4201
```

- Variant A: http://localhost:4201/project/0803/advanced-search
- Variant B: http://localhost:4201/project/0803/advanced-search-b

## Related

- Spec PR: https://github.com/dasch-swiss/dasch-specs/pull/55

## Test plan

- [ ] Run the prototype locally
- [ ] Test both variants' interaction flows
- [ ] Verify type-specific inputs (boolean, list, date, color)
- [ ] Test nested sub-queries on link "matches"
- [ ] Gather UX feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)