### PR TITLE
chore(deps): disable uuid major until Angular 21 / Jest 30 migration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -168,6 +168,12 @@
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
+    {
+      "description": "uuid major: v10+ is ESM-only, incompatible with Jest v29 CJS transform — disable until Angular 21 migration brings jest-preset-angular v16 + Jest 30 with proper ESM support (tracked in DEV-6217)",
+      "matchPackageNames": ["uuid", "@types/uuid"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
 
     {
       "description": "Major updates: PRs open automatically but require manual merge. Timing matters — merging a major before a release or production deployment could introduce undetected breakage that poor test coverage would miss. Human decides when it is safe to merge.",


### PR DESCRIPTION
## Summary

- uuid v10+ is ESM-only; Jest v29 in CJS mode fails with `SyntaxError: Unexpected token 'export'`
- uuid v14 also requires `node: ^22.13.0`, incompatible with current Node 22.12.0 in CI
- Disables uuid major in Renovate (same pattern as CKEditor, ESLint majors) until `nx migrate` to Angular 21 brings jest-preset-angular v16 + Jest 30 with proper ESM support
- Follow-up tracked in [DEV-6296](https://linear.app/dasch/issue/DEV-6296)

Closes #3035

🤖 Generated with [Claude Code](https://claude.com/claude-code)