### PR TITLE
chore(ci): avoid missing git context in deploy-preview-manual

### DIFF
--- a/.github/workflows/cloud-run-pr-preview.yml
+++ b/.github/workflows/cloud-run-pr-preview.yml
@@ -137,6 +137,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
             --head "${{ github.ref_name }}" \
             --state open \
             --json number \


### PR DESCRIPTION
[DEV-6232](https://linear.app/dasch/issue/DEV-6232/featci-add-workflow_dispatch-trigger-to-dsp-app-pr-preview-workflow)

## Summary
- The `gh pr list` call in `deploy-preview-manual` runs before `actions/checkout`, so there is no `.git` directory in the workspace yet
- `gh` was trying to infer the repository from git context and failing with `fatal: not a git repository`
- Fix: add `--repo "${{ github.repository }}"` so `gh` uses the GitHub API directly without needing a local git repo

## Changes
- One-line fix in `deploy-preview-manual` step "Resolve open PR for branch"

## Test Plan
- Run workflow from the branch dropdown on a branch with an open PR — verify the PR number is resolved correctly and the deploy proceeds