### PR TITLE
chore: add auto-approve workflow for Renovate patch/minor PRs

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -1,0 +1,30 @@
+name: Auto-approve Renovate PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]'
+    steps:
+      # Renovate enables auto-merge only for rules with automerge:true (patch/minor).
+      # Major PRs (automerge:false) never set autoMergeRequest, so approval is skipped,
+      # keeping manual-review enforcement for majors intact.
+      - name: Check if Renovate requested auto-merge
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          result=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json autoMergeRequest \
+            --jq '.autoMergeRequest != null')
+          echo "automerge=$result" >> $GITHUB_OUTPUT
+
+      - uses: hmarr/auto-approve-action@v4
+        if: steps.check.outputs.automerge == 'true'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-approve-renovate.yml` to satisfy the required-review branch protection gate for Renovate's `platformAutomerge`
- Approval is skipped for major PRs by checking `autoMergeRequest` on the PR — Renovate only sets this when `automerge: true`, so majors (`automerge: false`) are never auto-approved
- No duplication of package rules logic; `renovate.json` remains the single source of truth for what gets automerged

## Test plan

- [ ] Merge this PR, then verify the next Renovate patch/minor PR gets auto-approved by `github-actions[bot]` and automerges once CI passes
- [ ] Verify a major Renovate PR does **not** get auto-approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)