### PR TITLE
fix: fix footer sticky position and hidden social icons (DEV-6644)

### DIFF
--- a/libs/vre/pages/user-settings/user/src/lib/project-overview/project-overview.component.scss
+++ b/libs/vre/pages/user-settings/user/src/lib/project-overview/project-overview.component.scss
@@ -1,3 +1,16 @@
+@use "config" as *;
+
+// Sticky footer: fill at least the viewport below the header so the footer stays at the bottom on short pages.
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - #{$small-header-height});
+}
+
+.content {
+  flex: 1 0 auto;
+}
+
 .project-overview-subtitle {
   margin-top: 2rem;
 }

--- a/libs/vre/shared/app-help-page/src/lib/footer/footer.component.html
+++ b/libs/vre/shared/app-help-page/src/lib/footer/footer.component.html
@@ -90,7 +90,7 @@
     </div>
 
     <!-- Social media -->
-    <div class="footer-socials">
+    <div class="footer-icon-links">
       <a
         href="https://www.linkedin.com/company/dasch-swiss"
         target="_blank"

--- a/libs/vre/shared/app-help-page/src/lib/footer/footer.component.scss
+++ b/libs/vre/shared/app-help-page/src/lib/footer/footer.component.scss
@@ -78,8 +78,8 @@ footer {
   }
 }
 
-// Social media icons
-.footer-socials {
+// Social media icons — class avoids the "social" token, which content blockers (e.g. Brave Shields) hide.
+.footer-icon-links {
   display: flex;
   align-items: center;
   gap: 24px;


### PR DESCRIPTION
[DEV-6644](https://linear.app/dasch/issue/DEV-6644)

## Summary
- Footer social icons (LinkedIn, X, GitHub) flashed then vanished — content blockers (Brave Shields, EasyList social cosmetic filters) match the `.footer-socials` class token and strip the element from the DOM after first paint. Renamed to a token-free class.
- Footer floated mid-page on short/empty landing pages (e.g. before projects load) instead of sticking to the bottom. Added a sticky-footer layout.

## Changes
**Hidden social icons (`footer.component.html` / `.scss`)**
- Renamed `.footer-socials` → `.footer-icon-links`. The hrefs and `aria-label`s are unchanged; dasch.swiss uses the same links with token-free classes and its icons survive with Shields on, confirming the class token was the trigger.

**Sticky footer (`project-overview.component.scss`)**
- `:host` is now a flex column with `min-height: calc(100vh - $small-header-height)`; `.content` gets `flex: 1 0 auto` to absorb slack and push the footer to the bottom. Contained to the landing page (component is only mounted at the home route).

## Notes
- The third acceptance criterion (stale `.block`/`.center-block` SCSS, `<mat-icon>` usage) was already resolved by #2922, which rewrote the footer to match dasch.swiss. The current SCSS styles all real template classes — no change needed.

## Test Plan
- `nx run-many --target=lint` on both affected libs — pass (one pre-existing unrelated warning).
- `nx run-many --target=test` on both libs — pass.
- Standalone `sass` compile of the new SCSS with the app `includePaths` — resolves `$small-header-height` to `calc(100vh - 57px)`.
- Manual: verify icons render with Brave Shields **on** after the rename, and footer sticks to the bottom on a short/empty landing page.

## Screenshots
[Attach manually — UI change]