### PR TITLE
feat(i18n): translate data labels at easy-finding sites (DEV-6627)

### DIFF
--- a/libs/vre/pages/ontology/list/src/lib/action-bubble/action-bubble.component.ts
+++ b/libs/vre/pages/ontology/list/src/lib/action-bubble/action-bubble.component.ts
@@ -7,6 +7,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { ListNode } from '@dasch-swiss/dsp-js';
 import { ListApiService } from '@dasch-swiss/vre/3rd-party-services/api';
 import { DspDialogConfig } from '@dasch-swiss/vre/core/config';
+import { LocalizationService, pickPreferredLanguageString } from '@dasch-swiss/vre/shared/app-helper-services';
 import { MultiLanguages } from '@dasch-swiss/vre/ui/string-literal';
 import { DIALOG_LARGE, DialogService } from '@dasch-swiss/vre/ui/ui';
 import { TranslateService } from '@ngx-translate/core';
@@ -89,14 +90,15 @@ export class ActionBubbleComponent {
     private readonly _dialog: DialogService,
     private readonly _matDialog: MatDialog,
     private readonly _listItemService: ListItemService,
-    private readonly _listApiService: ListApiService
+    private readonly _listApiService: ListApiService,
+    private readonly _localizationService: LocalizationService
   ) {}
 
   askToDeleteListNode() {
     this._dialog
       .afterConfirmation(
         this._translate.instant('pages.ontology.list.actionBubble.deleteNode'),
-        this.node.labels[0].value
+        pickPreferredLanguageString(this.node.labels, this._localizationService.currentLanguage)
       )
       .pipe(switchMap(() => this._listApiService.deleteListNode(this.node.id)))
       .subscribe(() => {

--- a/libs/vre/pages/ontology/list/src/lib/list-item-form/edit-list-item/edit-list-item-dialog.component.ts
+++ b/libs/vre/pages/ontology/list/src/lib/list-item-form/edit-list-item/edit-list-item-dialog.component.ts
@@ -10,7 +10,7 @@ import {
 import { StringLiteral } from '@dasch-swiss/dsp-js';
 import { ListApiService } from '@dasch-swiss/vre/3rd-party-services/api';
 import { LoadingButtonDirective } from '@dasch-swiss/vre/ui/progress-indicator';
-import { MultiLanguages } from '@dasch-swiss/vre/ui/string-literal';
+import { MultiLanguages, StringifyStringLiteralPipe } from '@dasch-swiss/vre/ui/string-literal';
 import { DialogHeaderComponent } from '@dasch-swiss/vre/ui/ui';
 import { TranslatePipe } from '@ngx-translate/core';
 import { finalize, of, switchMap } from 'rxjs';
@@ -27,7 +27,7 @@ export interface EditListItemDialogProps {
   selector: 'app-edit-list-item-dialog',
   template: `
     <app-dialog-header
-      [title]="data.formData.labels[0].value"
+      [title]="data.formData.labels | appStringifyStringLiteral"
       [subtitle]="'pages.ontology.list.editDialog.subtitle' | translate" />
 
     <div mat-dialog-content>
@@ -53,6 +53,7 @@ export interface EditListItemDialogProps {
     MatDialogActions,
     MatDialogClose,
     MatDialogContent,
+    StringifyStringLiteralPipe,
     TranslatePipe,
     DialogHeaderComponent,
     LoadingButtonDirective,

--- a/libs/vre/pages/ontology/list/src/lib/list-item-form/list-item-form.component.ts
+++ b/libs/vre/pages/ontology/list/src/lib/list-item-form/list-item-form.component.ts
@@ -5,7 +5,11 @@ import { MatIcon } from '@angular/material/icon';
 import { ListNodeInfo } from '@dasch-swiss/dsp-js';
 import { ListApiService } from '@dasch-swiss/vre/3rd-party-services/api';
 import { atLeastOneStringRequired } from '@dasch-swiss/vre/shared/app-common';
-import { ProjectService } from '@dasch-swiss/vre/shared/app-helper-services';
+import {
+  LocalizationService,
+  pickPreferredLanguageString,
+  ProjectService,
+} from '@dasch-swiss/vre/shared/app-helper-services';
 import { DEFAULT_MULTILANGUAGE_FORM, MultiLanguageInputComponent } from '@dasch-swiss/vre/ui/string-literal';
 import { TranslateService } from '@ngx-translate/core';
 import { ListItemService } from '../list-item/list-item.service';
@@ -45,14 +49,15 @@ export class ListItemFormComponent {
 
   get placeholder() {
     return this._translate.instant('pages.ontology.list.listItemForm.appendItem', {
-      parent: this.parentNode.labels[0].value,
+      parent: pickPreferredLanguageString(this.parentNode.labels, this._localizationService.currentLanguage),
     });
   }
 
   constructor(
     private readonly _listApiService: ListApiService,
     private readonly _listItemService: ListItemService,
-    private readonly _fb: FormBuilder
+    private readonly _fb: FormBuilder,
+    private readonly _localizationService: LocalizationService
   ) {}
 
   createChildNode() {

--- a/libs/vre/pages/ontology/list/src/lib/list-page.component.ts
+++ b/libs/vre/pages/ontology/list/src/lib/list-page.component.ts
@@ -10,6 +10,7 @@ import { ListNodeInfo, ListResponse } from '@dasch-swiss/dsp-js';
 import { ListApiService } from '@dasch-swiss/vre/3rd-party-services/api';
 import { DspDialogConfig, RouteConstants } from '@dasch-swiss/vre/core/config';
 import { ProjectPageService } from '@dasch-swiss/vre/pages/project/project';
+import { LocalizationService, pickPreferredLanguageString } from '@dasch-swiss/vre/shared/app-helper-services';
 import { ProgressIndicatorOverlayComponent } from '@dasch-swiss/vre/ui/progress-indicator';
 import { StringifyStringLiteralPipe } from '@dasch-swiss/vre/ui/string-literal';
 import { CenteredLayoutComponent, DialogService, TruncatePipe } from '@dasch-swiss/vre/ui/ui';
@@ -65,6 +66,7 @@ export class ListPageComponent implements OnInit, OnDestroy {
   constructor(
     private readonly _dialog: DialogService,
     private readonly _listItemService: ListItemService,
+    private readonly _localizationService: LocalizationService,
     private readonly _matDialog: MatDialog,
     private readonly _projectPageService: ProjectPageService,
     private readonly _route: ActivatedRoute,
@@ -95,7 +97,10 @@ export class ListPageComponent implements OnInit, OnDestroy {
 
   askToDeleteList(list: ListNodeInfo): void {
     this._dialog
-      .afterConfirmation(this._translate.instant('pages.ontology.list.deleteConfirmation'), list.labels[0].value)
+      .afterConfirmation(
+        this._translate.instant('pages.ontology.list.deleteConfirmation'),
+        pickPreferredLanguageString(list.labels, this._localizationService.currentLanguage)
+      )
       .pipe(switchMap(() => this._listApiService.deleteListNode(list.id)))
       .subscribe(() => {
         this.navigateToDataModels();

--- a/libs/vre/pages/ontology/ontology/src/lib/properties/property-info/property-info.component.html
+++ b/libs/vre/pages/ontology/ontology/src/lib/properties/property-info/property-info.component.html
@@ -15,8 +15,7 @@
         matTooltipPosition="above"
         matTooltipClass="multi-line-tooltip"
         data-cy="property-labels">
-        {{ property.propDef!.labels.length ? (property.propDef!.labels | appStringifyStringLiteral) :
-        property.propDef?.label }}
+        {{ property.propDef!.labels | appStringifyStringLiteral }}
       </span>
       <mat-icon
         [matTooltip]="property.propDef.comments | appStringifyStringLiteral"

--- a/libs/vre/pages/ontology/ontology/src/lib/resource-classes/resource-class-info/cardinality-component/cardinality-change-dialog.component.ts
+++ b/libs/vre/pages/ontology/ontology/src/lib/resource-classes/resource-class-info/cardinality-component/cardinality-change-dialog.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef } fro
 import { MatIcon } from '@angular/material/icon';
 import { Cardinality, Constants, KnoraApiConnection } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
+import { LocalizationService, pickPreferredLanguageString } from '@dasch-swiss/vre/shared/app-helper-services';
 import { ProgressIndicatorOverlayComponent } from '@dasch-swiss/vre/ui/progress-indicator';
 import { DialogHeaderComponent } from '@dasch-swiss/vre/ui/ui';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -122,14 +123,18 @@ export class CardinalityChangeDialogComponent implements OnInit {
   }
 
   get propertyLabel(): string {
-    return this.data.propertyInfo.propDef?.label || '';
+    return pickPreferredLanguageString(
+      this.data.propertyInfo.propDef?.labels,
+      this._localizationService.currentLanguage
+    );
   }
 
   constructor(
     @Inject(DspApiConnectionToken) private readonly _dspApiConnection: KnoraApiConnection,
     @Inject(MAT_DIALOG_DATA) public data: CardinalityInfo,
     private readonly _cdr: ChangeDetectorRef,
-    protected dialogRef: MatDialogRef<CardinalityChangeDialogComponent, boolean>
+    protected dialogRef: MatDialogRef<CardinalityChangeDialogComponent, boolean>,
+    private readonly _localizationService: LocalizationService
   ) {}
 
   ngOnInit() {

--- a/libs/vre/pages/project/project/src/lib/download/download-property-list.component.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-property-list.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
 import { MatButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { PropertyInfoValues } from '@dasch-swiss/vre/shared/app-common';
+import { StringifyStringLiteralPipe } from '@dasch-swiss/vre/ui/string-literal';
 import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
@@ -33,9 +34,9 @@ import { TranslatePipe } from '@ngx-translate/core';
               style="margin-right: 12px" />
             <div style="flex: 1">
               <div style="display: flex; align-items: center; gap: 8px">
-                <span style="font-weight: 500">{{ property.property.propDef.label }}</span>
+                <span style="font-weight: 500">{{ property.property.propDef.labels | appStringifyStringLiteral }}</span>
               </div>
-              @if (property.property.propDef.comment; as comment) {
+              @if (property.property.propDef.comments | appStringifyStringLiteral; as comment) {
                 <p style="margin: 0; color: #666; font-size: 13px">{{ comment }}</p>
               }
             </div>
@@ -57,7 +58,7 @@ import { TranslatePipe } from '@ngx-translate/core';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [MatButton, MatCheckbox, TranslatePipe],
+  imports: [MatButton, MatCheckbox, StringifyStringLiteralPipe, TranslatePipe],
 })
 export class DownloadPropertyListComponent implements OnInit {
   @Input({ required: true }) propertyDefinitions!: PropertyInfoValues[];

--- a/libs/vre/resource-editor/resource-editor/src/lib/header/resource-header.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/header/resource-header.component.ts
@@ -7,6 +7,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { ReadResource, ResourceClassDefinitionWithPropertyDefinition } from '@dasch-swiss/dsp-js';
 import { DspDialogConfig } from '@dasch-swiss/vre/core/config';
 import { DspResource } from '@dasch-swiss/vre/shared/app-common';
+import { StringifyStringLiteralPipe } from '@dasch-swiss/vre/ui/string-literal';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ResourceFetcherService } from '../representation/resource-fetcher.service';
 import { EditResourceLabelDialogComponent } from './more-menu/edit-resource-label-dialog.component';
@@ -17,12 +18,13 @@ import { ResourceToolbarComponent } from './resource-toolbar.component';
   selector: 'app-resource-header',
   template: ` <div class="resource-header">
     <div class="resource-class-header">
+      @let resolvedComment = resourceClassType?.comments | appStringifyStringLiteral;
       <h3
-        [class.label-info]="resourceClassType?.comment"
-        [matTooltip]="resourceClassType?.comment"
+        [class.label-info]="resolvedComment"
+        [matTooltip]="resolvedComment"
         matTooltipClass="header-tooltip"
         matTooltipPosition="above">
-        {{ resourceClassType?.label }}
+        {{ resourceClassType?.labels | appStringifyStringLiteral }}
       </h3>
       <app-resource-toolbar [resource]="resource.res" />
     </div>
@@ -94,6 +96,7 @@ import { ResourceToolbarComponent } from './resource-toolbar.component';
     MatButtonModule,
     MatIconModule,
     MatTooltipModule,
+    StringifyStringLiteralPipe,
     TranslatePipe,
     ResourceInfoBarComponent,
     ResourceToolbarComponent,


### PR DESCRIPTION
[DEV-6627](https://linear.app/dasch/issue/DEV-6627)

## Summary
- Display data labels/comments in the user's current UI language at 8 easy-finding sites by swapping `.label` / `labels[0].value` reads for the existing `appStringifyStringLiteral` pipe (templates) and `pickPreferredLanguageString` helper (TypeScript).
- No upgrades to helpers, services, sort logic, or DTO shapes. Strictly mechanical adjustments using tools already in the codebase.

## Changes

**Pattern A — template pipe swaps (commit `46e4630e`)**
- `download-property-list.component.ts`: property label + comment
- `property-info.component.html`: drop unused `.label` fallback branch
- `resource-header.component.ts`: resource-class label + tooltip comment
- `edit-list-item-dialog.component.ts`: dialog title

**Pattern B — TS helper swaps (commit `6e23cd2e`)**
- `list-page.component.ts`: delete-confirmation subtitle
- `action-bubble.component.ts`: delete-node confirmation subtitle
- `list-item-form.component.ts`: append-item placeholder parent label
- `cardinality-change-dialog.component.ts`: `propertyLabel` getter

**Sites dropped (out of scope per the plan's gate)**
- `delete-value-dialog.component.ts` — `PropertyValueService.propertyDefinition` is typed `ResourcePropertyDefinition` (no `.labels`); widening the shared service field would ripple beyond a mechanical swap.
- `list-value.component.ts`, `list-viewer.component.ts` — `ListNodeV2.label` is single-language by API contract; requires API change.

## Test Plan
- [x] `npx nx run-many --target=lint --projects=vre-pages-project-project,vre-pages-ontology-ontology,vre-pages-ontology-list,vre-resource-editor-resource-editor` — 0 errors, only pre-existing non-null-assertion warnings on unchanged files
- [x] `npx nx run-many --target=test --projects=vre-pages-project-project,vre-pages-ontology-ontology,vre-pages-ontology-list,vre-resource-editor-resource-editor` — 366 passed, 1 skipped, 0 failed
- [ ] Manual: switch UI language; verify labels/tooltips on the touched components update without page reload

## References
- Plan: `docs/specs/2026-06-16-feat-language-consistency-plan.md` (untracked, local)
- Predecessor: DEV-6607 (PR #3115)
- Reference shape: DEV-6628 (PR #3172)

🤖 Generated with [Claude Code](https://claude.com/claude-code)