### PR TITLE
chore(open-api): bump dsp-api spec v35.4.0-11-g8b8a765 → v35.8.1-5-g8360b63

### DIFF
--- a/libs/vre/3rd-party-services/open-api/dsp-api_spec.yaml
+++ b/libs/vre/3rd-party-services/open-api/dsp-api_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: DSP-API
-  version: v35.4.0-11-g8b8a765
+  version: v35.8.1-5-g8360b63
   summary: DSP-API is part of the DaSCH Service Platform, a repository for the long-term
     preservation and reuse of data in the humanities.
   contact:
@@ -4683,7 +4683,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       responses:
         '200':
           description: ''
@@ -4741,7 +4741,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       responses:
         '200':
           description: ''
@@ -4799,7 +4799,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       responses:
         '200':
           description: ''
@@ -4970,7 +4970,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       responses:
         '200':
           description: ''
@@ -5030,7 +5030,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       responses:
         '200':
           description: ''
@@ -5216,7 +5216,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -5283,7 +5283,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -5351,7 +5351,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -5418,7 +5418,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -5486,7 +5486,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       - name: groupIri
         in: path
         description: The IRI of a group. Must be URL-encoded.
@@ -5553,7 +5553,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       - name: groupIri
         in: path
         description: The IRI of a group. Must be URL-encoded.
@@ -5621,7 +5621,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       requestBody:
         content:
           application/json:
@@ -5688,7 +5688,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       requestBody:
         content:
           application/json:
@@ -5755,7 +5755,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       requestBody:
         content:
           application/json:
@@ -5822,7 +5822,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/AnmxqxatRXK_fRAoT4BH8g
+        example: http://rdfh.ch/users/HzYygl4IQUy7pswFZOE33Q
       requestBody:
         content:
           application/json:
@@ -6069,7 +6069,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/lists/0001/daK3gqeWQJ2wMkzSZcQFkA
+        example: http://rdfh.ch/lists/0001/ffsOwpBiRv2DxgRjJQQp0g
       - name: x-knora-accept-schema
         in: header
         description: |-
@@ -6182,7 +6182,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/lists/0001/daK3gqeWQJ2wMkzSZcQFkA
+        example: http://rdfh.ch/lists/0001/ffsOwpBiRv2DxgRjJQQp0g
       - name: x-knora-accept-schema
         in: header
         description: |-
@@ -14477,12 +14477,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
               example:
-                webapi: v35.4.0-11-g8b8a765
-                buildCommit: 8b8a765d1
-                buildTime: '2026-04-01T11:03:22Z'
-                fuseki: 5.5.0-2
+                webapi: v35.8.1-5-g8360b63
+                buildCommit: 8360b6363
+                buildTime: '2026-05-06T07:40:09Z'
+                fuseki: 5.5.0-3
                 scala: 3.3.7
-                sipi: v4.0.0
+                sipi: v4.1.1
                 name: version
         '400':
           description: ''
@@ -14963,6 +14963,8 @@ components:
         createdAt:
           type: string
           format: date-time
+        errorMessage:
+          type: string
     DefaultObjectAccessPermissionADM:
       title: DefaultObjectAccessPermissionADM
       type: object


### PR DESCRIPTION
Automated spec update detected by CI. Review diff and merge when the frontend is ready to adopt the new API.