### PR TITLE
chore(ci): use PR number as workflow_dispatch input instead of branch name

### DIFF
--- a/.github/workflows/cloud-run-pr-preview.yml
+++ b/.github/workflows/cloud-run-pr-preview.yml
@@ -8,10 +8,9 @@ on:
       - 'libs/**'
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch to deploy (leave blank to use the branch this workflow runs from)'
-        required: false
-        default: ''
+      pr_number:
+        description: 'PR number to deploy a preview for'
+        required: true
   schedule:
     - cron: '0 2 * * *'  # daily at 02:00 UTC — clean up stale previews
 
@@ -124,30 +123,32 @@ jobs:
 
             _Updated on every push. Deleted when PR closes or after 4 days._
 
-  deploy-branch-preview:
-    name: Build and deploy branch preview
+  deploy-preview-manual:
+    name: Build and deploy manual PR preview
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     concurrency:
-      group: cloud-run-preview-branch-${{ inputs.branch || github.ref_name }}
+      group: cloud-run-preview-pr-${{ inputs.pr_number }}
       cancel-in-progress: true
     permissions:
       contents: read
       id-token: write
       pull-requests: write
+    env:
+      SERVICE_NAME: dsp-app-pr-${{ inputs.pr_number }}
+      IMAGE_TAG: pr-${{ inputs.pr_number }}
     steps:
-      - name: Compute service name from branch
+      - name: Resolve PR head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="${{ inputs.branch || github.ref_name }}"
-          # Lowercase, replace non-alphanumeric chars with hyphens, collapse runs, strip leading/trailing hyphens
-          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-34)
-          echo "BRANCH_SLUG=${SLUG}" >> $GITHUB_ENV
-          echo "SERVICE_NAME=dsp-app-branch-${SLUG}" >> $GITHUB_ENV
-          echo "IMAGE_TAG=branch-${SLUG}" >> $GITHUB_ENV
+          BRANCH=$(gh pr view "${{ inputs.pr_number }}" --json headRefName --jq .headRefName)
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ steps.pr.outputs.branch }}
 
       - uses: actions/setup-node@v6
         with:
@@ -210,45 +211,18 @@ jobs:
             --max-instances=1
             --cpu-throttling
 
-      - name: Output preview URL
-        run: |
-          echo "## Branch Preview Deployed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| | |" >> $GITHUB_STEP_SUMMARY
-          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          echo "| **Preview URL** | ${{ steps.deploy.outputs.url }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Cloud Run Service** | \`${{ env.SERVICE_NAME }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Branch** | \`${{ inputs.branch || github.ref_name }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Backend** | DEV API (\`api.dev.dasch.swiss\`) |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "_Deleted automatically after 4 days of inactivity._" >> $GITHUB_STEP_SUMMARY
-
-      - name: Find open PR for branch
-        id: find-pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=$(gh pr list \
-            --head "${{ inputs.branch || github.ref_name }}" \
-            --state open \
-            --json number \
-            --jq '.[0].number // empty')
-          echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
-
-      - name: Find existing preview comment on PR
-        if: steps.find-pr.outputs.pr_number != ''
+      - name: Find existing preview comment
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
-          issue-number: ${{ steps.find-pr.outputs.pr_number }}
+          issue-number: ${{ inputs.pr_number }}
           comment-author: github-actions[bot]
           body-includes: "<!-- dsp-app-preview -->"
 
-      - name: Post or update preview URL comment on PR
-        if: steps.find-pr.outputs.pr_number != ''
+      - name: Post or update preview URL comment
         uses: peter-evans/create-or-update-comment@v5
         with:
-          issue-number: ${{ steps.find-pr.outputs.pr_number }}
+          issue-number: ${{ inputs.pr_number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
           body: |
@@ -259,10 +233,10 @@ jobs:
             |---|---|
             | **Preview URL** | ${{ steps.deploy.outputs.url }} |
             | **Cloud Run Service** | `${{ env.SERVICE_NAME }}` |
-            | **Branch** | `${{ inputs.branch || github.ref_name }}` |
+            | **Branch** | `${{ steps.pr.outputs.branch }}` |
             | **Backend** | DEV API (`api.dev.dasch.swiss`) |
 
-            _Deployed via workflow_dispatch. Deleted automatically after 4 days of inactivity._
+            _Deployed manually via workflow_dispatch. Deleted when PR closes or after 4 days._
 
   cleanup-preview:
     name: Clean up PR close
@@ -333,32 +307,3 @@ jobs:
               --delete-tags --quiet 2>/dev/null || true
           done
 
-      - name: Delete stale branch preview services older than 4 days
-        run: |
-          CUTOFF=$(date -u -d '4 days ago' +%Y-%m-%dT%H:%M:%SZ)
-          # Use the latest *revision* timestamp, not the service creation timestamp.
-          # This avoids deleting services that have been recently redeployed.
-          mapfile -t SERVICES < <(gcloud run services list \
-            --region="${{ secrets.GCP_REGION }}" \
-            --filter="metadata.name:dsp-app-branch-" \
-            --format="value(metadata.name)" 2>/dev/null || true)
-          for SERVICE in "${SERVICES[@]}"; do
-            [ -z "$SERVICE" ] && continue
-            LATEST=$(gcloud run revisions list \
-              --service="$SERVICE" \
-              --region="${{ secrets.GCP_REGION }}" \
-              --sort-by="~metadata.creationTimestamp" \
-              --limit=1 \
-              --format="value(metadata.creationTimestamp)" 2>/dev/null || echo "")
-            if [ -z "$LATEST" ] || [[ "$LATEST" < "$CUTOFF" ]]; then
-              echo "Deleting stale branch service: $SERVICE (last deployed: ${LATEST:-unknown})"
-              BRANCH_SLUG="${SERVICE#dsp-app-branch-}"
-              gcloud run services delete "$SERVICE" \
-                --region="${{ secrets.GCP_REGION }}" --quiet 2>/dev/null || true
-              gcloud artifacts docker images delete \
-                "${{ secrets.GCP_ARTIFACT_REGISTRY }}/dsp-app:branch-${BRANCH_SLUG}" \
-                --delete-tags --quiet 2>/dev/null || true
-            else
-              echo "Skipping $SERVICE — last deployed ${LATEST}, within 4-day window"
-            fi
-          done


### PR DESCRIPTION
[DEV-6232](https://linear.app/dasch/issue/DEV-6232/featci-add-workflow_dispatch-trigger-to-dsp-app-pr-preview-workflow)

## Summary
- Replaces the free-form `branch` input with a `pr_number` input (required)
- Service/image names reuse the existing `dsp-app-pr-{N}` scheme — no branch-name sanitisation needed, no truncation edge cases
- PR head branch is resolved at runtime via `gh pr view`, so the correct code is always checked out
- Removes the separate `dsp-app-branch-*` stale cleanup step — the existing PR stale cleanup already covers these services

## Changes
- `workflow_dispatch` input: `branch` → `pr_number` (required)
- `deploy-branch-preview` job renamed to `deploy-preview-manual`; branch-slug computation replaced by a single `gh pr view` call
- `cleanup-stale`: removed the branch-service cleanup step (no longer applicable)

## Test Plan
- Run workflow from `main` with a valid PR number; verify the service deploys as `dsp-app-pr-{N}` and a comment appears on the PR