### PR TITLE
chore(deps): disable Node.js and npm major updates in package.json engines field

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -113,6 +113,20 @@
       "enabled": false
     },
     {
+      "description": "Node.js (package.json engines): major managed manually — same rationale as .nvmrc rule; engines field is a separate manager not covered by the nvm rule above",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "npm major: managed manually — not Angular/NX coupled but major npm releases have behavioural changes worth evaluating before adopting",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "CKEditor: custom build + Angular adapter tracked in DEV-6208; disable both until resolved",
       "matchPackageNames": [
         "ckeditor5-custom-build",


### PR DESCRIPTION
## Summary

- The existing `matchManagers: ["nvm"]` rule only disabled major Node.js updates coming from `.nvmrc`
- The `engines` field in `package.json` is read by a separate `npm` manager, leaving `node 22→24` and `npm 10→11` unblocked
- Adds two matching `enabled: false` rules to close the gap

## Why manual for both

- **Node.js major**: Angular 20 supports Node 18/20/22; Node 24 is too new and not yet validated against the Angular/NX support matrix
- **npm major**: Behavioural changes in major npm releases warrant a deliberate review before adoption

🤖 Generated with [Claude Code](https://claude.com/claude-code)