### PR TITLE
chore(renovate): automerge lock file maintenance and manage webpack ecosystem

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,10 @@
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 9am on Monday"]
+    "schedule": ["before 9am on Monday"],
+    "automerge": true,
+    "platformAutomerge": true,
+    "rebaseWhen": "behind-base-branch"
   },
   "ignorePaths": ["libs/**/package.json"],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -181,6 +181,12 @@
       "enabled": false
     },
     {
+      "description": "webpack ecosystem: major version is pinned by @angular-devkit/build-angular — disable major updates until ng update lifts the constraint",
+      "matchPackageNames": ["webpack", "webpack-dev-middleware", "webpack-dev-server", "webpack-merge"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "uuid major: v10+ is ESM-only, incompatible with Jest v29 CJS transform — disable until Angular 21 migration brings jest-preset-angular v16 + Jest 30 with proper ESM support (tracked in DEV-6217)",
       "matchPackageNames": ["uuid", "@types/uuid"],
       "matchUpdateTypes": ["major"],
@@ -252,6 +258,11 @@
       "description": "PostCSS + autoprefixer (autoprefixer not in postcss monorepo preset)",
       "matchPackageNames": ["autoprefixer", "/^postcss/"],
       "groupName": "postcss-deps"
+    },
+    {
+      "description": "webpack ecosystem — exact-pinned by @angular-devkit/build-angular; must move together to stay deduplicated",
+      "matchPackageNames": ["webpack", "webpack-dev-middleware", "webpack-dev-server", "webpack-merge"],
+      "groupName": "webpack-deps"
     },
     {
       "description": "OpenSeaDragon image viewer",


### PR DESCRIPTION
## Summary

- Adds `automerge`, `platformAutomerge`, and `rebaseWhen: "behind-base-branch"` to `lockFileMaintenance`
- Disables major updates for the webpack ecosystem (coupled to Angular's exact pins)
- Groups webpack ecosystem packages so patch/minor updates land as one PR

## Lock file maintenance automerge

Lock file maintenance refreshes transitive dep versions within already-approved semver ranges — equivalent to merging many patch updates simultaneously, which are already automerged. There is no human decision to make when CI passes.

`rebaseWhen: "behind-base-branch"` prevents the manual `@renovate rebase` dance: the global setting is `"conflicted"`, meaning the PR only rebases on actual merge conflicts. Every time another PR touches `package-lock.json`, the lock file maintenance PR goes stale and requires manual intervention. With `behind-base-branch` it tracks main automatically.

## webpack ecosystem rules

`@angular-devkit/build-angular` exact-pins webpack, webpack-dev-middleware, webpack-dev-server and webpack-merge. These overrides were added in #3083 to prevent npm from creating nested webpack installs (which break Storybook's Angular build with an `instanceof Compilation` error). Renovate would otherwise manage these override entries independently and could bump a major version out of sync with Angular. The new rules:

- Disable major updates (must align with Angular — unlock after `ng update`)
- Group patch/minor updates into one PR so they land together

## Context

Exposed when #3083 landed and immediately conflicted with the open lock file maintenance PR, requiring a manual `@renovate rebase`.