### PR TITLE
chore(ci): reduce fetch-depth in changes and e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0   # full history of the pushed ref; needed for merge-base
+          fetch-depth: 2   # shallow; depth-2 covers merge-base for branches off latest main
       - id: detect
         # Pass GitHub context via `env:` (NOT inline `${{ ... }}` in the script
         # body) — inline interpolation is a documented shell-injection vector:
@@ -187,8 +187,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # gets additionally all tags which we need
       - name: Set up Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- `changes` job: `fetch-depth` 0 → 2. Branches off latest main always have their merge-base within 1 commit; the existing fallback (`could not fetch origin/main → run full pipeline`) covers the rare deep-branch edge case.
- `dsp-app-e2e-tests` job: remove `fetch-depth: 0` entirely. The full history was never needed — no git tags or history are used in the build (version comes from `package.json`), and the comment claiming otherwise was incorrect.

## Test plan

- [x] CI passes on this PR — `changes` job correctly detects path changes with depth 2
- [ ] E2E jobs complete with faster checkout (shallow clone instead of full history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)