### PR TITLE
chore(deps): overhaul Renovate config — automerge tiers, grouping, and major-update constraints (DEV-6217)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --ignore-scripts
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --ignore-scripts
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Cache Cypress binary
         uses: actions/cache@v5
@@ -260,7 +260,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --ignore-scripts

--- a/.github/workflows/cloud-run-pr-preview.yml
+++ b/.github/workflows/cloud-run-pr-preview.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
           cache: 'npm'
 
       - name: Install dependencies
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
           cache: 'npm'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/publish-from-branch.yml
+++ b/.github/workflows/publish-from-branch.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0 # gets additionally all tags which we need
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version-file: .nvmrc
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:

--- a/.github/workflows/release-dsp-js.yml
+++ b/.github/workflows/release-dsp-js.yml
@@ -6,7 +6,6 @@ on:
       - 'dsp-js-v*'
 
 env:
-  NodeVersion: 22.12.0
 
 jobs:
   publish:
@@ -22,7 +21,7 @@ jobs:
       - name: Set up Node.js ${{ env.NodeVersion }}
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NodeVersion }}
+          node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/renovate.json
+++ b/renovate.json
@@ -71,8 +71,8 @@
       "enabled": false
     },
     {
-      "description": "@ngrx/component-store: Angular-version coupled",
-      "matchPackageNames": ["@ngrx/component-store"],
+      "description": "@ngrx/*: all packages are Angular-version coupled — upgrade only after ng update",
+      "matchPackageNames": ["/^@ngrx//"],
       "enabled": false
     },
     {
@@ -97,6 +97,26 @@
       "description": "zone.js: maintenance mode — allow patches only (disable minor and major)",
       "matchPackageNames": ["zone.js"],
       "matchUpdateTypes": ["minor", "major"],
+      "enabled": false
+    },
+    {
+      "description": "NX-wrapped tools: major version ceiling is set by @nx/* peer deps — disable majors until nx migrate lifts the constraint",
+      "matchPackageNames": [
+        "cypress",
+        "@cypress/code-coverage",
+        "/^jest/",
+        "@types/jest",
+        "/^ts-jest$/",
+        "storybook",
+        "/^@storybook//"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Angular-coupled ecosystem: rxjs major must align with Angular peer dep; ng-mocks and ngx-build-plus are Angular-version coupled — upgrade only after ng update",
+      "matchPackageNames": ["rxjs", "ng-mocks", "ngx-build-plus"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
 

--- a/renovate.json
+++ b/renovate.json
@@ -109,11 +109,6 @@
       "enabled": false
     },
     {
-      "description": "@dasch-swiss/dsp-js: updated manually per release",
-      "matchPackageNames": ["@dasch-swiss/dsp-js"],
-      "enabled": false
-    },
-    {
       "description": "CKEditor: custom build + Angular adapter tracked in DEV-6208; disable both until resolved",
       "matchPackageNames": [
         "ckeditor5-custom-build",
@@ -272,6 +267,11 @@
       ],
       "groupName": "angular-ecosystem-deps"
     },
+    {
+      "description": "Storybook packages — @storybook/test-runner lives in a separate repo (storybookjs/test-runner) and is not covered by the monorepo:storybook preset in config:recommended; explicit group prevents sync drift on minor/patch updates",
+      "matchPackageNames": ["storybook", "/^@storybook//"],
+      "groupName": "storybook-deps"
+    },
 
     {
       "description": "Automerge all dev dependency updates (patch + minor) — no age guard; dev deps don't affect production",
@@ -297,6 +297,14 @@
       "automerge": true,
       "platformAutomerge": true,
       "minimumReleaseAge": "7 days",
+      "rebaseWhen": "behind-base-branch"
+    },
+    {
+      "description": "Automerge github-actions and docker patch/minor updates — matchDepTypes: devDependencies does not apply to these managers so they need an explicit rule",
+      "matchManagers": ["github-actions", "dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "platformAutomerge": true,
       "rebaseWhen": "behind-base-branch"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "prConcurrentLimit: 1 — serial automerge queue; avoids package-lock.json race conditions that occur when multiple concurrent dep update PRs each rebase and re-run CI after every merge.",
+    "rebaseWhen: conflicted (global) — major PRs sit unmerged intentionally; rebasing them on every automated merge would waste CI runs on a PR nobody is about to merge. Automated rules override this with behind-base-branch to keep the automerge chain moving."
+  ],
   "extends": ["config:recommended"],
   "schedule": ["before 9am on Tuesday"],
   "timezone": "Europe/Zurich",

--- a/renovate.json
+++ b/renovate.json
@@ -199,14 +199,10 @@
       "groupName": "eslint-plugins-deps"
     },
     {
-      "description": "@jscutlery utilities: not in monorepo:swc preset — explicit standalone group",
+      "description": "@jscutlery utilities: not in monorepo:swc preset — explicit standalone group. @jscutlery/swc-angular excluded here so it stays in swc-deps (later rules win in Renovate)",
       "groupName": "jscutlery-deps",
-      "matchPackageNames": ["/^@jscutlery//"]
-    },
-    {
-      "description": "@sentry/cli: lives in getsentry/sentry-cli repo, not matched by monorepo:sentry-javascript — join sentry group manually",
-      "matchPackageNames": ["@sentry/cli"],
-      "groupName": "sentry-javascript"
+      "matchPackageNames": ["/^@jscutlery//"],
+      "excludePackageNames": ["@jscutlery/swc-angular"]
     },
     {
       "description": "Jest test framework and utilities — jest-preset-angular bridges Jest and Angular so it must move with the Jest group",

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "commitMessageExtra": "{{#if currentVersion}}from {{currentVersion}} to {{newVersion}}{{/if}}",
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "lockFileMaintenance": {
     "enabled": true,
@@ -184,7 +184,8 @@
       "matchUpdateTypes": ["patch", "minor"],
       "matchDepTypes": ["devDependencies"],
       "automerge": true,
-      "platformAutomerge": true
+      "platformAutomerge": true,
+      "rebaseWhen": "behind-base-branch"
     },
     {
       "description": "Automerge production patch updates — 3-day age guard prevents adopting broken releases",
@@ -192,7 +193,8 @@
       "matchDepTypes": ["dependencies"],
       "automerge": true,
       "platformAutomerge": true,
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "3 days",
+      "rebaseWhen": "behind-base-branch"
     },
     {
       "description": "Automerge production minor updates — 7-day age guard for extra caution on production code",
@@ -200,7 +202,8 @@
       "matchDepTypes": ["dependencies"],
       "automerge": true,
       "platformAutomerge": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "rebaseWhen": "behind-base-branch"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "rebaseWhen: conflicted (global) — major PRs sit unmerged intentionally; rebasing them on every automated merge would waste CI runs on a PR nobody is about to merge. Automated rules override this with behind-base-branch to keep the automerge chain moving."
   ],
   "extends": ["config:recommended"],
+  "semanticCommitType": "chore",
   "timezone": "Europe/Zurich",
   "prConcurrentLimit": 2,
   "dependencyDashboard": true,

--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
     "prConcurrentLimit: 2 — allows one automated PR and one unmerged major PR to coexist. A single slot would let a major PR waiting for manual merge block the entire automated queue. rebaseWhen: behind-base-branch on automated rules makes the automated slot effectively serial (each merge triggers a rebase + CI re-run on the next), so two slots do not cause package-lock.json race conditions.",
-    "No global schedule — with prConcurrentLimit: 2 and age guards (3d/7d) as the real safety mechanism, a schedule only adds unnecessary delay. Updates flow through as soon as age guards pass. lockFileMaintenance keeps its own Monday schedule.",
+    "schedule: before 5am on monday through friday — Renovate opens new PRs only during the midnight-to-5am window on weekdays (Europe/Zurich). platformAutomerge merges a PR the moment CI passes, so the last batch (Fri 00:00-05:00) runs CI during Friday and merges before the weekend. lockFileMaintenance keeps its own Monday schedule.",
     "rebaseWhen: conflicted (global) — major PRs sit unmerged intentionally; rebasing them on every automated merge would waste CI runs on a PR nobody is about to merge. Automated rules override this with behind-base-branch to keep the automerge chain moving.",
     "vulnerabilityAlerts disabled — Dependabot handles security advisories instead. Its native GitHub Security Advisory integration links CVEs to the Security tab with GHSA references and co-locates with secret scanning and code scanning, which Renovate cannot replicate. Tradeoff: Dependabot covers only direct dependencies and is slower than Renovate would be, but the GitHub-native security workflow outweighs that for this project."
   ],
   "extends": ["config:recommended"],
   "semanticCommitType": "chore",
   "timezone": "Europe/Zurich",
+  "schedule": ["before 5am on monday through friday"],
   "prConcurrentLimit": 2,
   "dependencyDashboard": true,
   "labels": ["dependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -97,9 +97,9 @@
     },
 
     {
-      "description": "Major updates: require manual approval via Dependency Dashboard",
+      "description": "Major updates: PRs open automatically but require manual merge. Timing matters — merging a major before a release or production deployment could introduce undetected breakage that poor test coverage would miss. Human decides when it is safe to merge.",
       "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
+      "automerge": false
     },
 
     {

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "description": [
     "prConcurrentLimit: 2 — allows one automated PR and one unmerged major PR to coexist. A single slot would let a major PR waiting for manual merge block the entire automated queue. rebaseWhen: behind-base-branch on automated rules makes the automated slot effectively serial (each merge triggers a rebase + CI re-run on the next), so two slots do not cause package-lock.json race conditions.",
     "No global schedule — with prConcurrentLimit: 2 and age guards (3d/7d) as the real safety mechanism, a schedule only adds unnecessary delay. Updates flow through as soon as age guards pass. lockFileMaintenance keeps its own Monday schedule.",
-    "rebaseWhen: conflicted (global) — major PRs sit unmerged intentionally; rebasing them on every automated merge would waste CI runs on a PR nobody is about to merge. Automated rules override this with behind-base-branch to keep the automerge chain moving."
+    "rebaseWhen: conflicted (global) — major PRs sit unmerged intentionally; rebasing them on every automated merge would waste CI runs on a PR nobody is about to merge. Automated rules override this with behind-base-branch to keep the automerge chain moving.",
+    "vulnerabilityAlerts disabled — Dependabot handles security advisories instead. Its native GitHub Security Advisory integration links CVEs to the Security tab with GHSA references and co-locates with secret scanning and code scanning, which Renovate cannot replicate. Tradeoff: Dependabot covers only direct dependencies and is slower than Renovate would be, but the GitHub-native security workflow outweighs that for this project."
   ],
   "extends": ["config:recommended"],
   "semanticCommitType": "chore",
@@ -39,6 +40,7 @@
       "addLabels": ["docker"],
       "groupName": "docker-deps"
     },
+
     {
       "description": "Angular and NX: manual upgrade only (ng update / nx migrate)",
       "enabled": false,
@@ -58,12 +60,25 @@
       "enabled": false
     },
     {
-      "description": "ESLint ecosystem: coupled to TypeScript version",
+      "description": "ESLint core + TypeScript ESLint: frozen until Angular/NX upgrade unlocks ESLint 9 flat config migration",
       "matchPackageNames": [
         "eslint",
         "eslint-plugin-angular",
         "/^@typescript-eslint//"
       ],
+      "enabled": false
+    },
+    {
+      "description": "ESLint plugins and Airbnb configs: major updates disabled — coupled to frozen ESLint 8; a plugin major dropping ESLint 8 support would break the entire lint pipeline",
+      "matchPackageNames": [
+        "eslint-plugin-import",
+        "eslint-plugin-ban",
+        "eslint-plugin-jsdoc",
+        "eslint-plugin-unused-imports",
+        "eslint-config-airbnb-base",
+        "eslint-config-airbnb-typescript"
+      ],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -77,8 +92,14 @@
       "enabled": false
     },
     {
-      "description": "@types/node: must match Node.js version in Docker images",
+      "description": "@types/node: must match Node.js version used in CI and local toolchain",
       "matchPackageNames": ["@types/node"],
+      "enabled": false
+    },
+    {
+      "description": "Node.js (.nvmrc): major version managed manually — must align with CI runners and @types/node",
+      "matchManagers": ["nvm"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -106,6 +127,7 @@
         "cypress",
         "@cypress/code-coverage",
         "/^jest/",
+        "jest-preset-angular",
         "@types/jest",
         "/^ts-jest$/",
         "storybook",
@@ -115,8 +137,15 @@
       "enabled": false
     },
     {
-      "description": "Angular-coupled ecosystem: rxjs major must align with Angular peer dep; ng-mocks and ngx-build-plus are Angular-version coupled — upgrade only after ng update",
-      "matchPackageNames": ["rxjs", "ng-mocks", "ngx-build-plus"],
+      "description": "Angular-coupled ecosystem: major version must align with Angular major — upgrade only after ng update",
+      "matchPackageNames": [
+        "rxjs",
+        "ng-mocks",
+        "ngx-build-plus",
+        "@ngx-translate/core",
+        "@ngx-translate/http-loader",
+        "@jscutlery/swc-angular"
+      ],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
@@ -128,6 +157,42 @@
     },
 
     {
+      "description": "SWC compiler suite — all packages must update together to avoid ABI mismatches between core, helpers, and jest transform",
+      "matchPackageNames": [
+        "/^@swc//",
+        "@swc-node/register",
+        "@jscutlery/swc-angular"
+      ],
+      "groupName": "swc-deps"
+    },
+    {
+      "description": "Grafana Faro observability SDK — packages are released together and must stay in sync",
+      "matchPackageNames": ["/^@grafana/faro/"],
+      "groupName": "grafana-faro-deps"
+    },
+    {
+      "description": "JSON-LD + its type definitions",
+      "matchPackageNames": ["jsonld", "@types/jsonld"],
+      "groupName": "jsonld-deps"
+    },
+    {
+      "description": "ngx-translate i18n — core and http-loader are always used together",
+      "matchPackageNames": ["/^@ngx-translate//"],
+      "groupName": "ngx-translate-deps"
+    },
+    {
+      "description": "ESLint plugins and Airbnb configs — group patch/minor together; major is disabled above",
+      "matchPackageNames": [
+        "eslint-plugin-import",
+        "eslint-plugin-ban",
+        "eslint-plugin-jsdoc",
+        "eslint-plugin-unused-imports",
+        "eslint-config-airbnb-base",
+        "eslint-config-airbnb-typescript"
+      ],
+      "groupName": "eslint-plugins-deps"
+    },
+    {
       "description": "@jscutlery utilities: not in monorepo:swc preset — explicit standalone group",
       "groupName": "jscutlery-deps",
       "matchPackageNames": ["/^@jscutlery//"]
@@ -138,9 +203,10 @@
       "groupName": "sentry-javascript"
     },
     {
-      "description": "Jest test framework and utilities (^jest pattern intentionally broad: groups all jest-* packages including future additions)",
+      "description": "Jest test framework and utilities — jest-preset-angular bridges Jest and Angular so it must move with the Jest group",
       "matchPackageNames": [
         "@types/jest",
+        "jest-preset-angular",
         "reflect-metadata",
         "ng-mocks",
         "@faker-js/faker",
@@ -195,11 +261,13 @@
       "groupName": "test-coverage-deps"
     },
     {
-      "description": "Third-party Angular-compatible packages (not coupled to Angular version)",
+      "description": "Third-party Angular-compatible packages (not strictly version-coupled to Angular)",
       "matchPackageNames": [
         "angular-split",
         "angular-imask",
-        "angular-html-parser"
+        "angular-html-parser",
+        "ng2-pdf-viewer",
+        "ngx-color-picker"
       ],
       "groupName": "angular-ecosystem-deps"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -215,7 +215,6 @@
         "jest-preset-angular",
         "reflect-metadata",
         "ng-mocks",
-        "@faker-js/faker",
         "/^jest/",
         "/^ts-jest$/"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
-    "prConcurrentLimit: 1 — serial automerge queue; avoids package-lock.json race conditions that occur when multiple concurrent dep update PRs each rebase and re-run CI after every merge.",
+    "prConcurrentLimit: 2 — allows one automated PR and one unmerged major PR to coexist. A single slot would let a major PR waiting for manual merge block the entire automated queue. rebaseWhen: behind-base-branch on automated rules makes the automated slot effectively serial (each merge triggers a rebase + CI re-run on the next), so two slots do not cause package-lock.json race conditions.",
+    "No global schedule — with prConcurrentLimit: 2 and age guards (3d/7d) as the real safety mechanism, a schedule only adds unnecessary delay. Updates flow through as soon as age guards pass. lockFileMaintenance keeps its own Monday schedule.",
     "rebaseWhen: conflicted (global) — major PRs sit unmerged intentionally; rebasing them on every automated merge would waste CI runs on a PR nobody is about to merge. Automated rules override this with behind-base-branch to keep the automerge chain moving."
   ],
   "extends": ["config:recommended"],
-  "schedule": ["before 9am on Tuesday"],
   "timezone": "Europe/Zurich",
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 2,
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "commitMessageExtra": "{{#if currentVersion}}from {{currentVersion}} to {{newVersion}}{{/if}}",

--- a/renovate.json
+++ b/renovate.json
@@ -84,7 +84,9 @@
         "eslint-plugin-jsdoc",
         "eslint-plugin-unused-imports",
         "eslint-config-airbnb-base",
-        "eslint-config-airbnb-typescript"
+        "eslint-config-airbnb-typescript",
+        "eslint-config-prettier",
+        "eslint-plugin-prettier"
       ],
       "matchUpdateTypes": ["major"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -196,12 +196,6 @@
       "groupName": "eslint-plugins-deps"
     },
     {
-      "description": "@jscutlery utilities: not in monorepo:swc preset — explicit standalone group. @jscutlery/swc-angular excluded here so it stays in swc-deps (later rules win in Renovate)",
-      "groupName": "jscutlery-deps",
-      "matchPackageNames": ["/^@jscutlery//"],
-      "excludePackageNames": ["@jscutlery/swc-angular"]
-    },
-    {
       "description": "Jest test framework and utilities — jest-preset-angular bridges Jest and Angular so it must move with the Jest group",
       "matchPackageNames": [
         "@types/jest",
@@ -228,19 +222,9 @@
       "groupName": "postcss-deps"
     },
     {
-      "description": "OpenAPI code generation",
-      "matchPackageNames": ["/^@openapitools//"],
-      "groupName": "openapi-deps"
-    },
-    {
       "description": "OpenSeaDragon image viewer",
       "matchPackageNames": ["openseadragon", "@types/openseadragon"],
       "groupName": "openseadragon-deps"
-    },
-    {
-      "description": "JWT decode",
-      "matchPackageNames": ["jwt-decode"],
-      "groupName": "jwt-decode-deps"
     },
     {
       "description": "UUID",

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
     "enabled": true,
     "schedule": ["before 9am on Monday"]
   },
+  "ignorePaths": ["libs/**/package.json"],
   "vulnerabilityAlerts": {
     "enabled": false
   },
@@ -237,7 +238,7 @@
     },
     {
       "description": "JWT decode",
-      "matchPackageNames": ["jwt-decode", "@types/jwt-decode"],
+      "matchPackageNames": ["jwt-decode"],
       "groupName": "jwt-decode-deps"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,12 @@
       "enabled": false
     },
     {
+      "description": "ts-node: major updates disabled — each major drops older TypeScript versions; must align with frozen TypeScript",
+      "matchPackageNames": ["ts-node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "ESLint core + TypeScript ESLint: frozen until Angular/NX upgrade unlocks ESLint 9 flat config migration",
       "matchPackageNames": [
         "eslint",

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "commitMessageExtra": "{{#if currentVersion}}from {{currentVersion}} to {{newVersion}}{{/if}}",
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "behind-base-branch",
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Complete overhaul of \`renovate.json\` and complementary CI workflow fixes. The goal: maximum safe automation with explicit, documented constraints for everything that must be upgraded manually.

### Automerge strategy

- **`prConcurrentLimit: 2`** — one slot for the automerge chain, one for an open major PR; prevents an unmerged major from blocking the automated queue
- **`rebaseWhen: behind-base-branch`** scoped to automerge rules only — major PRs use the global `conflicted` default to avoid wasted CI runs while they sit unmerged waiting for a human decision
- **`semanticCommitType: chore`** — all Renovate commits use `chore(deps):` prefix; no accidental version bumps in release-please
- **Schedule: Mon–Fri before 5am (Europe/Zurich)** — PRs open overnight on weekdays; `platformAutomerge` merges them the moment CI passes, so the last batch (Fri 00:00–05:00) clears during Friday and nothing lands over the weekend unnoticed
- **Automerge tiers by dep type and age:**
  - Dev deps patch + minor → automerge immediately (no age guard)
  - Prod patch → automerge after 3-day age guard
  - Prod minor → automerge after 7-day age guard
  - All majors → PR opens automatically, **manual merge required**
- **GitHub Actions + Docker patch/minor → automerge** — explicit rule needed because `matchDepTypes: devDependencies` does not apply to non-npm managers

### Disabled rules (manual upgrade only)

| Packages | Reason |
|---|---|
| `@angular/*`, `@angular-devkit/*`, `@angular-eslint/*`, `@schematics/angular`, `nx`, `@nx/*`, `@nrwl/*` | `ng update` / `nx migrate` required |
| `typescript` | Tightly coupled to Angular/NX version |
| `ts-node` major | Each major drops older TypeScript; must align with frozen TS |
| `eslint`, `eslint-plugin-angular`, `@typescript-eslint/*` | Frozen until Angular/NX upgrade unlocks ESLint 9 flat-config migration |
| `eslint-plugin-*`, `eslint-config-airbnb-*`, `eslint-config-prettier`, `eslint-plugin-prettier` major | Coupled to frozen ESLint 8; a major dropping ESLint 8 support breaks the lint pipeline |
| `ng-packagr` | Coupled to Angular version |
| `@ngrx/*` | All ngrx packages are Angular-version coupled |
| `@types/node` | Must match Node.js version in CI and local toolchain |
| `.nvmrc` (nvm manager) major | Aligned manually with CI runners and `@types/node` |
| `ckeditor5-custom-build`, `@ckeditor/ckeditor5-angular` | Custom build tracked in DEV-6208 |
| `zone.js` minor + major | Maintenance mode — patches only |
| `cypress`, `jest` ecosystem, `storybook` ecosystem major | Version ceiling set by `@nx/*` peer deps; wait for `nx migrate` |
| `rxjs`, `ng-mocks`, `ngx-build-plus`, `@ngx-translate/*`, `@jscutlery/swc-angular` major | Must align with Angular major; upgrade only after `ng update` |

### Package groups

Packages that must update together in a single PR: `swc-deps`, `grafana-faro-deps`, `jsonld-deps`, `ngx-translate-deps`, `eslint-plugins-deps`, `jest-deps`, `prettier-deps`, `postcss-deps`, `openseadragon-deps`, `uuid-deps`, `test-coverage-deps`, `angular-ecosystem-deps`, `storybook-deps` (explicit because `@storybook/test-runner` is in a separate repo not covered by the `monorepo:storybook` preset).

### Security

- `vulnerabilityAlerts` disabled — Dependabot handles security advisories via the GitHub Security Advisory integration (CVEs linked to the Security tab with GHSA references, co-located with secret scanning and code scanning); `.github/dependabot.yml` kept with `open-pull-requests-limit: 0` so only security PRs are opened by Dependabot, not version updates
- `dependencyDashboardOSVVulnerabilitySummary: all` — OSV vulnerability summary visible on the Renovate Dependency Dashboard

### Other

- `ignorePaths: ["libs/**/package.json"]` — prevents duplicate update PRs for `json2typescript`, `jsonld`, and `tslib` that appear in sub-package.jsons under `libs/`; all versions are resolved by the root `package-lock.json`
- All CI workflows: hardcoded `node-version: X.Y.Z` replaced with `node-version-file: .nvmrc` — `.nvmrc` is the single source of truth for the Node.js version

Closes #3001 
Closes #3009
Closes #3011
Closes #3012

Linear: DEV-6217

🤖 Generated with [Claude Code](https://claude.com/claude-code)