### PR TITLE
fix(ci): pin send-google-chat-webhook to v0.0.4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - name: Send notification to google chat room "DSP releases"
-        uses: google-github-actions/send-google-chat-webhook@v0
+        uses: google-github-actions/send-google-chat-webhook@v0.0.4
         with:
           webhook_url: ${{ secrets.GOOGLE_CHAT_DSP_RELEASES_WEBHOOK_URL }}
           mention: '<users/all>'

--- a/.github/workflows/release-dsp-js.yml
+++ b/.github/workflows/release-dsp-js.yml
@@ -44,7 +44,7 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#dsp-js-v}" >> $GITHUB_OUTPUT
       - name: Send notification to google chat room "DSP releases"
-        uses: google-github-actions/send-google-chat-webhook@v0
+        uses: google-github-actions/send-google-chat-webhook@v0.0.4
         with:
           webhook_url: ${{ secrets.GOOGLE_CHAT_DSP_RELEASES_WEBHOOK_URL }}
           mention: '<users/all>'


### PR DESCRIPTION
## Summary
- The `release-dsp-js` workflow's notification job referenced `google-github-actions/send-google-chat-webhook@v0`, but that action does not publish a floating `v0` tag — only specific patch tags (`v0.0.1` … `v0.0.4`).
- The job failed at *Set up job* with: `Unable to resolve action google-github-actions/send-google-chat-webhook@v0, unable to find version v0` ([failed run](https://github.com/dasch-swiss/dsp-app/actions/runs/25001046126/job/73211722745)).
- Pin to the latest published release `v0.0.4`.

## Test plan
- [ ] Next `dsp-js-v*` tag triggers `Release dsp-js` workflow and the notification job resolves the action and posts to the Google Chat room.