### PR TITLE
feat(download-dialog): warn user when CSV export may take a long time

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -409,7 +409,8 @@
         "includeArkUrlsExplanation": "Fügt eine ARK-URL-Spalte als erste Spalte in der CSV für jede Ressource hinzu.",
         "downloadCsv": "CSV herunterladen",
         "downloadSuccess": "CSV erfolgreich heruntergeladen.",
-        "downloadError": "Fehler beim Herunterladen der CSV. Bitte versuchen Sie es erneut."
+        "downloadError": "Fehler beim Herunterladen der CSV. Bitte versuchen Sie es erneut.",
+        "largeExportWarning": "Dieser Export enthält {{count}} Ressourcen und kann mehrere Minuten dauern. Bitte lassen Sie diesen Tab geöffnet."
       }
     }
   },

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -409,7 +409,8 @@
         "includeArkUrlsExplanation": "Adds an ARK URL column as the first column in the CSV for each resource.",
         "downloadCsv": "Download CSV",
         "downloadSuccess": "CSV downloaded successfully.",
-        "downloadError": "Failed to download CSV. Please try again."
+        "downloadError": "Failed to download CSV. Please try again.",
+        "largeExportWarning": "This export contains {{count}} resources and may take several minutes. Please keep this tab open."
       }
     }
   },

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -409,7 +409,8 @@
         "includeArkUrlsExplanation": "Ajoute une colonne ARK URL en première position dans le CSV pour chaque ressource.",
         "downloadCsv": "Télécharger CSV",
         "downloadSuccess": "CSV téléchargé avec succès.",
-        "downloadError": "Échec du téléchargement du CSV. Veuillez réessayer."
+        "downloadError": "Échec du téléchargement du CSV. Veuillez réessayer.",
+        "largeExportWarning": "Cet export contient {{count}} ressources et peut prendre plusieurs minutes. Veuillez garder cet onglet ouvert."
       }
     }
   },

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -409,7 +409,8 @@
         "includeArkUrlsExplanation": "Aggiunge una colonna ARK URL come prima colonna nel CSV per ogni risorsa.",
         "downloadCsv": "Scarica CSV",
         "downloadSuccess": "CSV scaricato con successo.",
-        "downloadError": "Impossibile scaricare il CSV. Riprova."
+        "downloadError": "Impossibile scaricare il CSV. Riprova.",
+        "largeExportWarning": "Questo export contiene {{count}} risorse e potrebbe richiedere diversi minuti. Tieni aperta questa scheda."
       }
     }
   },

--- a/apps/dsp-app/src/assets/i18n/rm.json
+++ b/apps/dsp-app/src/assets/i18n/rm.json
@@ -409,7 +409,8 @@
         "includeArkUrlsExplanation": "Adds an ARK URL column as the first column in the CSV for each resource.",
         "downloadCsv": "Download CSV",
         "downloadSuccess": "CSV downloaded successfully.",
-        "downloadError": "Failed to download CSV. Please try again."
+        "downloadError": "Failed to download CSV. Please try again.",
+        "largeExportWarning": "This export contains {{count}} resources and may take several minutes. Please keep this tab open."
       }
     }
   },

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog.component.spec.ts
@@ -4,8 +4,8 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { PropertyDefinition, ResourceClassDefinitionWithAllLanguages } from '@dasch-swiss/dsp-js';
 import { PropertyInfoValues } from '@dasch-swiss/vre/shared/app-common';
 import { provideTranslateService, TranslateService } from '@ngx-translate/core';
-import { CSV_EXPORT_LARGE_THRESHOLD, DownloadDialogComponent, DownloadDialogData } from './download-dialog.component';
 import { DownloadDialogResourcesTabComponent } from './download-dialog-resources-tab.component';
+import { CSV_EXPORT_LARGE_THRESHOLD, DownloadDialogComponent, DownloadDialogData } from './download-dialog.component';
 
 @Component({ selector: 'app-download-dialog-properties-tab', standalone: true, template: '' })
 class StubDownloadDialogResourcesTabComponent {}

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog.component.spec.ts
@@ -1,10 +1,14 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { PropertyDefinition, ResourceClassDefinitionWithAllLanguages } from '@dasch-swiss/dsp-js';
 import { PropertyInfoValues } from '@dasch-swiss/vre/shared/app-common';
 import { provideTranslateService, TranslateService } from '@ngx-translate/core';
