### PR TITLE
chore: add security label to Dependabot security alert PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
 # ─── Update strategy overview ──────────────────────────────────────────────────
 #
-# All version updates (npm, github-actions, docker) are managed by Renovate.
+# Version updates (npm, github-actions, docker) are managed by Renovate.
 # See renovate.json for configuration.
 #
-# Dependabot security alerts remain active via GitHub org/repo settings
-# (independent of this file — no entries needed here).
+# The npm entry below is kept solely so that Dependabot security update PRs
+# inherit the labels config. open-pull-requests-limit: 0 disables version
+# update PRs for npm (Renovate handles those); security update PRs are
+# unaffected by the limit and will receive the "security" label.
 # ───────────────────────────────────────────────────────────────────────────────
 
 version: 2
-updates: []
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "security"
+      - "dependencies"


### PR DESCRIPTION
[DEV-6241](https://linear.app/dasch/issue/DEV-6241)

## Summary
- Fixes schema validation error: `updates: []` is invalid (minimum 1 item required)
- Adds an npm entry with `open-pull-requests-limit: 0` to keep version update PRs disabled (Renovate handles those) while allowing Dependabot security update PRs to inherit the `security` and `dependencies` labels

## Changes
- `.github/dependabot.yml` — replaced empty `updates: []` with a minimal npm entry that disables version updates and configures labels for security PRs

## Test Plan
- Schema validation: the updated config passes GitHub's dependabot.yml schema (no more "did not contain a minimum number of items 1" error)
- Next Dependabot security alert PR will carry the `security` and `dependencies` labels automatically