### PR TITLE
fix(dsp-js): remove registry-url for OIDC authentication

### DIFF
--- a/.github/workflows/release-dsp-js.yml
+++ b/.github/workflows/release-dsp-js.yml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+          # Note: registry-url is NOT set here to allow OIDC authentication
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit
@@ -33,8 +33,7 @@ jobs:
 
       - name: Publish to NPM
         run: npx npm@11 publish dist/libs/dsp-js --access public --provenance
-        # Uses npx to run npm@11 which supports trusted publishers
-        # No NODE_AUTH_TOKEN needed - OIDC authentication via trusted publishers
+        # OIDC authentication via trusted publishers - no token needed
 
   notification:
     name: Google chat notification about release


### PR DESCRIPTION
## Summary
The previous publish attempts failed with `404 Not Found` because OIDC authentication wasn't working.

**Root cause:** `actions/setup-node` with `registry-url` creates an `.npmrc` file that expects `NODE_AUTH_TOKEN`. Since we removed the token (to use OIDC instead), authentication fails.

**Fix:** Remove `registry-url` from setup-node to allow npm to auto-detect the OIDC environment and use trusted publishers.

## Test plan
After merging:
1. Delete tag `dsp-js-v12.0.0`
2. Recreate tag pointing to the merge commit
3. Verify workflow succeeds and package is published to npm
