### PR TITLE
chore(deps): upgrade @faker-js/faker to v10 and fix breaking API usages

### DIFF
--- a/apps/dsp-app/cypress/e2e/logged-out-user/auth.cy.ts
+++ b/apps/dsp-app/cypress/e2e/logged-out-user/auth.cy.ts
@@ -28,7 +28,7 @@ describe('Authentication', () => {
 
     cy.get(po.loginButton).click();
 
-    cy.get(po.username).type(faker.internet.userName());
+    cy.get(po.username).type(faker.internet.username());
     cy.get(po.password).type(faker.internet.password());
     cy.get(po.submitButton).click();
 

--- a/apps/dsp-app/cypress/e2e/system-admin/data-model-class.cy.ts
+++ b/apps/dsp-app/cypress/e2e/system-admin/data-model-class.cy.ts
@@ -209,8 +209,8 @@ describe('Data Model Class', () => {
     cy.get(`[data-cy=${PropertyType.Dropdown}]`).should('be.visible').click();
 
     cy.get('[data-cy=name-input]').clear().type(faker.lorem.word());
-    cy.get('[data-cy=label-input] input').clear().type(faker.lorem.word(2));
-    cy.get('[data-cy=comment-textarea]').type(faker.lorem.word(5));
+    cy.get('[data-cy=label-input] input').clear().type(faker.lorem.word({ length: 2 }));
+    cy.get('[data-cy=comment-textarea]').type(faker.lorem.word({ length: 5 }));
     cy.get('[data-cy=object-attribute-list]').click(); // open dropdown
 
     cy.get('mat-option').contains(listLabel).scrollIntoView().should('be.visible').click();

--- a/apps/dsp-app/cypress/e2e/system-admin/lists.cy.ts
+++ b/apps/dsp-app/cypress/e2e/system-admin/lists.cy.ts
@@ -40,7 +40,7 @@ describe('Lists', () => {
   it('user can edit a list', () => {
     const data = {
       label: faker.lorem.words(2),
-      comment: faker.lorem.word(2),
+      comment: faker.lorem.word({ length: 2 }),
     };
     cy.intercept('PUT', '/admin/lists/*').as('editRequest');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@angular/compiler-cli": "20.2.4",
         "@angular/language-service": "20.2.4",
         "@cypress/code-coverage": "^3.14.7",
-        "@faker-js/faker": "^8.3.1",
+        "@faker-js/faker": "^10.4.0",
         "@jscutlery/swc-angular": "^0.22.0",
         "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
         "@nx/cypress": "21.5.1",
@@ -6749,9 +6749,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
-      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
       "dev": true,
       "funding": [
         {
@@ -6761,8 +6761,8 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@fastify/busboy": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@angular/compiler-cli": "20.2.4",
     "@angular/language-service": "20.2.4",
     "@cypress/code-coverage": "^3.14.7",
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^10.4.0",
     "@jscutlery/swc-angular": "^0.22.0",
     "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
     "@nx/cypress": "21.5.1",


### PR DESCRIPTION
## Summary

- Bumps `@faker-js/faker` from `8.4.1` to `10.4.0`
- Updates `package-lock.json` accordingly
- Fixes 4 call sites that use APIs removed in v9/v10:
  - `faker.internet.userName()` → `faker.internet.username()` (`auth.cy.ts`)
  - `faker.lorem.word(2)` → `faker.lorem.word({ length: 2 })` (`lists.cy.ts`, `data-model-class.cy.ts`)
  - `faker.lorem.word(5)` → `faker.lorem.word({ length: 5 })` (`data-model-class.cy.ts`)

Closes #3040

## Test plan

- [ ] E2E tests pass (no more `TypeError` on renamed/removed faker APIs)
- [ ] No other faker usages in the codebase are affected (all other calls use stable APIs: `lorem.words`, `lorem.sentence`, `lorem.word()` without args, `string.alpha`, `string.alphanumeric`, `number.int`, `company.name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)