-import { DownloadDialogComponent, DownloadDialogData } from './download-dialog.component';
+import { CSV_EXPORT_LARGE_THRESHOLD, DownloadDialogComponent, DownloadDialogData } from './download-dialog.component';
+import { DownloadDialogResourcesTabComponent } from './download-dialog-resources-tab.component';
+
+@Component({ selector: 'app-download-dialog-properties-tab', standalone: true, template: '' })
+class StubDownloadDialogResourcesTabComponent {}
 
 describe('DownloadDialogComponent', () => {
   let component: DownloadDialogComponent;
@@ -182,5 +186,64 @@ describe('DownloadDialogComponent', () => {
       expect(data.resClass.id).toBe('http://custom.org/ontology/CustomClass');
       expect(data.resClass.label).toBe('Custom Class');
     });
+  });
+});
+
+describe('DownloadDialogComponent: large export warning', () => {
+  const mockResClass = {
+    id: 'http://example.org/ontology/ResourceClass',
+    label: 'Test Resource Class',
+  } as ResourceClassDefinitionWithAllLanguages;
+
+  const mockProperty: PropertyInfoValues = {
+    propDef: { id: 'prop-1', label: 'Title' } as PropertyDefinition,
+    guiDef: {} as any,
+    values: [],
+  };
+
+  const mockDialogRef = { close: jest.fn() };
+
+  const createFixture = async (resourceCount: number) => {
+    const data: DownloadDialogData = { resClass: mockResClass, resourceCount, properties: [mockProperty] };
+
+    await TestBed.configureTestingModule({
+      imports: [DownloadDialogComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        provideTranslateService(),
+        TranslateService,
+      ],
+    })
+      .overrideComponent(DownloadDialogComponent, {
+        remove: { imports: [DownloadDialogResourcesTabComponent] },
+        add: { imports: [StubDownloadDialogResourcesTabComponent] },
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(DownloadDialogComponent);
+    fixture.detectChanges();
+    return fixture;
+  };
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('shows warning when resourceCount exceeds threshold', async () => {
+    const fixture = await createFixture(CSV_EXPORT_LARGE_THRESHOLD + 1);
+    const warning = fixture.nativeElement.querySelector('[data-cy="large-export-warning"]');
+    expect(warning).toBeTruthy();
+  });
+
+  it('does not show warning when resourceCount equals threshold', async () => {
+    const fixture = await createFixture(CSV_EXPORT_LARGE_THRESHOLD);
+    const warning = fixture.nativeElement.querySelector('[data-cy="large-export-warning"]');
+    expect(warning).toBeFalsy();
+  });
+
+  it('does not show warning when resourceCount is below threshold', async () => {
+    const fixture = await createFixture(CSV_EXPORT_LARGE_THRESHOLD - 1);
+    const warning = fixture.nativeElement.querySelector('[data-cy="large-export-warning"]');
+    expect(warning).toBeFalsy();
   });
 });

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog.component.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog.component.ts
@@ -1,10 +1,13 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogContent, MatDialogRef } from '@angular/material/dialog';
+import { MatIcon } from '@angular/material/icon';
 import { ResourceClassDefinitionWithAllLanguages } from '@dasch-swiss/dsp-js';
 import { PropertyInfoValues } from '@dasch-swiss/vre/shared/app-common';
 import { DialogHeaderComponent } from '@dasch-swiss/vre/ui/ui';
 import { TranslatePipe } from '@ngx-translate/core';
 import { DownloadDialogResourcesTabComponent } from './download-dialog-resources-tab.component';
+
+export const CSV_EXPORT_LARGE_THRESHOLD = 1_000;
 
 export interface DownloadDialogData {
   resClass: ResourceClassDefinitionWithAllLanguages;
@@ -18,6 +21,14 @@ export interface DownloadDialogData {
     <app-dialog-header
       [title]="'pages.dataBrowser.downloadDialog.title' | translate"
       [subtitle]="'pages.dataBrowser.downloadDialog.resourcesAvailable' | translate: { count: data.resourceCount }" />
+    @if (data.resourceCount > largeThreshold) {
+      <div
+        data-cy="large-export-warning"
+        style="display: flex; align-items: flex-start; gap: 8px; padding: 12px 24px; background: #fff3e0; color: #e65100">
+        <mat-icon style="flex-shrink: 0">warning</mat-icon>
+        <span>{{ 'pages.dataBrowser.downloadDialog.largeExportWarning' | translate: { count: data.resourceCount } }}</span>
+      </div>
+    }
     <div mat-dialog-content style="max-height: 90vh">
       <app-download-dialog-properties-tab
         [properties]="data.properties"
@@ -27,9 +38,11 @@ export interface DownloadDialogData {
     </div>
   `,
   standalone: true,
-  imports: [DialogHeaderComponent, TranslatePipe, MatDialogContent, DownloadDialogResourcesTabComponent],
+  imports: [DialogHeaderComponent, MatIcon, TranslatePipe, MatDialogContent, DownloadDialogResourcesTabComponent],
 })
 export class DownloadDialogComponent {
+  readonly largeThreshold = CSV_EXPORT_LARGE_THRESHOLD;
+
   constructor(
     public dialogRef: MatDialogRef<DownloadDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: DownloadDialogData

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog.component.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog.component.ts
@@ -26,7 +26,9 @@ export interface DownloadDialogData {
         data-cy="large-export-warning"
         style="display: flex; align-items: flex-start; gap: 8px; padding: 12px 24px; background: #fff3e0; color: #e65100">
         <mat-icon style="flex-shrink: 0">warning</mat-icon>
-        <span>{{ 'pages.dataBrowser.downloadDialog.largeExportWarning' | translate: { count: data.resourceCount } }}</span>
+        <span>{{
+          'pages.dataBrowser.downloadDialog.largeExportWarning' | translate: { count: data.resourceCount }
+        }}</span>
       </div>
     }
     <div mat-dialog-content style="max-height: 90vh">

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog.component.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog.component.ts
@@ -22,10 +22,8 @@ export interface DownloadDialogData {
       [title]="'pages.dataBrowser.downloadDialog.title' | translate"
       [subtitle]="'pages.dataBrowser.downloadDialog.resourcesAvailable' | translate: { count: data.resourceCount }" />
     @if (data.resourceCount > largeThreshold) {
-      <div
-        data-cy="large-export-warning"
-        style="display: flex; align-items: flex-start; gap: 8px; padding: 12px 24px; background: #fff3e0; color: #e65100">
-        <mat-icon style="flex-shrink: 0">warning</mat-icon>
+      <div class="large-export-warning" data-cy="large-export-warning" role="alert">
+        <mat-icon color="warn">warning</mat-icon>
         <span>{{
           'pages.dataBrowser.downloadDialog.largeExportWarning' | translate: { count: data.resourceCount }
         }}</span>
@@ -39,6 +37,18 @@ export interface DownloadDialogData {
         style="display: block; height: 100%" />
     </div>
   `,
+  styles: [
+    `
+      .large-export-warning {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        padding: 12px 24px;
+        background: var(--mat-warn-container-color);
+        color: var(--mat-warn-on-container-color);
+      }
+    `,
+  ],
   standalone: true,
   imports: [DialogHeaderComponent, MatIcon, TranslatePipe, MatDialogContent, DownloadDialogResourcesTabComponent],
 })


### PR DESCRIPTION
[DEV-6423](https://linear.app/dasch/issue/DEV-6423)

## Summary
- Shows a warning banner in the Download dialog when resource count exceeds 1,000
- Warning text advises the user that the export may take several minutes and to keep the tab open
- Translated in all 5 languages (en, de, fr, it, rm)

## Changes
**`DownloadDialogComponent`** — adds `CSV_EXPORT_LARGE_THRESHOLD = 1_000` constant and a conditional `@if` banner between the dialog header and content. Adds `MatIcon` to imports.

**i18n** — adds `largeExportWarning` key to `en`, `de`, `fr`, `it`, `rm` JSON files under `pages.dataBrowser.downloadDialog`.

**Tests** — adds 3 fix-confirmation tests in a new `describe` block that renders the real template and verifies the banner appears/disappears based on resource count vs threshold.

## Test Plan
- `npx nx test vre-pages-project-project` — 130 tests pass

## Screenshots
[Attach manually if UI changes]