### PR TITLE
chore: enforce chore(deps): commit prefix for all Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   ],
   "extends": ["config:recommended"],
   "semanticCommitType": "chore",
+  "commitMessagePrefix": "chore(deps):",
   "timezone": "Europe/Zurich",
   "schedule": ["before 5am on monday through friday"],
   "prConcurrentLimit": 2,


### PR DESCRIPTION
## Summary

- Adds `commitMessagePrefix: "chore(deps):"` to `renovate.json` to hard-override the commit/PR title prefix for all Renovate-generated PRs
- `semanticCommitType: "chore"` was already present but auto-detection from existing commits could still produce `fix(deps):` — the explicit prefix removes that ambiguity

🤖 Generated with [Claude Code](https://claude.com/claude-code)