### PR TITLE
fix(dsp-js): switch to npm trusted publishers (OIDC)

### DIFF
--- a/.github/workflows/release-dsp-js.yml
+++ b/.github/workflows/release-dsp-js.yml
@@ -5,25 +5,26 @@ on:
     tags:
       - 'dsp-js-v*'
 
-env:
-
 jobs:
   publish:
     name: Build and publish dsp-js to NPM
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # Required for provenance
+      id-token: write  # Required for OIDC trusted publishers
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node.js ${{ env.NodeVersion }}
+      - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+
+      - name: Upgrade npm for trusted publishers
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit
@@ -35,8 +36,7 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish dist/libs/dsp-js --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_DASCHBOT }}
+        # No NODE_AUTH_TOKEN needed - OIDC authentication via trusted publishers
 
   notification:
     name: Google chat notification about release


### PR DESCRIPTION
## Summary
- Remove empty `env:` block causing workflow file errors
- Add npm upgrade step (Node 22.x bundles npm 10.9.7, **trusted publishers need 11.5.1+**)
- Remove `NODE_AUTH_TOKEN` secret (using OIDC trusted publishers instead)

Since trusted publishers have already been configured on npm for this workflow file, this PR switches to OIDC authentication which:
- Eliminates the need for long-lived npm tokens
- Uses short-lived, cryptographically-signed tokens specific to the workflow
- Automatically includes provenance attestations

## Test plan
- [x] Merge this PR
- [x] Merge the pending release PR #2934 (dsp-js 12.0.0)

Related to Linear project: move-js-lib-to-dsp-das