### PR TITLE
fix(i18n): add 15 missing translation keys (DEV-6239)

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -210,7 +210,9 @@
         "name": "Eindeutigen Namen festlegen",
         "label": "Bezeichnung",
         "comment": "Kommentar",
-        "nameExists": "Dieser Name ist nicht erlaubt oder existiert bereits."
+        "nameExists": "Dieser Name ist nicht erlaubt oder existiert bereits.",
+        "namePatternError": "Der Name muss mit einem Buchstaben beginnen und darf nur Buchstaben, Ziffern, Bindestriche, Punkte und Unterstriche enthalten.",
+        "nameExistsError": "Dieser Name ist nicht erlaubt oder existiert bereits."
       },
       "list": {
         "deleteList": "Kontrolliertes Vokabular löschen",
@@ -290,13 +292,16 @@
       "propertyItem": {
         "edit": "Bearbeiten",
         "removeFromClass": "Aus Klasse entfernen",
-        "copyId": "Eigenschafts-ID kopieren"
+        "copyId": "Eigenschafts-ID kopieren",
+        "idCopied": "Eigenschafts-ID in Zwischenablage kopiert!"
       },
       "propertyInfo": {
         "usedIn": "Verwendet in",
         "notUsed": "Nicht verwendet",
         "cannotEdit": "Kann nicht bearbeitet werden",
-        "cannotDelete": "Kann nicht gelöscht werden"
+        "cannotDelete": "Kann nicht gelöscht werden",
+        "deleteConfirmation": "Möchten Sie diese Eigenschaft löschen?",
+        "restrictedTo": "Eingeschränkt auf {{className}}"
       },
       "resourceClassInfo": {
         "collapse": "Einklappen",
@@ -306,7 +311,9 @@
         "openInstances": "Instanzen öffnen",
         "copyId": "Klassen-ID kopieren",
         "cannotDelete": "Diese Klasse kann nicht gelöscht werden, da sie verwendet wird!",
-        "delete": "Löschen"
+        "delete": "Löschen",
+        "deleteConfirmation": "Möchten Sie diese Ressourcenklasse löschen?",
+        "idCopied": "Klassen-ID in Zwischenablage kopiert!"
       },
       "propertyForm": {
         "editTitle": "Eigenschaft bearbeiten",
@@ -452,7 +459,14 @@
         "play": "Abspielen",
         "stop": "Stoppen und zum Anfang gehen",
         "defaultView": "Standardansicht",
-        "cinemaMode": "Kinomodus"
+        "cinemaMode": "Kinomodus",
+        "errors": {
+          "playbackAborted": "Die Videowiedergabe wurde abgebrochen.",
+          "networkError": "Ein Netzwerkfehler hat das Herunterladen des Videos verhindert.",
+          "decodingError": "Das Video konnte nicht dekodiert werden.",
+          "formatNotSupported": "Das Videoformat wird nicht unterstützt.",
+          "unknownError": "Ein unbekannter Videofehler ist aufgetreten."
+        }
       },
       "stillImage": {
         "createAnnotation": "Annotation erstellen",
@@ -673,7 +687,8 @@
       "authorship": {
         "label": "Autorenschaft",
         "placeholder": "Neue Autorenschaft...",
-        "pressEnterOrTab": "Drücken Sie Enter oder Tab, um ein Element hinzuzufügen."
+        "pressEnterOrTab": "Drücken Sie Enter oder Tab, um ein Element hinzuzufügen.",
+        "removeItem": "{{name}} entfernen"
       },
       "image": {
         "label": "Bild",

--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -716,7 +716,9 @@
     },
     "templateSwitcher": {
       "nullableEditor": {
+        "add": "Hinzufügen",
         "addTooltip": "Hinzufügen",
+        "remove": "Entfernen",
         "removeTooltip": "Entfernen"
       },
       "createResourceDialog": {

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -210,7 +210,9 @@
         "name": "Set a unique name",
         "label": "Label",
         "comment": "Comment",
-        "nameExists": "This name is not allowed or exists already."
+        "nameExists": "This name is not allowed or exists already.",
+        "namePatternError": "The name must start with a letter and may only contain letters, digits, hyphens, dots and underscores.",
+        "nameExistsError": "This name is not allowed or already exists."
       },
       "list": {
         "deleteList": "Delete controlled vocabulary",
@@ -290,13 +292,16 @@
       "propertyItem": {
         "edit": "Edit",
         "removeFromClass": "Remove from class",
-        "copyId": "Copy property ID"
+        "copyId": "Copy property ID",
+        "idCopied": "Property ID copied to clipboard!"
       },
       "propertyInfo": {
         "usedIn": "Used in",
         "notUsed": "Not used",
         "cannotEdit": "Cannot edit",
-        "cannotDelete": "Cannot delete"
+        "cannotDelete": "Cannot delete",
+        "deleteConfirmation": "Do you want to delete this property?",
+        "restrictedTo": "Restricted to {{className}}"
       },
       "resourceClassInfo": {
         "collapse": "Collapse",
@@ -306,7 +311,9 @@
         "openInstances": "Open instances",
         "copyId": "Copy class ID",
         "cannotDelete": "This class cannot be deleted because it is in use!",
-        "delete": "Delete"
+        "delete": "Delete",
+        "deleteConfirmation": "Do you want to delete this resource class?",
+        "idCopied": "Class ID copied to clipboard!"
       },
       "propertyForm": {
         "editTitle": "Edit property",
@@ -509,7 +516,14 @@
         "play": "Play",
         "stop": "Stop and go to start",
         "defaultView": "Default view",
-        "cinemaMode": "Cinema mode"
+        "cinemaMode": "Cinema mode",
+        "errors": {
+          "playbackAborted": "Video playback was aborted.",
+          "networkError": "A network error caused the video download to fail.",
+          "decodingError": "The video could not be decoded.",
+          "formatNotSupported": "The video format is not supported.",
+          "unknownError": "An unknown video error occurred."
+        }
       },
       "document": {
         "searchPlaceholder": "Search in pdf...",
@@ -673,7 +687,8 @@
       "authorship": {
         "label": "Authorship",
         "placeholder": "New authorship...",
-        "pressEnterOrTab": "Press Enter or Tab to add an item."
+        "pressEnterOrTab": "Press Enter or Tab to add an item.",
+        "removeItem": "Remove {{name}}"
       },
       "image": {
         "label": "Image",

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -716,7 +716,9 @@
     },
     "templateSwitcher": {
       "nullableEditor": {
+        "add": "Add",
         "addTooltip": "Add",
+        "remove": "Remove",
         "removeTooltip": "Remove"
       },
       "createResourceDialog": {

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -716,7 +716,9 @@
     },
     "templateSwitcher": {
       "nullableEditor": {
+        "add": "Ajouter",
         "addTooltip": "Ajouter",
+        "remove": "Supprimer",
         "removeTooltip": "Supprimer"
       },
       "createResourceDialog": {

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -210,7 +210,9 @@
         "name": "Définir un nom unique",
         "label": "Label",
         "comment": "Commentaire",
-        "nameExists": "Ce nom n'est pas autorisé ou existe déjà."
+        "nameExists": "Ce nom n'est pas autorisé ou existe déjà.",
+        "namePatternError": "Le nom doit commencer par une lettre et ne peut contenir que des lettres, des chiffres, des traits d'union, des points et des soulignements.",
+        "nameExistsError": "Ce nom n'est pas autorisé ou existe déjà."
       },
       "list": {
         "deleteList": "Supprimer le vocabulaire contrôlé",
@@ -290,13 +292,16 @@
       "propertyItem": {
         "edit": "Modifier",
         "removeFromClass": "Retirer de la classe",
-        "copyId": "Copier l'ID de la propriété"
+        "copyId": "Copier l'ID de la propriété",
+        "idCopied": "ID de propriété copié dans le presse-papiers !"
       },
       "propertyInfo": {
         "usedIn": "Utilisé dans",
         "notUsed": "Non utilisé",
         "cannotEdit": "Ne peut pas être modifié",
-        "cannotDelete": "Ne peut pas être supprimé"
+        "cannotDelete": "Ne peut pas être supprimé",
+        "deleteConfirmation": "Voulez-vous supprimer cette propriété ?",
+        "restrictedTo": "Limité à {{className}}"
       },
       "resourceClassInfo": {
         "collapse": "Réduire",
@@ -306,7 +311,9 @@
         "openInstances": "Ouvrir les instances",
         "copyId": "Copier l'ID de la classe",
         "cannotDelete": "Cette classe ne peut pas être supprimée car elle est utilisée !",
-        "delete": "Supprimer"
+        "delete": "Supprimer",
+        "deleteConfirmation": "Voulez-vous supprimer cette classe de ressource ?",
+        "idCopied": "ID de classe copié dans le presse-papiers !"
       },
       "propertyForm": {
         "editTitle": "Modifier la propriété",
@@ -509,7 +516,14 @@
         "play": "Lire",
         "stop": "Arrêter et revenir au début",
         "defaultView": "Vue par défaut",
-        "cinemaMode": "Mode cinéma"
+        "cinemaMode": "Mode cinéma",
+        "errors": {
+          "playbackAborted": "La lecture de la vidéo a été interrompue.",
+          "networkError": "Une erreur réseau a empêché le téléchargement de la vidéo.",
+          "decodingError": "La vidéo n'a pas pu être décodée.",
+          "formatNotSupported": "Le format vidéo n'est pas pris en charge.",
+          "unknownError": "Une erreur vidéo inconnue s'est produite."
+        }
       },
       "document": {
         "searchPlaceholder": "Rechercher dans le pdf...",
@@ -673,7 +687,8 @@
       "authorship": {
         "label": "Auteur·ice",
         "placeholder": "Nouvel·le auteur·ice...",
-        "pressEnterOrTab": "Appuyez sur Entrée ou Tab pour ajouter un élément."
+        "pressEnterOrTab": "Appuyez sur Entrée ou Tab pour ajouter un élément.",
+        "removeItem": "Supprimer {{name}}"
       },
       "image": {
         "label": "Image",

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -210,7 +210,9 @@
         "name": "Imposta un nome univoco",
         "label": "Etichetta",
         "comment": "Commento",
-        "nameExists": "Questo nome non è consentito o esiste già."
+        "nameExists": "Questo nome non è consentito o esiste già.",
+        "namePatternError": "Il nome deve iniziare con una lettera e può contenere solo lettere, cifre, trattini, punti e trattini bassi.",
+        "nameExistsError": "Questo nome non è consentito o esiste già."
       },
       "list": {
         "deleteList": "Elimina vocabolario controllato",
@@ -290,13 +292,16 @@
       "propertyItem": {
         "edit": "Modifica",
         "removeFromClass": "Rimuovi dalla classe",
-        "copyId": "Copia ID della proprietà"
+        "copyId": "Copia ID della proprietà",
+        "idCopied": "ID proprietà copiato negli appunti!"
       },
       "propertyInfo": {
         "usedIn": "Usato in",
         "notUsed": "Non usato",
         "cannotEdit": "Non può essere modificato",
-        "cannotDelete": "Non può essere eliminato"
+        "cannotDelete": "Non può essere eliminato",
+        "deleteConfirmation": "Vuoi eliminare questa proprietà?",
+        "restrictedTo": "Limitato a {{className}}"
       },
       "resourceClassInfo": {
         "collapse": "Riduci",
@@ -306,7 +311,9 @@
         "openInstances": "Apri istanze",
         "copyId": "Copia ID della classe",
         "cannotDelete": "Questa classe non può essere eliminata perché è in uso!",
-        "delete": "Elimina"
+        "delete": "Elimina",
+        "deleteConfirmation": "Vuoi eliminare questa classe di risorsa?",
+        "idCopied": "ID classe copiato negli appunti!"
       },
       "propertyForm": {
         "editTitle": "Modifica proprietà",
@@ -509,7 +516,14 @@
         "play": "Riproduci",
         "stop": "Ferma e torna all'inizio",
         "defaultView": "Vista predefinita",
-        "cinemaMode": "Modalità cinema"
+        "cinemaMode": "Modalità cinema",
+        "errors": {
+          "playbackAborted": "La riproduzione del video è stata interrotta.",
+          "networkError": "Un errore di rete ha impedito il download del video.",
+          "decodingError": "Impossibile decodificare il video.",
+          "formatNotSupported": "Il formato video non è supportato.",
+          "unknownError": "Si è verificato un errore video sconosciuto."
+        }
       },
       "document": {
         "searchPlaceholder": "Cerca nel pdf...",
@@ -673,7 +687,8 @@
       "authorship": {
         "label": "Autore",
         "placeholder": "Nuovo autore...",
-        "pressEnterOrTab": "Premere Invio o Tab per aggiungere un elemento."
+        "pressEnterOrTab": "Premere Invio o Tab per aggiungere un elemento.",
+        "removeItem": "Rimuovi {{name}}"
       },
       "image": {
         "label": "Immagine",

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -716,7 +716,9 @@
     },
     "templateSwitcher": {
       "nullableEditor": {
+        "add": "Aggiungi",
         "addTooltip": "Aggiungi",
+        "remove": "Rimuovi",
         "removeTooltip": "Rimuovi"
       },
       "createResourceDialog": {

--- a/apps/dsp-app/src/assets/i18n/rm.json
+++ b/apps/dsp-app/src/assets/i18n/rm.json
@@ -210,7 +210,9 @@
         "name": "Set a unique name",
         "label": "Label",
         "comment": "Comment",
-        "nameExists": "This name is not allowed or exists already."
+        "nameExists": "This name is not allowed or exists already.",
+        "namePatternError": "The name must start with a letter and may only contain letters, digits, hyphens, dots and underscores.",
+        "nameExistsError": "This name is not allowed or already exists."
       },
       "list": {
         "deleteList": "Delete controlled vocabulary",
@@ -290,13 +292,16 @@
       "propertyItem": {
         "edit": "Edit",
         "removeFromClass": "Remove from class",
-        "copyId": "Copy property ID"
+        "copyId": "Copy property ID",
+        "idCopied": "Property ID copied to clipboard!"
       },
       "propertyInfo": {
         "usedIn": "Used in",
         "notUsed": "Not used",
         "cannotEdit": "Cannot edit",
-        "cannotDelete": "Cannot delete"
+        "cannotDelete": "Cannot delete",
+        "deleteConfirmation": "Do you want to delete this property?",
+        "restrictedTo": "Restricted to {{className}}"
       },
       "resourceClassInfo": {
         "collapse": "Collapse",
@@ -306,7 +311,9 @@
         "openInstances": "Open instances",
         "copyId": "Copy class ID",
         "cannotDelete": "This class cannot be deleted because it is in use!",
-        "delete": "Delete"
+        "delete": "Delete",
+        "deleteConfirmation": "Do you want to delete this resource class?",
+        "idCopied": "Class ID copied to clipboard!"
       },
       "propertyForm": {
         "editTitle": "Edit property",
@@ -509,7 +516,14 @@
         "play": "Play",
         "stop": "Stop and go to start",
         "defaultView": "Default view",
-        "cinemaMode": "Cinema mode"
+        "cinemaMode": "Cinema mode",
+        "errors": {
+          "playbackAborted": "Video playback was aborted.",
+          "networkError": "A network error caused the video download to fail.",
+          "decodingError": "The video could not be decoded.",
+          "formatNotSupported": "The video format is not supported.",
+          "unknownError": "An unknown video error occurred."
+        }
       },
       "document": {
         "searchPlaceholder": "Search in pdf...",
@@ -673,7 +687,8 @@
       "authorship": {
         "label": "Authorship",
         "placeholder": "New authorship...",
-        "pressEnterOrTab": "Press Enter or Tab to add an item."
+        "pressEnterOrTab": "Press Enter or Tab to add an item.",
+        "removeItem": "Remove {{name}}"
       },
       "image": {
         "label": "Image",

--- a/apps/dsp-app/src/assets/i18n/rm.json
+++ b/apps/dsp-app/src/assets/i18n/rm.json
@@ -716,7 +716,9 @@
     },
     "templateSwitcher": {
       "nullableEditor": {
+        "add": "Add",
         "addTooltip": "Add",
+        "remove": "Remove",
         "removeTooltip": "Remove"
       },
       "createResourceDialog": {


### PR DESCRIPTION
[DEV-6239](https://linear.app/dasch/issue/DEV-6239)

## Summary

- Adds **15** translation keys that are referenced by code (`_translate.instant()` / `| translate`) but were missing from the JSON files, causing raw keys to render in the UI.
- 13 keys were listed in the Linear issue (ontology editor + resource editor); a follow-up codebase audit found 2 more in the nullable-editor component.
- Pure data change — no code modifications. The code already references the keys correctly.
- Applied to all 5 languages (en/de/fr/it/rm); Romansh uses English values per the repo's `apps/dsp-app/src/assets/i18n/CLAUDE.md` policy.

## Changes

**Ontology module (7 keys):**
- `pages.ontology.resourceClassInfo.deleteConfirmation`
- `pages.ontology.resourceClassInfo.idCopied`
- `pages.ontology.propertyInfo.deleteConfirmation`
- `pages.ontology.propertyInfo.restrictedTo` (uses `{{className}}`)
- `pages.ontology.propertyItem.idCopied`
- `pages.ontology.ontologyForm.namePatternError`
- `pages.ontology.ontologyForm.nameExistsError`

**Resource editor module (8 keys):**
- `resourceEditor.representations.video.errors.playbackAborted`
- `resourceEditor.representations.video.errors.networkError`
- `resourceEditor.representations.video.errors.decodingError`
- `resourceEditor.representations.video.errors.formatNotSupported`
- `resourceEditor.representations.video.errors.unknownError`
- `resourceEditor.resourceCreator.authorship.removeItem` (uses `{{name}}`)
- `resourceEditor.templateSwitcher.nullableEditor.add` *(found in audit)*
- `resourceEditor.templateSwitcher.nullableEditor.remove` *(found in audit)*

## Test Plan

- [x] JSON validity verified for all 5 files
- [x] Key parity verified across en/de/fr/it/rm (586 keys each, no missing/extra)
- [x] All 15 new keys confirmed present in all 5 files
- [x] Full codebase audit: 532 referenced keys, 0 still missing
- [ ] Manual UI verification on a running build — switch between languages and confirm:
  - Delete confirmation dialogs (resource class, property) render translated text
  - Snackbars after copying class ID / property ID render translated text
  - Locked-property tooltip shows "Restricted to <className>"
  - Ontology name validation errors render translated text
  - Video player error states render translated text
  - Authorship chip remove button aria-label renders translated text
  - Nullable-editor add/remove button browser tooltips (title attr) render translated text

## Screenshots

[Attach manually after UI verification]