### PR TITLE
chore(deps): automerge pip_requirements patch/minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -308,6 +308,14 @@
       "automerge": true,
       "platformAutomerge": true,
       "rebaseWhen": "behind-base-branch"
+    },
+    {
+      "description": "Automerge pip_requirements patch/minor updates — docs tooling only (docs/requirements.txt); matchDepTypes does not apply to this manager so an explicit rule is needed",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "platformAutomerge": true,
+      "rebaseWhen": "behind-base-branch"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `matchDepTypes: ["devDependencies"/"dependencies"]` is an npm concept and does not apply to the `pip_requirements` manager
- Patch/minor updates to `docs/requirements.txt` (mkdocs tooling) were opening PRs but never getting `autoMergeRequest` set, so the auto-approve workflow correctly skipped them and they stalled
- Adds an explicit rule mirroring the existing github-actions/docker pattern

## Only manager affected

`pip_requirements` is the only non-npm/non-docker/non-github-actions manager currently detected in this repo (`docs/requirements.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)