### PR TITLE
fix(download-dialog): call HttpClient directly for CSV export text st…

### DIFF
--- a/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.spec.ts
@@ -1,10 +1,10 @@
-import { HttpDownloadProgressEvent, HttpEvent, HttpEventType, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpDownloadProgressEvent, HttpEvent, HttpEventType, HttpResponse } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PropertyDefinition } from '@dasch-swiss/dsp-js';
-import { APIV3ApiService } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { BASE_PATH } from '@dasch-swiss/vre/3rd-party-services/open-api';
 import { PropertyInfoValues } from '@dasch-swiss/vre/shared/app-common';
 import { LocalizationService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
@@ -15,8 +15,9 @@ import { DownloadDialogResourcesTabComponent } from './download-dialog-resources
 describe('DownloadDialogResourcesTabComponent', () => {
   let component: DownloadDialogResourcesTabComponent;
   let fixture: ComponentFixture<DownloadDialogResourcesTabComponent>;
-  let mockV3: jest.Mocked<APIV3ApiService>;
+  let mockHttp: jest.Mocked<HttpClient>;
   let events$: Subject<HttpEvent<string>>;
+  const basePath = 'http://api.test';
   let mockNotificationService: jest.Mocked<NotificationService>;
   let mockLocalizationService: jest.Mocked<LocalizationService>;
 
@@ -37,9 +38,9 @@ describe('DownloadDialogResourcesTabComponent', () => {
 
   beforeEach(async () => {
     events$ = new Subject<HttpEvent<string>>();
-    mockV3 = {
-      postV3ExportResources: jest.fn().mockReturnValue(events$.asObservable()),
-    } as unknown as jest.Mocked<APIV3ApiService>;
+    mockHttp = {
+      post: jest.fn().mockReturnValue(events$.asObservable()),
+    } as unknown as jest.Mocked<HttpClient>;
 
     mockNotificationService = { openSnackBar: jest.fn() } as any;
     mockLocalizationService = { getCurrentLanguage: jest.fn().mockReturnValue('en') } as any;
@@ -57,7 +58,8 @@ describe('DownloadDialogResourcesTabComponent', () => {
       imports: [DownloadDialogResourcesTabComponent, FormsModule, NoopAnimationsModule],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
-        { provide: APIV3ApiService, useValue: mockV3 },
+        { provide: HttpClient, useValue: mockHttp },
+        { provide: BASE_PATH, useValue: basePath },
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: LocalizationService, useValue: mockLocalizationService },
         provideTranslateService(),
@@ -108,15 +110,17 @@ describe('DownloadDialogResourcesTabComponent', () => {
       component.selectedPropertyIds = ['prop-1', 'prop-2'];
     });
 
-    it('calls postV3ExportResources with the body, events overload, reportProgress, and text/csv Accept', () => {
+    it('posts to the export endpoint with the body and a text-streaming events request', () => {
       component.includeResourceIris = false;
       component.includeArkUrls = false;
 
       component.downloadCsv();
 
-      // observe:'events' + reportProgress + httpHeaderAccept:'text/csv' are load-bearing: the text/csv
-      // Accept makes the generated client select responseType:'text', which populates partialText for row counting.
-      expect(mockV3.postV3ExportResources).toHaveBeenCalledWith(
+      // responseType:'text' + observe:'events' + reportProgress are load-bearing: they populate
+      // partialText on DownloadProgress events, which feeds the row counter (DEV-6462). The Accept
+      // header selects the CSV representation. See the component comment for why HttpClient is used directly.
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        `${basePath}/v3/export/resources`,
         {
           resourceClass: 'http://example.org/ontology/ResourceClass',
           selectedProperties: ['prop-1', 'prop-2'],
@@ -124,42 +128,42 @@ describe('DownloadDialogResourcesTabComponent', () => {
           includeIris: false,
           includeArkUrls: false,
         },
-        'events',
-        true,
-        { httpHeaderAccept: 'text/csv' }
+        {
+          observe: 'events',
+          reportProgress: true,
+          responseType: 'text',
+          headers: { Accept: 'text/csv' },
+        }
       );
     });
 
     it('passes includeIris=true when toggled', () => {
       component.includeResourceIris = true;
       component.downloadCsv();
-      expect(mockV3.postV3ExportResources).toHaveBeenCalledWith(
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        `${basePath}/v3/export/resources`,
         expect.objectContaining({ includeIris: true }),
-        'events',
-        true,
-        { httpHeaderAccept: 'text/csv' }
+        expect.objectContaining({ responseType: 'text', observe: 'events' })
       );
     });
 
     it('passes includeArkUrls=true when toggled', () => {
       component.includeArkUrls = true;
       component.downloadCsv();
-      expect(mockV3.postV3ExportResources).toHaveBeenCalledWith(
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        `${basePath}/v3/export/resources`,
         expect.objectContaining({ includeArkUrls: true }),
-        'events',
-        true,
-        { httpHeaderAccept: 'text/csv' }
+        expect.objectContaining({ responseType: 'text', observe: 'events' })
       );
     });
 
     it('passes the current language from LocalizationService', () => {
       mockLocalizationService.getCurrentLanguage.mockReturnValue('de');
       component.downloadCsv();
-      expect(mockV3.postV3ExportResources).toHaveBeenCalledWith(
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        `${basePath}/v3/export/resources`,
         expect.objectContaining({ language: 'de' }),
-        'events',
-        true,
-        { httpHeaderAccept: 'text/csv' }
+        expect.objectContaining({ responseType: 'text', observe: 'events' })
       );
     });
 

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.ts
@@ -1,5 +1,5 @@
-import { HttpDownloadProgressEvent, HttpEvent, HttpEventType } from '@angular/common/http';
-import { ChangeDetectorRef, Component, DestroyRef, EventEmitter, Input, Output } from '@angular/core';
+import { HttpClient, HttpDownloadProgressEvent, HttpEvent, HttpEventType } from '@angular/common/http';
+import { ChangeDetectorRef, Component, DestroyRef, EventEmitter, Inject, Input, Output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
@@ -7,7 +7,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialogActions } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { APIV3ApiService, ExportRequest } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { BASE_PATH, ExportRequest } from '@dasch-swiss/vre/3rd-party-services/open-api';
 import { PropertyInfoValues } from '@dasch-swiss/vre/shared/app-common';
 import { LocalizationService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
@@ -176,7 +176,8 @@ export class DownloadDialogResourcesTabComponent {
   private _scannerState: RowScannerState = initRowScanner();
 
   constructor(
-    private readonly _v3: APIV3ApiService,
+    private readonly _http: HttpClient,
+    @Inject(BASE_PATH) private readonly _basePath: string,
     private readonly _localizationService: LocalizationService,
     private readonly _notificationService: NotificationService,
     private readonly _translateService: TranslateService,
@@ -203,11 +204,18 @@ export class DownloadDialogResourcesTabComponent {
       includeArkUrls: this.includeArkUrls,
     };
 
-    // observe:'events' + reportProgress stream HttpDownloadProgressEvents; the text/csv Accept header
-    // makes the generated client select responseType:'text', which populates `partialText` for the
-    // row counter. This is the only reason the endpoint uses the events overload. See DEV-6462 / DEV-6336.
-    this._v3
-      .postV3ExportResources(body, 'events', true, { httpHeaderAccept: 'text/csv' })
+    // Call HttpClient directly instead of the generated APIV3ApiService: now that dsp-api streams the
+    // CSV as a chunked binary body (format: binary), the generated client hardcodes responseType:'blob',
+    // which would drop `partialText` and break the row counter. responseType:'text' + observe:'events' +
+    // reportProgress give HttpDownloadProgressEvents whose `partialText` feeds the counter. The Bearer
+    // token is added by authInterceptorFn (matches the API base path). See DEV-6462 / DEV-6336.
+    this._http
+      .post(`${this._basePath}/v3/export/resources`, body, {
+        observe: 'events',
+        reportProgress: true,
+        responseType: 'text',
+        headers: { Accept: 'text/csv' },
+      })
       .pipe(
         takeUntilDestroyed(this._destroyRef),
         finalize(() => {


### PR DESCRIPTION
…ream (DEV-6336)

dsp-api now streams the CSV export as a chunked binary body (format: binary, PR dasch-swiss/dsp-api#4124). The OpenAPI generator turns that into a responseType:'blob' client method returning HttpEvent<Blob>, which (a) breaks the compile of the events callback typed HttpEvent<string> and (b) would drop HttpDownloadProgressEvent.partialText — the input the live row counter (DEV-6462) depends on.

Bypass the generated APIV3ApiService and issue the request via HttpClient with responseType:'text', observe:'events', reportProgress:true — the behaviour the generated client provided before the backend switched to a binary stream. The Bearer token is still attached by authInterceptorFn (URL matches the API base path). Spec assertions updated to match the direct HttpClient call.