### PR TITLE
chore(deps): tune Renovate config with safety and UX improvements

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,13 @@
   "prHourlyLimit": 2,
   "dependencyDashboard": true,
   "labels": ["dependencies"],
+  "commitMessageExtra": "{{#if currentVersion}}from {{currentVersion}} to {{newVersion}}{{/if}}",
+  "rebaseWhen": "conflicted",
+  "dependencyDashboardOSVVulnerabilitySummary": "all",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on Monday"]
+  },
   "vulnerabilityAlerts": {
     "enabled": false
   },
@@ -152,17 +159,19 @@
     },
 
     {
-      "description": "Automerge patch updates (all dep types)",
+      "description": "Automerge patch updates (all dep types) — 3-day age guard prevents automerging broken releases",
       "matchUpdateTypes": ["patch"],
       "automerge": true,
-      "platformAutomerge": true
+      "platformAutomerge": true,
+      "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Automerge minor updates for dev dependencies",
+      "description": "Automerge minor updates for dev dependencies — 3-day age guard prevents automerging broken releases",
       "matchUpdateTypes": ["minor"],
       "matchDepTypes": ["devDependencies"],
       "automerge": true,
-      "platformAutomerge": true
+      "platformAutomerge": true,
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
[DEV-6217](https://linear.app/dasch/issue/DEV-6217)

## Summary
- Single-package PR titles now show "from X to Y" version range
- Automerge has a 3-day safety guard against broken npm releases
- Less CI churn: PRs only rebased on actual merge conflicts
- Lockfile kept fresh with a weekly Monday maintenance run
- OSV vulnerability summary visible in the Dependency Dashboard

## Changes

**`commitMessageExtra`** — `{{#if currentVersion}}from {{currentVersion}} to {{newVersion}}{{/if}}`
Single-package PRs: `chore(deps): update dependency @types/openseadragon from 3.0.9 to 3.0.10`
Grouped PRs: unaffected (handlebars guard renders empty when currentVersion is undefined)

**`rebaseWhen: "conflicted"`** — Renovate only rebases open PRs when there are actual merge conflicts, not every time main advances. Reduces unnecessary CI re-runs on open update PRs.

**`dependencyDashboardOSVVulnerabilitySummary: "all"`** — OSV (Open Source Vulnerabilities) database data shown in the Dependency Dashboard alongside pending updates.

**`lockFileMaintenance`** — weekly Monday run regenerates `package-lock.json` without changing any package versions. Keeps the lockfile from drifting. Scheduled Monday to avoid collision with Tuesday's regular update PRs.

**`minimumReleaseAge: "3 days"`** on both automerge rules — Renovate waits 3 days after a version is published before automerging it. Protects against broken releases being silently merged before the npm ecosystem notices.

## Test Plan
- Verify next single-package Renovate PR title includes "from X to Y"
- Verify grouped PR titles are unchanged (no "from  to " artifact)
- Verify patch PRs are not automerged until 3 days after the release date