### PR TITLE
fix: prevent destruction if the resource does not change (DEV-6611)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,10 +180,10 @@ jobs:
         include:
           # Heavy runner: resource.cy.ts (many API requests per test), data-model-class.cy.ts (DB reset per test), plus smaller specs to balance load
           - runner: heavy
-            specs: cypress/e2e/system-admin/resource.cy.ts,cypress/e2e/system-admin/resource-edit-preserves-view.cy.ts,cypress/e2e/system-admin/data-model-class.cy.ts,cypress/e2e/system-admin/still-image.cy.ts,cypress/e2e/system-admin/file-representation.cy.ts
+            specs: cypress/e2e/system-admin/resource.cy.ts,cypress/e2e/system-admin/data-model-class.cy.ts,cypress/e2e/system-admin/still-image.cy.ts,cypress/e2e/system-admin/file-representation.cy.ts
           # Rest runner: remaining specs
           - runner: rest
-            specs: cypress/e2e/system-admin/ontology.cy.ts,cypress/e2e/system-admin/projects.cy.ts,cypress/e2e/system-admin/lists.cy.ts,cypress/e2e/system-admin/project-members.cy.ts,cypress/e2e/system-admin/project-overview.cy.ts,cypress/e2e/project-member/**/*.cy.ts,cypress/e2e/logged-out-user/**/*.cy.ts,cypress/e2e/performance/**/*.cy.ts
+            specs: cypress/e2e/system-admin/resource-edit-preserves-view.cy.ts,cypress/e2e/system-admin/ontology.cy.ts,cypress/e2e/system-admin/projects.cy.ts,cypress/e2e/system-admin/lists.cy.ts,cypress/e2e/system-admin/project-members.cy.ts,cypress/e2e/system-admin/project-overview.cy.ts,cypress/e2e/project-member/**/*.cy.ts,cypress/e2e/logged-out-user/**/*.cy.ts,cypress/e2e/performance/**/*.cy.ts
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         include:
           # Heavy runner: resource.cy.ts (many API requests per test), data-model-class.cy.ts (DB reset per test), plus smaller specs to balance load
           - runner: heavy
-            specs: cypress/e2e/system-admin/resource.cy.ts,cypress/e2e/system-admin/data-model-class.cy.ts,cypress/e2e/system-admin/still-image.cy.ts,cypress/e2e/system-admin/file-representation.cy.ts
+            specs: cypress/e2e/system-admin/resource.cy.ts,cypress/e2e/system-admin/resource-edit-preserves-view.cy.ts,cypress/e2e/system-admin/data-model-class.cy.ts,cypress/e2e/system-admin/still-image.cy.ts,cypress/e2e/system-admin/file-representation.cy.ts
           # Rest runner: remaining specs
           - runner: rest
             specs: cypress/e2e/system-admin/ontology.cy.ts,cypress/e2e/system-admin/projects.cy.ts,cypress/e2e/system-admin/lists.cy.ts,cypress/e2e/system-admin/project-members.cy.ts,cypress/e2e/system-admin/project-overview.cy.ts,cypress/e2e/project-member/**/*.cy.ts,cypress/e2e/logged-out-user/**/*.cy.ts,cypress/e2e/performance/**/*.cy.ts

