### PR TITLE
chore: remove types/openseadragon and types/jsonld packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "@types/jest": "29.5.14",
         "@types/jsonld": "^1.5.6",
         "@types/node": "^22.18.11",
-        "@types/openseadragon": "^5.0.0",
         "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
@@ -18247,13 +18246,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/openseadragon": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/openseadragon/-/openseadragon-5.0.2.tgz",
-      "integrity": "sha512-c5x6YsT3GA6kyBOcesdwuZYn3blw7hucSoSG0scGKeyu82UgRahRuVL8+Yw4WKpEOlMvXnb7CrI8HleDIPnfuw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "@swc/helpers": "0.5.21",
         "@swc/jest": "^0.2.39",
         "@types/jest": "29.5.14",
-        "@types/jsonld": "^1.5.6",
         "@types/node": "^22.18.11",
         "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "7.18.0",
@@ -18203,13 +18202,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/jsonld": {
-      "version": "1.5.15",
-      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.15.tgz",
-      "integrity": "sha512-PlAFPZjL+AuGYmwlqwKEL0IMP8M8RexH0NIPGfCVWSQ041H2rR/8OlyZSD7KsCVoN8vCfWdtWDBxX8yBVP+xow==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@types/jest": "29.5.14",
     "@types/jsonld": "^1.5.6",
     "@types/node": "^22.18.11",
-    "@types/openseadragon": "^5.0.0",
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@swc/helpers": "0.5.21",
     "@swc/jest": "^0.2.39",
     "@types/jest": "29.5.14",
-    "@types/jsonld": "^1.5.6",
     "@types/node": "^22.18.11",
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "7.18.0",

--- a/renovate.json
+++ b/renovate.json
@@ -212,11 +212,6 @@
       "groupName": "grafana-faro-deps"
     },
     {
-      "description": "JSON-LD + its type definitions",
-      "matchPackageNames": ["jsonld", "@types/jsonld"],
-      "groupName": "jsonld-deps"
-    },
-    {
       "description": "ngx-translate i18n — core and http-loader are always used together",
       "matchPackageNames": ["/^@ngx-translate//"],
       "groupName": "ngx-translate-deps"

--- a/renovate.json
+++ b/renovate.json
@@ -265,11 +265,6 @@
       "groupName": "webpack-deps"
     },
     {
-      "description": "OpenSeaDragon image viewer",
-      "matchPackageNames": ["openseadragon", "@types/openseadragon"],
-      "groupName": "openseadragon-deps"
-    },
-    {
       "description": "UUID",
       "matchPackageNames": ["uuid", "@types/uuid"],
       "groupName": "uuid-deps"


### PR DESCRIPTION
**@types/openseadragon is unused:**
The runtime package openseadragon@6.0.2 already ships its own types via "types": "types/index.d.ts" and uses export = OpenSeadragon, which supports both import OpenSeadragon from 'openseadragon' and import * as OpenSeadragon from 'openseadragon' patterns used in the codebase (osd-viewer.config.ts:1, osd-drawer.service.ts:13).

**@types/jsonld is unused.**
All 5 jsonld usages in libs/dsp-js/src/api/v2/ use require('jsonld/dist/jsonld.js') — untyped, result is any
Zero import … from 'jsonld' anywhere in the workspace
Typecheck without the package: dsp-js clean, dsp-app clean

Closes #3118