### PR TITLE
feat(advanced search): enable escaping and searching of regex

### DIFF
--- a/libs/vre/pages/search/advanced-search/src/lib/model.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/model.ts
@@ -10,6 +10,24 @@ import {
 } from './constants';
 import { getOperatorsForObjectType, Operator } from './operators.config';
 
+/**
+ * Escape a user-supplied IsLike value for safe embedding inside a Gravsearch
+ * FILTER regex(…) call. We do NOT escape regex metacharacters — IsLike is a
+ * regex field, so users can type `.`, `*`, `(`, etc. and have them reach the
+ * regex engine as metacharacters. To match a literal metacharacter the user
+ * escapes it themselves (`\*` for a literal asterisk), exactly as in SPARQL.
+ *
+ * Two string-escape layers stand between the HTTP body and the regex engine
+ * (verified empirically against api.dev.dasch.swiss). To deliver one literal
+ * `\` to the regex engine (so the user's `\*` reaches the regex as `\*` and
+ * matches a literal `*`), the wire must carry four backslashes. The double
+ * quote `"` is not a regex metacharacter, so it only needs to survive the
+ * two string layers — three backslashes + quote on the wire.
+ */
+function escapeForGravsearchStringLiteral(value: string): string {
+  return value.replace(/\\/g, '\\\\\\\\').replace(/"/g, '\\\\\\"');
+}
+
 export enum PropertyObjectType {
   None = 'NONE',
   ValueObject = 'VALUE_OBJECT',
@@ -377,8 +395,10 @@ class GravsearchWriterScoped {
         return `FILTER (${this.objectPlaceHolder} != "${this._selectedValue}") .\n`;
       case Operator.Matches:
         return `FILTER knora-api:matchLabel(${MAIN_RESOURCE_PLACEHOLDER}, "${this._selectedValue}") .\n`;
-      case Operator.IsLike:
-        return `FILTER regex(${this.objectPlaceHolder}, "${this._selectedValue}", "i") .\n`;
+      case Operator.IsLike: {
+        const pattern = escapeForGravsearchStringLiteral(this._selectedValue ?? '');
+        return `FILTER regex(${this.objectPlaceHolder}, "${pattern}", "i") .\n`;
+      }
       default:
         return '';
     }
@@ -403,7 +423,9 @@ class GravsearchWriterScoped {
         ? `knora-api:toSimpleDate(${this.objectPlaceHolder})`
         : `${this.objectPlaceHolder}${VALUE_SUFFIX}`;
     if (this._operator === Operator.IsLike && this._objectType === Constants.TextValue) {
-      return `FILTER regex(${object}, ${this.typedValueLiteral}, "i") .\n`;
+      const pattern = escapeForGravsearchStringLiteral(this._selectedValue ?? '');
+      const regexLiteral = `"${pattern}"^^<${this.valueTypeIri}>`;
+      return `FILTER regex(${object}, ${regexLiteral}, "i") .\n`;
     }
     return `FILTER (${object} ${this.operatorSymbol} ${this.typedValueLiteral} ) .\n`;
   }

--- a/libs/vre/pages/search/advanced-search/src/lib/service/spec/gravsearch.service.spec.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/service/spec/gravsearch.service.spec.ts
@@ -88,6 +88,17 @@ function changeOperator(searchStateService: SearchStateService, statementIndex: 
 }
 
 /**
+ * Helper function to set the selected value (StringValue) on a statement
+ * while preserving the existing operator. Useful for parameterising tests
+ * that vary the user-supplied search input.
+ */
+function setSelectedValue(searchStateService: SearchStateService, statementIndex: number, value: string): void {
+  const statements = searchStateService.currentState.statementElements;
+  statements[statementIndex].selectedObjectNode = new StringValue(statements[statementIndex].id, value);
+  searchStateService.patchState({ statementElements: statements });
+}
+
+/**
  * Helper function to normalize whitespace in queries for comparison
  */
 function normalizeQuery(query: string): string {
@@ -254,6 +265,37 @@ OFFSET 0`;
     // Only check the operator-specific FILTER clause
     expect(query).toContain('FILTER knora-api:matchLabel(?mainRes, "foo")');
   });
+
+  it('passes regex metacharacters through unchanged in label isLike pattern', () => {
+    const jsonSnapshot = JSON.stringify(baseJsonSnapshot);
+    const resourceClass: IriLabelPair = { iri: '', label: 'All resource classes' };
+    setupTestFromJson(searchStateService, jsonSnapshot, resourceClass);
+
+    changeOperator(searchStateService, 0, Operator.IsLike);
+    // User input: a.b*c(d) — full regex; user wants `.` `*` `(` `)` as metachars.
+    setSelectedValue(searchStateService, 0, 'a.b*c(d)');
+
+    const query = gravsearchService.generateGravSearchQuery(searchStateService.validStatementElements);
+
+    expect(query).toContain('FILTER regex(?res0, "a.b*c(d)", "i")');
+  });
+
+  it('quadruples user-typed backslashes and triples-escapes quotes in label isLike pattern', () => {
+    const jsonSnapshot = JSON.stringify(baseJsonSnapshot);
+    const resourceClass: IriLabelPair = { iri: '', label: 'All resource classes' };
+    setupTestFromJson(searchStateService, jsonSnapshot, resourceClass);
+
+    changeOperator(searchStateService, 0, Operator.IsLike);
+    // User input: say "hi" \* — TS source: 'say "hi" \\*'
+    // Intent: regex literal `*` (because user wrote `\*`), plus literal quotes.
+    setSelectedValue(searchStateService, 0, 'say "hi" \\*');
+
+    const query = gravsearchService.generateGravSearchQuery(searchStateService.validStatementElements);
+
+    // Runtime wire string inside the FILTER literal: say \\\"hi\\\" \\\\*
+    // (3 backslashes per quote, 4 backslashes per user backslash)
+    expect(query).toContain('FILTER regex(?res0, "say \\\\\\"hi\\\\\\" \\\\\\\\*", "i")');
+  });
 });
 
 describe('Gravsearch Service and Writer - TextValue', () => {
@@ -400,6 +442,38 @@ OFFSET 0`;
 
     // Only check the operator-specific FILTER clause
     expect(query).toContain('FILTER regex(?res0val, "Wien"^^<http://www.w3.org/2001/XMLSchema#string>, "i") .');
+  });
+
+  it('passes regex metacharacters through unchanged in TextValue isLike pattern', () => {
+    const jsonSnapshot = JSON.stringify(baseJsonSnapshot);
+    const resourceClass: IriLabelPair = { iri: '', label: 'All resource classes' };
+    setupTestFromJson(searchStateService, jsonSnapshot, resourceClass);
+
+    changeOperator(searchStateService, 0, Operator.IsLike);
+    // User input: Wien.* — wildcard search.
+    setSelectedValue(searchStateService, 0, 'Wien.*');
+
+    const query = gravsearchService.generateGravSearchQuery(searchStateService.validStatementElements);
+
+    expect(query).toContain('FILTER regex(?res0val, "Wien.*"^^<http://www.w3.org/2001/XMLSchema#string>, "i")');
+  });
+
+  it('quadruples user-typed backslashes and triples-escapes quotes in TextValue isLike pattern', () => {
+    const jsonSnapshot = JSON.stringify(baseJsonSnapshot);
+    const resourceClass: IriLabelPair = { iri: '', label: 'All resource classes' };
+    setupTestFromJson(searchStateService, jsonSnapshot, resourceClass);
+
+    changeOperator(searchStateService, 0, Operator.IsLike);
+    // User input: a"b\c — TS source: 'a"b\\c'
+    setSelectedValue(searchStateService, 0, 'a"b\\c');
+
+    const query = gravsearchService.generateGravSearchQuery(searchStateService.validStatementElements);
+
+    // Runtime wire string inside the FILTER literal: a\\\"b\\\\c
+    // (3 backslashes per quote, 4 backslashes per user backslash)
+    expect(query).toContain(
+      'FILTER regex(?res0val, "a\\\\\\"b\\\\\\\\c"^^<http://www.w3.org/2001/XMLSchema#string>, "i")'
+    );
   });
 });
 


### PR DESCRIPTION
As the operator "is like" is parsed and executed as regex we need to enable escaping of regex meta characters in order to search also for literal characters used by regex. 

Example:

A user wants to search for a literal Asterisk "" . Then the input should be: one escape backslash to escape the regex char "" -> "\*"

The app then needs to send the query as a quadruple escape: "\\\\" (every layer needs its own escaping …)

In order to search for a literal quote string '"' the user also can escape it once, e.g. '\"'. The app however does only need to triple the escape for this case (the regex layer is not applied) so the quote char survives 