### PR TITLE
fix: retry enabling auto-merge on openapi spec-bump PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,10 +372,24 @@ jobs:
             echo "::error::No open PR found for branch ${BRANCH} after create."
             exit 1
           fi
-          if ! gh pr merge --auto --squash "$PR_URL"; then
-            echo "::warning::Enabling auto-merge failed; current state:"
-            gh pr view "$PR_URL" --json autoMergeRequest --jq .autoMergeRequest || true
-          fi
+          # Enabling auto-merge immediately after `gh pr create` often fails
+          # while GitHub is still computing mergeability (mergeable: UNKNOWN),
+          # which previously left the PR needing a manual click. Retry until it
+          # sticks. Arming it via the App token (a bypass actor) is what lets the
+          # PR merge without a review once the required checks pass.
+          for attempt in 1 2 3 4 5; do
+            if gh pr merge --auto --squash "$PR_URL"; then
+              echo "Auto-merge enabled (attempt ${attempt})."
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::warning::Could not enable auto-merge after ${attempt} attempts; current state:"
+              gh pr view "$PR_URL" --json autoMergeRequest --jq .autoMergeRequest || true
+            else
+              echo "Enabling auto-merge failed (attempt ${attempt}); retrying in 10s…"
+              sleep 10
+            fi
+          done
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}


### PR DESCRIPTION
Follow-up to #3155.

## Problem

#3155 wired up auto-merge for spec-bump PRs, but the `gh pr merge --auto` call runs **immediately after** `gh pr create`, when GitHub hasn't finished computing the PR's mergeability (`mergeable: UNKNOWN`). The call errors, the old code only logged a warning and moved on, so the PR was created but auto-merge never armed.

Observed on #3156: created by the App with green required CI, but `enabledBy` was a human — auto-merge had to be enabled manually ~12 min later.

## Fix

Retry `gh pr merge --auto --squash` up to 5× with a 10s backoff until it sticks. Arming it via the **App token** (a bypass actor for the required-review rule on `main`) is what lets the PR squash-merge without a review once the required checks pass — so the bump flows end-to-end with no human click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)