### PR TITLE
chore: optimise CI workflow runs — skip checks where not applicable (DEV-6264)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,91 @@ concurrency:
 
 jobs:
 
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      automation_skip: ${{ steps.detect.outputs.automation_skip }}
+      only_workflows: ${{ steps.detect.outputs.only_workflows }}
+      only_pkg: ${{ steps.detect.outputs.only_pkg }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # full history of the pushed ref; needed for merge-base
+      - id: detect
+        # Pass GitHub context via `env:` (NOT inline `${{ ... }}` in the script
+        # body) — inline interpolation is a documented shell-injection vector:
+        # a crafted commit message could break out of the string. Inside bash,
+        # references are normal `$VAR` expansions and are safe.
+        # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.username }}
+          GH_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          # Existing daschbot / release-please skip — consolidated.
+          # COMMIT_MSG / COMMIT_AUTHOR are empty on PR events (not used by ci.yml
+          # today, but defensively preserved). Empty strings don't match either
+          # pattern, so automation_skip=false — same outcome as the prior
+          # null-guard (head_commit == null || !startsWith(...)).
+          if [[ "$COMMIT_MSG" == "chore(main): release"* || "$COMMIT_AUTHOR" == "daschbot" ]]; then
+            echo "automation_skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "automation_skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Tag and direct-main pushes: full pipeline (no path-based skip).
+          if [[ "$GH_REF" == refs/tags/* ]] || [ "$GH_REF" = "refs/heads/main" ]; then
+            echo "only_workflows=false" >> "$GITHUB_OUTPUT"
+            echo "only_pkg=false"       >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Feature branch push: fetch main and three-dot-diff.
+          # No --depth on the fetch — the merge-base may be far back in main's
+          # history; --depth=1 would silently break for any branch even slightly
+          # behind main. Cost: a few seconds, runs once per CI invocation.
+          if ! git fetch --no-tags origin main 2>/dev/null; then
+            echo "::warning::could not fetch origin/main; running full pipeline"
+            echo "only_workflows=false" >> "$GITHUB_OUTPUT"
+            echo "only_pkg=false"       >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          DIFF=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
+          if [ -z "$DIFF" ]; then
+            # No diff (rare for push events) — fail-safe.
+            echo "only_workflows=false" >> "$GITHUB_OUTPUT"
+            echo "only_pkg=false"       >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # only_workflows: every changed file is under .github/workflows/
+          if echo "$DIFF" | grep -qv '^\.github/workflows/'; then
+            echo "only_workflows=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "only_workflows=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+          # only_pkg: every changed file is package.json or package-lock.json
+          if echo "$DIFF" | grep -qvE '^(package\.json|package-lock\.json)$'; then
+            echo "only_pkg=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "only_pkg=true"  >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     name: DSP-APP Linting
-    runs-on: ubuntu-latest
+    needs: [changes]
     if: |
-      (github.event.head_commit == null ||
-       !startsWith(github.event.head_commit.message, 'chore(main): release')) &&
-      (github.event.head_commit == null ||
-       github.event.head_commit.author.username != 'daschbot')
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.automation_skip == 'false' &&
+      needs.changes.outputs.only_workflows == 'false'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -39,12 +116,12 @@ jobs:
 
   test:
     name: DSP-APP Unit tests
-    runs-on: ubuntu-latest
+    needs: [changes]
     if: |
-      (github.event.head_commit == null ||
-       !startsWith(github.event.head_commit.message, 'chore(main): release')) &&
-      (github.event.head_commit == null ||
-       github.event.head_commit.author.username != 'daschbot')
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.automation_skip == 'false' &&
+      needs.changes.outputs.only_workflows == 'false'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -66,6 +143,7 @@ jobs:
         env:
           TZ: Europe/Zurich
       - name: Upload coverage reports to Codecov
+        if: needs.changes.outputs.only_pkg == 'false'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -76,12 +154,12 @@ jobs:
 
   dsp-app-e2e-tests:
     name: DSP-APP E2E tests (${{ matrix.runner }})
-    runs-on: ubuntu-latest
+    needs: [changes]
     if: |
-      (github.event.head_commit == null ||
-       !startsWith(github.event.head_commit.message, 'chore(main): release')) &&
-      (github.event.head_commit == null ||
-       github.event.head_commit.author.username != 'daschbot')
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.automation_skip == 'false' &&
+      needs.changes.outputs.only_workflows == 'false'
+    runs-on: ubuntu-latest
     strategy:
       # Run all runners to completion even if one fails, so all failures are visible
       fail-fast: false
@@ -152,12 +230,16 @@ jobs:
 
   dsp-app-e2e-tests-status:
     name: DSP-APP E2E tests
-    needs: dsp-app-e2e-tests
+    needs: [changes, dsp-app-e2e-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check matrix result
+      - name: Verify CI integrity and aggregate matrix result
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "::error::changes job failed (${{ needs.changes.result }}); refusing to report green"
+            exit 1
+          fi
           result="${{ needs.dsp-app-e2e-tests.result }}"
           if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
             echo "One or more e2e matrix runners failed (result: $result)"
@@ -166,15 +248,15 @@ jobs:
 
   check-openapi-sync:
     name: Check OpenAPI Spec is Up-to-Date
+    needs: [changes]
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     if: |
-      (github.event.head_commit == null ||
-       !startsWith(github.event.head_commit.message, 'chore(main): release')) &&
-      (github.event.head_commit == null ||
-       github.event.head_commit.author.username != 'daschbot')
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.automation_skip == 'false' &&
+      needs.changes.outputs.only_workflows == 'false'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -246,12 +328,12 @@ jobs:
 
   storybook-tests:
     name: Storybook Interaction Tests
-    runs-on: ubuntu-latest
+    needs: [changes]
     if: |
-      (github.event.head_commit == null ||
-       !startsWith(github.event.head_commit.message, 'chore(main): release')) &&
-      (github.event.head_commit == null ||
-       github.event.head_commit.author.username != 'daschbot')
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.automation_skip == 'false' &&
+      needs.changes.outputs.only_workflows == 'false'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -280,12 +362,12 @@ jobs:
 
   docs-build-test:
     name: Docs Build Test
-    runs-on: ubuntu-latest
+    needs: [changes]
     if: |
-      (github.event.head_commit == null ||
-       !startsWith(github.event.head_commit.message, 'chore(main): release')) &&
-      (github.event.head_commit == null ||
-       github.event.head_commit.author.username != 'daschbot')
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.automation_skip == 'false' &&
+      needs.changes.outputs.only_workflows == 'false'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         env:
           TZ: Europe/Zurich
       - name: Upload coverage reports to Codecov
-        if: needs.changes.outputs.only_pkg == 'false'
+        if: needs.changes.result == 'success' && needs.changes.outputs.only_pkg == 'false'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,23 @@ jobs:
 
           # only_workflows: every changed file is under .github/workflows/
           if echo "$DIFF" | grep -qv '^\.github/workflows/'; then
-            echo "only_workflows=false" >> "$GITHUB_OUTPUT"
+            only_workflows="false"
           else
-            echo "only_workflows=true"  >> "$GITHUB_OUTPUT"
+            only_workflows="true"
           fi
+
+          # Author-based override: only bot-authored workflow-only PRs
+          # benefit from the skip. Human edits to workflow files often
+          # change job logic that needs validating in the same PR — force
+          # the full pipeline so the change is exercised.
+          if [ "$only_workflows" = "true" ]; then
+            case "$COMMIT_AUTHOR" in
+              renovate*|dependabot*) ;;       # bot — keep skip
+              *) only_workflows="false" ;;    # human — force full pipeline
+            esac
+          fi
+
+          echo "only_workflows=$only_workflows" >> "$GITHUB_OUTPUT"
 
           # only_pkg: every changed file is package.json or package-lock.json
           if echo "$DIFF" | grep -qvE '^(package\.json|package-lock\.json)$'; then

--- a/.github/workflows/cloud-run-pr-preview.yml
+++ b/.github/workflows/cloud-run-pr-preview.yml
@@ -122,9 +122,10 @@ jobs:
 
   deploy-preview-manual:
     name: Build and deploy manual PR preview
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      !startsWith(github.head_ref, 'release-please-')
+    # No release-please head-ref guard here: github.head_ref is empty on
+    # workflow_dispatch (only set for pull_request events), so the check would
+    # be a no-op. Manual dispatch is intentionally opt-in.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     concurrency:
       group: cloud-run-preview-pr-${{ github.ref_name }}

--- a/.github/workflows/cloud-run-pr-preview.yml
+++ b/.github/workflows/cloud-run-pr-preview.yml
@@ -16,7 +16,8 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.head_ref, 'release-please-')
     runs-on: ubuntu-latest
     concurrency:
       group: cloud-run-preview-pr-${{ github.event.pull_request.number }}
@@ -121,7 +122,9 @@ jobs:
 
   deploy-preview-manual:
     name: Build and deploy manual PR preview
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      !startsWith(github.head_ref, 'release-please-')
     runs-on: ubuntu-latest
     concurrency:
       group: cloud-run-preview-pr-${{ github.ref_name }}


### PR DESCRIPTION
[DEV-6264](https://linear.app/dasch/issue/DEV-6264)

## Summary

- Adds a small bash `changes` job to `ci.yml` that emits three booleans (`automation_skip`, `only_workflows`, `only_pkg`) via `git diff origin/main...HEAD`. Every other job in `ci.yml` gates on those booleans, replacing the 6× duplicated `chore(main): release` / `daschbot` `if:` block.
- `only_workflows` skip is gated on bot authorship (`renovate*` / `dependabot*`); human edits to workflow files always run the full pipeline so the change is validated in the same PR.
- Codecov upload step gates on `only_pkg == 'false'` so npm dep-bump PRs (root `package.json` + `package-lock.json` only) skip the upload.
- `cloud-run-pr-preview.yml` skips `deploy-preview` on `release-please-*` head refs (`chore(main): release dsp-js` no longer triggers an unused Cloud Run deploy).
- No new third-party action introduced. GitHub context (commit message, author, ref) passed via `env:` block to avoid shell injection.

## Changes

**`.github/workflows/ci.yml`**
- New `changes` job: `actions/checkout` with `fetch-depth: 0`, then bash that fetches `origin/main` (no depth limit) and runs `git diff --name-only origin/main...HEAD` (three-dot, walks merge-base internally). Tag pushes and direct-main pushes short-circuit to full pipeline (`force_full` semantic).
- `only_workflows` is set to `true` only when every file is under `.github/workflows/` AND the commit author matches `renovate*` or `dependabot*`. Human-authored workflow edits keep `only_workflows=false` so the full pipeline runs.
- Every existing job (`lint`, `test`, `dsp-app-e2e-tests`, `check-openapi-sync`, `storybook-tests`, `docs-build-test`) adds `needs: [changes]` and a unified gate: `needs.changes.result == 'success' && automation_skip == 'false' && only_workflows == 'false'`.
- Aggregator (`dsp-app-e2e-tests-status`) gains `needs: [changes, dsp-app-e2e-tests]` and refuses to report green when `changes.result != 'success'`.
- Codecov upload step in `test` job gates on `needs.changes.result == 'success' && only_pkg == 'false'`.

**`.github/workflows/cloud-run-pr-preview.yml`**
- `deploy-preview`: adds `&& !startsWith(github.head_ref, 'release-please-')` to the existing `if:`.
- `deploy-preview-manual`: unchanged. A head-ref guard would be a no-op on `workflow_dispatch` since `head_ref` is empty there; manual dispatch is intentional opt-in.

## Test Plan

Smoke-tests (run from a feature branch):

- [ ] Renovate `chore(deps):` PR touching only `.github/workflows/foo.yml` → only `changes` and `dsp-app-e2e-tests-status` run; everything else `skipped`; aggregator green.
- [ ] **Human** PR touching only `.github/workflows/ci.yml` → full pipeline runs (`only_workflows` falls back to `false` for non-bot authors).
- [ ] Renovate npm PR (only `package.json` + `package-lock.json`) → `lint`/`test`/e2e/storybook/openapi/docs run; **codecov upload step skipped**.
- [ ] PR touching only `apps/dsp-app/src/some.ts` → full pipeline.
- [ ] Mixed `.github/workflows/*.yml` + `apps/**` change in same PR → full pipeline.
- [ ] Branch ≥10 commits behind `main` with workflow-only Renovate change → `only_workflows=true` still detected (verifies merge-base over full main history).
- [ ] Tag push (annotated) → full pipeline (`force_full`).
- [ ] Branch named `release-please--branches--main--components--dsp-js` with `libs/dsp-js/CHANGELOG.md` change → `cloud-run-pr-preview.deploy-preview` does not trigger.

Plan: `dasch-specs/specs/2026-04-27-optimise-ci-workflow-runs-skip-checks/01-feat-optimise-ci-workflow-runs-plan.md` (status: `reviewed(2)`, local-only).

## Follow-up

[DEV-6311](https://linear.app/dasch/issue/DEV-6311) — supply-chain consolidation: replace thin-wrapper third-party actions (`peter-evans/*`, `hmarr/auto-approve-action`, `deepakputhraya/action-pr-title@master`) with native `gh` CLI. Backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)