### PR TITLE
chore(deps): upgrade @types/openseadragon to 3.0.10 with type compatibility fixes

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/open-sea-dragon.service.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/open-sea-dragon.service.ts
@@ -97,13 +97,13 @@ export class OpenSeaDragonService {
     viewer.addHandler('canvas-release', () => this._onCanvasRelease(viewer));
   }
 
-  private _onCanvasPress(event: OpenSeadragon.ViewerEvent, viewer: OpenSeadragon.Viewer): void {
+  private _onCanvasPress(event: OpenSeadragon.CanvasEvent, viewer: OpenSeadragon.Viewer): void {
     if (!this._drawing) {
       return;
     }
     const overlayElement: HTMLElement = document.createElement('div');
     overlayElement.style.background = this._OVERLAY_COLOR;
-    const viewportPos = viewer.viewport.pointFromPixel((event as OpenSeadragon.ViewerEvent).position!);
+    const viewportPos = viewer.viewport.pointFromPixel(event.position);
     viewer.addOverlay(overlayElement, new OpenSeadragon.Rect(viewportPos.x, viewportPos.y, 0, 0));
     this._rectangleInDrawing = {
       overlayElement,
@@ -111,11 +111,11 @@ export class OpenSeaDragonService {
     };
   }
 
-  private _onCanvasDrag(event: OpenSeadragon.ViewerEvent, viewer: OpenSeadragon.Viewer): void {
+  private _onCanvasDrag(event: OpenSeadragon.CanvasEvent, viewer: OpenSeadragon.Viewer): void {
     if (!this._drawing || !this._rectangleInDrawing) {
       return;
     }
-    const viewPortPos = viewer.viewport.pointFromPixel((event as OpenSeadragon.ViewerEvent).position!);
+    const viewPortPos = viewer.viewport.pointFromPixel(event.position);
     const diffX = viewPortPos.x - this._rectangleInDrawing.startPos.x;
     const diffY = viewPortPos.y - this._rectangleInDrawing.startPos.y;
     const location = new OpenSeadragon.Rect(

--- a/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/osd-drawer.service.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/osd-drawer.service.ts
@@ -49,11 +49,7 @@ export class OsdDrawerService implements OnDestroy {
 
     this._osd.viewer.addHandler(
       'canvas-click',
-      (
-        event: OpenSeadragon.ViewerEvent & {
-          originalTarget?: Element;
-        }
-      ) => {
+      (event: OpenSeadragon.CanvasClickEvent) => {
         event.preventDefaultAction = true;
         const target = event.originalTarget as SVGElement;
         const regionIri = target.getAttribute('data-region-iri');
@@ -303,7 +299,7 @@ export class OsdDrawerService implements OnDestroy {
     // Add the master SVG as a single overlay covering the entire image
     this._osd.viewer.addOverlay({
       id: this._masterOverlayId,
-      element: svgElement,
+      element: svgElement as unknown as HTMLElement,
       location: new OpenSeadragon.Rect(0, 0, 1, aspectRatio),
     });
     this._masterSvgOverlay = svgElement;

--- a/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/osd-drawer.service.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/osd-drawer.service.ts
@@ -47,19 +47,16 @@ export class OsdDrawerService implements OnDestroy {
     this._subscribeToSelectedRegion();
     this._subscribeToCreatedRectangle();
 
-    this._osd.viewer.addHandler(
-      'canvas-click',
-      (event: OpenSeadragon.CanvasClickEvent) => {
-        event.preventDefaultAction = true;
-        const target = event.originalTarget as SVGElement;
-        const regionIri = target.getAttribute('data-region-iri');
-        if (regionIri === this._currentHighlightedRegion) {
-          this._regionService.setHighlightedRegionClicked(regionIri);
-        } else {
-          this._regionService.selectRegion(regionIri);
-        }
+    this._osd.viewer.addHandler('canvas-click', (event: OpenSeadragon.CanvasClickEvent) => {
+      event.preventDefaultAction = true;
+      const target = event.originalTarget as SVGElement;
+      const regionIri = target.getAttribute('data-region-iri');
+      if (regionIri === this._currentHighlightedRegion) {
+        this._regionService.setHighlightedRegionClicked(regionIri);
+      } else {
+        this._regionService.selectRegion(regionIri);
       }
-    );
+    });
   }
 
   update(resource: ReadResource): void {

--- a/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/still-image-helper.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representations/still-image/still-image-helper.ts
@@ -11,7 +11,6 @@ import {
   RegionGeometry,
 } from '@dasch-swiss/dsp-js';
 import { handleXML } from '@dasch-swiss/vre/shared/app-common';
-import OpenSeadragon from 'openseadragon';
 import { Region } from '../region';
 import { GeometryForRegion } from './geometry-for-region';
 import { PolygonsForRegion } from './polygons-for-region.interface';
@@ -159,7 +158,7 @@ export class StillImageHelper {
     return w * h;
   }
 
-  static preventDefault(event: OpenSeadragon.ViewerEvent): void {
+  static preventDefault(event: { preventDefaultAction: boolean }): void {
     event.preventDefaultAction = true;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "@types/jest": "29.5.14",
         "@types/jsonld": "^1.5.6",
         "@types/node": "^22.18.11",
-        "@types/openseadragon": "3.0.0",
+        "@types/openseadragon": "^3.0.10",
         "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
@@ -17435,9 +17435,9 @@
       }
     },
     "node_modules/@types/openseadragon": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/openseadragon/-/openseadragon-3.0.0.tgz",
-      "integrity": "sha512-jN9pQmxEgGkld3lqKeyQLBLK40JJYl1r4zzHSzZF1BXVKDY6L4MKtKfnU5vOb0/DCL6GIJnIKsnkvr0Xdo20QA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/openseadragon/-/openseadragon-3.0.10.tgz",
+      "integrity": "sha512-nNVlu9PUNDVTudkSqVWhHtghCsyzQrJObEtN5zsVN2ghh5HYAC6U6xAcT9NQRfVfZVZkWXEYp2Hw7hQgwRxqgg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/jest": "29.5.14",
     "@types/jsonld": "^1.5.6",
     "@types/node": "^22.18.11",
-    "@types/openseadragon": "3.0.0",
+    "@types/openseadragon": "^3.0.10",
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",


### PR DESCRIPTION
## Summary

- Upgrades `@types/openseadragon` from `3.0.0` to `3.0.10`
- Fixes TypeScript compatibility breaks introduced by the new types

## Why the Renovate PR (#3024) was failing

In `3.0.10`, `ViewerEvent` became an empty interface — all fields (`position`, `preventDefaultAction`, `tracker`, etc.) were moved into specific event subtypes (`CanvasEvent`, `CanvasClickEvent`, `CanvasDragEvent`, etc.). This caused the Angular production build (`ng serve:production`) to fail with type errors, which appeared as an E2E timeout since the app never started on port 4200. Unit tests and linting weren't affected because they don't run full AOT type checking.

## Changes

- `open-sea-dragon.service.ts`: change `_onCanvasPress`/`_onCanvasDrag` params from `ViewerEvent` → `CanvasEvent` (which has `position`); drop redundant `as ViewerEvent` casts
- `osd-drawer.service.ts`: change `canvas-click` handler param from `ViewerEvent & { originalTarget?: Element }` → `CanvasClickEvent` (already has both fields); cast `SVGSVGElement` overlay element to satisfy the now-narrower `addOverlay` typing
- `still-image-helper.ts`: change `preventDefault` param from `ViewerEvent` → `{ preventDefaultAction: boolean }` structural type; remove unused `OpenSeadragon` import

Closes #3024

🤖 Generated with [Claude Code](https://claude.com/claude-code)