### PR TITLE
fix(deps): add javascript label to Renovate npm PRs to match Dependabot convention

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,9 @@
   "packageRules": [
 
     {
-      "description": "Add npm label to match Dependabot label convention",
+      "description": "Add javascript label to match Dependabot language label convention",
       "matchManagers": ["npm"],
-      "addLabels": ["npm"]
+      "addLabels": ["javascript"]
     },
 
     {

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
   "packageRules": [
 
     {
+      "description": "Add npm label to match Dependabot label convention",
+      "matchManagers": ["npm"],
+      "addLabels": ["npm"]
+    },
+
+    {
       "description": "Angular and NX: manual upgrade only (ng update / nx migrate)",
       "matchPackagePatterns": [
         "^@angular/",


### PR DESCRIPTION
[DEV-6217](https://linear.app/dasch/issue/DEV-6217)

## Summary
- Renovate npm PRs were missing the `javascript` label that Dependabot applied automatically to npm update PRs
- Adds `addLabels: ["javascript"]` scoped to the npm manager via `matchManagers: ["npm"]`

## Changes
`renovate.json` — new packageRule at the top of the rules list applying `javascript` label to all npm-managed PRs

## Test Plan
- Verify next Renovate PR carries both `dependencies` and `javascript` labels