### PR TITLE
chore(storybook): disable preview source maps to fix webpack .map asset conflict

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,6 +8,18 @@ const config: StorybookConfig = {
     options: {},
   },
   staticDirs: [{ from: '../apps/dsp-app/src/assets', to: '/assets' }],
+  // The Angular webpack pipeline and Storybook's webpack5 builder both emit *.map
+  // assets for the preview bundles, producing "Multiple assets emit different content
+  // to the same filename <chunk>.iframe.bundle.js.map" conflicts that break the build.
+  // Source maps are not needed for the interaction-test build, so disable devtool and
+  // strip any SourceMapDevToolPlugin to make map emission deterministically off.
+  webpackFinal: async webpackConfig => {
+    webpackConfig.devtool = false;
+    webpackConfig.plugins = (webpackConfig.plugins ?? []).filter(
+      plugin => !/SourceMapDevToolPlugin/.test(plugin?.constructor?.name ?? '')
+    );
+    return webpackConfig;
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- Storybook's `build-storybook` is broken on `main` — the Angular webpack pipeline (`@ngtools/webpack`) and Storybook's webpack5 builder both emit `*.map` assets for the preview bundles, producing hundreds of `Multiple assets emit different content to the same filename <chunk>.iframe.bundle.js.map` conflicts that fail the build.
- Regressed after the #3131 lockfile-maintenance bump (a transitive webpack-related change exposed the double-emit). The Storybook Interaction Tests job has been red on `main` since 2026-05-25.

## Changes
- `.storybook/main.ts`: add a `webpackFinal` hook that disables `devtool` and strips any `SourceMapDevToolPlugin` for the preview build. Source maps are not needed for interaction tests, so map emission is now deterministically off.

## Test Plan
- `npx nx run dsp-app:build-storybook:ci` locally
  - **Before:** `Broken build`, 244 `.map` filename conflicts in CI (15 locally; 100% `.map`, zero non-`.map`)
  - **After:** **0 conflicts, exit 0, `Successfully ran target build-storybook`**, no `.map` files emitted

Splitting this out of #3135 so it can merge quickly and unblock Storybook CI for all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)