### PR TITLE
chore: document CKEditor Renovate freeze rationale (DEV-6208)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -127,7 +127,7 @@
       "enabled": false
     },
     {
-      "description": "CKEditor: custom build + Angular adapter tracked in DEV-6208; disable both until resolved",
+      "description": "CKEditor: both packages frozen pending full architectural migration (DEV-6294). ckeditor5-custom-build has no newer tags so this freeze is a no-op for it. @ckeditor/ckeditor5-angular v6 is low-value, v7 would cause ckeditor-duplicated-modules, and v8+ requires replacing the custom build with the ckeditor5 npm package and rewriting the footnote plugin — tracked in DEV-6294.",
       "matchPackageNames": [
         "ckeditor5-custom-build",
         "@ckeditor/ckeditor5-angular"


### PR DESCRIPTION
[DEV-6208](https://linear.app/dasch/issue/DEV-6208/dsp-app-investigate-ckeditorckeditor5-angular-update-strategy)

## Summary
- Replaces the vague "tracked in DEV-6208; disable until resolved" comment with a precise explanation of why both packages are frozen
- `ckeditor5-custom-build` has no newer tags (v2.1.5 is the latest) so its Renovate freeze is a no-op
- `@ckeditor/ckeditor5-angular` is blocked because v7 causes `ckeditor-duplicated-modules` and v8+ requires a full architectural migration away from the custom build

## Changes
- `renovate.json` — updated description on the CKEditor package rule, referencing DEV-6294 for the follow-up migration work

## Test Plan
- No functional change; Renovate config only