### PR TITLE
fix(deps): remove duplicate brace in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -161,7 +161,6 @@
       "enabled": false
     },
     {
-    {
       "description": "@jscutlery/swc-angular: fully disabled — bridges frozen Angular with SWC; package is at v0.x so the major-disable rule is a no-op, and any update is a coordinated toolchain decision",
       "matchPackageNames": ["@jscutlery/swc-angular"],
       "enabled": false


### PR DESCRIPTION
## Summary

- Removes a stray opening brace introduced in #3048 that made `renovate.json` invalid JSON
- Renovate detected the error and halted all PRs (issue #3051)

Closes #3051

🤖 Generated with [Claude Code](https://claude.com/claude-code)