--- a/apps/dsp-app/cypress/e2e/system-admin/resource-edit-preserves-view.cy.ts
+++ b/apps/dsp-app/cypress/e2e/system-admin/resource-edit-preserves-view.cy.ts
@@ -1,0 +1,103 @@
+import { faker } from '@faker-js/faker';
+
+import { Project00FFPayloads } from '../../fixtures/project00FF-resource-payloads';
+import { ClassPropertyPayloads } from '../../fixtures/property-definition-payloads';
+import { ResourceRequests, ResponseUtil } from '../../fixtures/requests';
+import { AddResourceInstancePage } from '../../support/pages/add-resource-instance-page';
+
+const getAuthHeaders = () => ({
+  Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+});
+
+/**
+ * Guards the architectural contract that editing a property in the resource
+ * viewer must NOT tear down and recreate the resource subtree. If it did,
+ * the page would scroll back to the top and the user would lose their place
+ * mid-edit — a UX regression we explicitly want to prevent.
+ *
+ * The Storybook story `resource-dispatcher.component.stories.ts` covers the
+ * dispatcher's own contract in isolation; this e2e covers the full chain
+ * from `ResourceFetcherComponent` down through the dispatcher to
+ * `PropertiesDisplayComponent` against a real backend, so it catches
+ * destroy-on-reload regressions introduced anywhere along that path.
+ *
+ * The "plain" resource (no file representation) is the case that historically
+ * carried the bug — see the fix in `resource-dispatcher.component.ts`'s
+ * `ngOnChanges` and the matching unit-test coverage.
+ */
+describe('Resource view preserves identity on edit (no scroll-to-top)', () => {
+  let finalLastModificationDate: string;
+  let propertyName: string;
+  let po: AddResourceInstancePage;
+  const project00FFPayloads = new Project00FFPayloads();
+
+  // Mirrors the setup in resource.cy.ts: create a fresh plain class on the
+  // 00FF/images ontology and attach a short-text property to it.
+  beforeEach(() => {
+    const className = `class${faker.string.alphanumeric(8)}`;
+    propertyName = `prop${faker.string.alphanumeric(8)}`;
+    po = new AddResourceInstancePage(className);
+
+    const ontologyIri = encodeURIComponent(`${Cypress.env('apiUrl')}/ontology/00FF/images/v2`);
+    cy.request({
+      method: 'GET',
+      url: `${Cypress.env('apiUrl')}/v2/ontologies/allentities/${ontologyIri}`,
+      headers: getAuthHeaders(),
+    }).then(ontResponse => {
+      const currentLmd = ontResponse.body['knora-api:lastModificationDate']['@value'];
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('apiUrl')}/v2/ontologies/classes`,
+        headers: getAuthHeaders(),
+        body: project00FFPayloads.createClassPayload(className, undefined, currentLmd),
+      }).then(response => {
+        finalLastModificationDate = ResponseUtil.lastModificationDate(response);
+      });
+    });
+  });
+
+  it('keeps the properties-display subtree alive after editing a text value', () => {
+    const initialValue = faker.lorem.word();
+    const editedValue = faker.lorem.word();
+
+    ResourceRequests.resourceRequest(
+      ClassPropertyPayloads.textShort(finalLastModificationDate, propertyName),
+      false,
+      po.className,
+      propertyName
+    );
+    po.visitAddPage();
+
+    // ---- Create the resource ----
+    po.addInitialLabel();
+    cy.get('[data-cy=text-input]').type(initialValue);
+    po.clickOnSubmit();
+    cy.contains(initialValue);
+
+    // ---- Tag the live DOM so we can prove it survives the edit ----
+    // The dispatcher renders <app-resource-plain> for non-representation
+    // resources. If the dispatcher destroys+recreates the subtree on reload,
+    // this tagged node will be gone and the assertion below fails.
+    cy.get('app-resource-plain').first().invoke('attr', 'data-test-survives-edit', 'original');
+
+    // ---- Edit the value WITHOUT cy.reload() ----
+    // AddResourceInstancePage.saveEdit() calls cy.reload() — we intentionally
+    // bypass it here because that reload would mask the very regression we
+    // are guarding against.
+    po.mouseHover();
+    cy.get('[data-cy=edit-button]').click({ force: true });
+    cy.get('[data-cy=text-input] input').clear().type(editedValue);
+    cy.intercept('PUT', '**/v2/values').as('saveValue');
+    cy.get('[data-cy=save-button]').click({ force: true });
+    cy.wait('@saveValue');
+
+    // ---- Assertions ----
+    // 1. The edited value is rendered.
+    cy.contains(editedValue);
+
+    // 2. The tagged <app-resource-plain> still exists with its marker —
+    //    proves the subtree was NOT destroyed and recreated.
+    //    A regression of the destroy-on-reload bug would make this fail.
+    cy.get('app-resource-plain[data-test-survives-edit="original"]').should('exist');
+  });
+});

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-dispatcher.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-dispatcher.component.stories.ts
@@ -1,0 +1,234 @@
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Component, importProvidersFrom, Input } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import {
+  CountQueryResponse,
+  ReadResource,
+  ResourceClassAndPropertyDefinitions,
+  ResourceClassDefinitionWithPropertyDefinition,
+} from '@dasch-swiss/dsp-js';
+import { ProjectApiService, UserApiService } from '@dasch-swiss/vre/3rd-party-services/api';
+import { AdminAPIApiService } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { AppConfigService, DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
+import { DspResource } from '@dasch-swiss/vre/shared/app-common';
+import { NotificationService } from '@dasch-swiss/vre/ui/notification';
+import { applicationConfig, moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
+import { NEVER, of } from 'rxjs';
+import { expect, waitFor } from 'storybook/test';
+
+import { ResourceFetcherService } from './representation/resource-fetcher.service';
+import { ResourceDispatcherComponent } from './resource-dispatcher.component';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const PLAIN_RESOURCE_IRI = 'http://rdfh.ch/resource/plain-1';
+const PLAIN_RESOURCE_TYPE = 'http://example.org/onto#PlainThing';
+
+const makeEmptyEntityInfo = (resourceType: string): ResourceClassAndPropertyDefinitions => {
+  const classStub = {
+    label: 'Plain Thing',
+    getResourcePropertiesList: () => [],
+    propertiesList: [],
+  } as unknown as ResourceClassDefinitionWithPropertyDefinition;
+  return new ResourceClassAndPropertyDefinitions({ [resourceType]: classStub }, {});
+};
+
+// Builds a Plain (no file value, no Region/Segment) DspResource — exactly the type
+// that routes through the dispatcher's async compound-count branch, which is where
+// the destroy-on-reload bug used to live.
+const makePlainResource = (label: string): DspResource => {
+  const res = new ReadResource();
+  res.id = PLAIN_RESOURCE_IRI;
+  res.type = PLAIN_RESOURCE_TYPE;
+  res.label = label;
+  res.attachedToProject = 'http://rdfh.ch/projects/test';
+  res.attachedToUser = 'http://rdfh.ch/users/test';
+  res.userHasPermission = 'CR';
+  res.properties = {};
+  res.entityInfo = makeEmptyEntityInfo(res.type);
+
+  const dsp = new DspResource(res);
+  dsp.resProps = [];
+  return dsp;
+};
+
+// ---------------------------------------------------------------------------
+// Host component
+//
+// The point of this story is to assert that the dispatcher does NOT tear down
+// the rendered subtree (<app-resource-plain> in our case) when the parent
+// re-emits a fresh DspResource reference with the same id — the production
+// path that ResourceFetcherService.reload() takes after a property edit.
+//
+// Storybook does not have a built-in "swap @Input mid-play" primitive, so we
+// wrap the dispatcher in a tiny host that exposes a button which reassigns
+// the resource @Input. The play() function clicks the button — the click
+// runs inside Angular's NgZone so change detection picks up the new reference
+// and the dispatcher's ngOnChanges fires, mirroring the production flow.
+// ---------------------------------------------------------------------------
+
+@Component({
+  selector: 'app-dispatcher-reload-host',
+  template: `
+    <button data-cy="story-reload-button" (click)="reloadWithSameId('Updated label')">Reload</button>
+    <app-resource-dispatcher [resource]="resource" />
+  `,
+  imports: [ResourceDispatcherComponent],
+})
+class DispatcherReloadHostComponent {
+  @Input() resource!: DspResource;
+
+  reloadWithSameId(updatedLabel: string) {
+    // Mimic ResourceFetcherService.reload(): emit a *new* DspResource reference
+    // with the same id but mutated content. Same identity check, different object.
+    this.resource = makePlainResource(updatedLabel);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared providers
+// ---------------------------------------------------------------------------
+
+const appConfigServiceStub = {
+  dspApiConfig: { apiUrl: '' },
+  dspAppConfig: { iriBase: 'http://rdfh.ch' },
+};
+
+const projectApiServiceStub = {
+  get: () =>
+    of({
+      project: {
+        id: 'http://rdfh.ch/projects/test',
+        shortcode: '0000',
+        shortname: 'test',
+        longname: 'Test Project',
+      },
+    }),
+};
+
+// CountQueryResponse with 0 results → dispatcher classifies the resource as Plain
+// (not Compound). The constant is exposed so the play() can verify the right
+// branch is exercised.
+const PLAIN_COUNT_RESPONSE: CountQueryResponse = { numberOfResults: 0 } as CountQueryResponse;
+
+const sharedProviders = [
+  importProvidersFrom(OverlayModule),
+  provideRouter([{ path: '**', component: class {} }]),
+  { provide: AppConfigService, useValue: appConfigServiceStub },
+  { provide: ProjectApiService, useValue: projectApiServiceStub },
+  { provide: UserApiService, useValue: { get: () => of({ user: { givenName: 'Jane', familyName: 'Doe' } }) } },
+  { provide: NotificationService, useValue: { openSnackBar: () => {} } },
+  {
+    provide: AdminAPIApiService,
+    useValue: {
+      getAdminProjectsIriProjectiri: () =>
+        of({
+          project: {
+            id: 'http://rdfh.ch/projects/test',
+            shortcode: '0000',
+            shortname: 'test',
+            longname: 'Test Project',
+          },
+        }),
+      getAdminProjectsShortcodeProjectshortcodeLegalInfoLicenses: () => of({ licenses: [] }),
+    },
+  },
+  // The ResourceFetcherService is provided by an ancestor in production. The
+  // dispatcher itself does not inject it, but the subtree (ResourceHeader etc.)
+  // does. A minimal stub keeps observable subscriptions happy without driving
+  // any state changes.
+  {
+    provide: ResourceFetcherService,
+    useValue: {
+      userCanEdit$: of(false),
+      userCanDelete$: of(false),
+      attachedUser$: of({ givenName: 'Jane', familyName: 'Doe', username: 'jane.doe' }),
+      resource$: NEVER,
+      scrollToTop$: NEVER,
+    },
+  },
+  {
+    provide: DspApiConnectionToken,
+    useValue: {
+      v2: {
+        // dispatcher.ngOnChanges() calls this for resources without a file value
+        // to disambiguate Plain from Compound. Returning 0 → Plain.
+        search: {
+          doSearchStillImageRepresentationsCount: () => of(PLAIN_COUNT_RESPONSE),
+          doSearchIncomingLinks: () => of({ resources: [], mayHaveMoreResults: false }),
+        },
+        res: {
+          canDeleteResource: () => of({ canDo: true }),
+        },
+        onto: { getOntology: () => of({}) },
+      },
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<DispatcherReloadHostComponent> = {
+  title: 'Resource Editor / Resource Dispatcher',
+  component: DispatcherReloadHostComponent,
+  decorators: [
+    moduleMetadata({ imports: [DispatcherReloadHostComponent] }),
+    applicationConfig({ providers: sharedProviders }),
+  ],
+};
+export default meta;
+type Story = StoryObj<DispatcherReloadHostComponent>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+export const PreservesSubtreeOnSameIdReload: Story = {
+  name: 'preserves the resource subtree when reloaded with the same id (no scroll-to-top)',
+  args: { resource: makePlainResource('Initial label') },
+  play: async ({ canvasElement, step }) => {
+    await step('Plain resource subtree is rendered', async () => {
+      await waitFor(
+        () => {
+          const subtreeRoot = canvasElement.querySelector('app-resource-plain');
+          expect(subtreeRoot).not.toBeNull();
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    await step('Tag the rendered DOM node so survival can be asserted after reload', async () => {
+      const subtreeRoot = canvasElement.querySelector('app-resource-plain');
+      expect(subtreeRoot).not.toBeNull();
+      subtreeRoot!.setAttribute('data-test-survives-reload', 'original');
+    });
+
+    await step('Simulate ResourceFetcherService.reload() — new DspResource, same id', async () => {
+      // Click the host's reload button. The button click runs inside Angular's
+      // NgZone, which propagates the new @Input reference and fires the
+      // dispatcher's ngOnChanges with a previousValue carrying the same id —
+      // the exact production path triggered by ResourceFetcherService.reload().
+      const button = canvasElement.querySelector<HTMLButtonElement>('[data-cy="story-reload-button"]');
+      expect(button).not.toBeNull();
+      button!.click();
+    });
+
+    await step('Same DOM node is still present — subtree was NOT destroyed', async () => {
+      await waitFor(
+        () => {
+          const survivor = canvasElement.querySelector('app-resource-plain[data-test-survives-reload="original"]');
+          // If this assertion fails, the dispatcher destroyed and recreated the
+          // subtree on same-id reload — a regression of the bug fixed in
+          // resource-dispatcher.component.ts ngOnChanges. The user-visible
+          // effect would be the page scrolling back to the top mid-edit.
+          expect(survivor).not.toBeNull();
+        },
+        { timeout: 1000 }
+      );
+    });
+  },
+};

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-dispatcher.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-dispatcher.component.ts
@@ -102,9 +102,7 @@ export class ResourceDispatcherComponent implements OnChanges, OnDestroy {
     // torn down and recreated, which would scroll the page back to the top.
     const previousResource = changes?.['resource']?.previousValue as DspResource | undefined;
     const isSameResource =
-      previousResource !== undefined &&
-      previousResource.res.id === this.resource.res.id &&
-      this.resourceType !== null;
+      previousResource !== undefined && previousResource.res.id === this.resource.res.id && this.resourceType !== null;
     if (isSameResource) {
       return;
     }

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-dispatcher.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-dispatcher.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Inject, Input, OnChanges, OnDestroy } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { CountQueryResponse, KnoraApiConnection } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
 import { DspResource } from '@dasch-swiss/vre/shared/app-common';
@@ -96,7 +96,19 @@ export class ResourceDispatcherComponent implements OnChanges, OnDestroy {
     @Inject(DspApiConnectionToken) private readonly _dspApi: KnoraApiConnection
   ) {}
 
-  ngOnChanges() {
+  ngOnChanges(changes?: SimpleChanges) {
+    // Reloading the same resource (same id) cannot change its type — skip re-classification
+    // so the existing subtree (PropertiesDisplay etc.) receives ngOnChanges instead of being
+    // torn down and recreated, which would scroll the page back to the top.
+    const previousResource = changes?.['resource']?.previousValue as DspResource | undefined;
+    const isSameResource =
+      previousResource !== undefined &&
+      previousResource.res.id === this.resource.res.id &&
+      this.resourceType !== null;
+    if (isSameResource) {
+      return;
+    }
+
     this._destroy$.next();
     this.resourceType = null;
     this.compoundCount = 0;


### PR DESCRIPTION
Fixes the issue that child components get destroyed after updating or adding property values for two types of resources:
- plain resources
- compound resources

(All other resource types were not affected). Destruction and nulling of the type forced a reload of the resource and the properties, so users lost their focus after updating a property.

The fix: We compare the id/iri of the resource and only reset and destroy when the resource changes.

If the new resource has the same id/iri it must have the same type (we can not change a resources type), so we don't need to null and reset the type, so the child components do not get destroyed and the changes run through without destroying and reloading the properties.