### PR TITLE
chore: convert NX lint/test targets to inferred + align Node engines floor (DEV-6686)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /dist
 /tmp
 /out-tsc
-/.swc
+.swc/
 migrations.json
 
 # dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ The main application is **DSP-APP** - a user interface for the Swiss National Da
 
 ### Additional Commands
 - `npm run lint-fix-all` - Lint and fix all projects in monorepo
-- `npm run lint-ci-all` - Lint all projects without auto-fix
+- `npm run lint-all` - Lint all projects without auto-fix
 
 ## Architecture Overview
 

--- a/apps/dsp-app/eslint.config.mjs
+++ b/apps/dsp-app/eslint.config.mjs
@@ -9,6 +9,10 @@ export default [
     },
   },
   {
-    ignores: ['coverage/'],
+    // Project-local ignores, resolved relative to this config's project root. The inferred
+    // `lint` target (@nx/eslint/plugin) runs `eslint .` with cwd = apps/dsp-app, so the
+    // workspace-root-relative `apps/dsp-app/cypress/` ignore in the base config no longer
+    // matches — re-ignore cypress here so E2E specs stay excluded as before (see DEV-6686).
+    ignores: ['coverage/', 'cypress/'],
   },
 ];

--- a/apps/dsp-app/project.json
+++ b/apps/dsp-app/project.json
@@ -176,15 +176,14 @@
       }
     },
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "apps/dsp-app/jest.config.ts"
+        "passWithNoTests": true
       },
       "configurations": {
         "ci": {
           "ci": true,
-          "codeCoverage": true
+          "runInBand": true,
+          "coverage": true
         }
       }
     },

--- a/apps/dsp-app/project.json
+++ b/apps/dsp-app/project.json
@@ -14,6 +14,7 @@
       "executor": "@angular-devkit/build-angular:application",
       "outputs": ["{options.outputPath.base}"],
       "dependsOn": ["vre-open-api:generate"],
+      "defaultConfiguration": "production",
       "options": {
         "outputPath": {
           "base": "dist/apps/dsp-app",
@@ -142,11 +143,11 @@
           "sourceMap": true,
           "extractLicenses": false
         }
-      },
-      "defaultConfiguration": "production"
+      }
     },
     "serve": {
       "executor": "@angular-devkit/build-angular:dev-server",
+      "continuous": true,
       "options": {
         "buildTarget": "dsp-app:build"
       },
@@ -166,18 +167,13 @@
         "stage-server": {
           "buildTarget": "dsp-app:build:stage-server"
         }
-      },
-      "continuous": true
+      }
     },
     "extract-i18n": {
       "executor": "@angular-devkit/build-angular:extract-i18n",
       "options": {
         "buildTarget": "dsp-app:build"
       }
-    },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
     },
     "test": {
       "executor": "@nx/jest:jest",
@@ -230,7 +226,13 @@
         "stylePreprocessorOptions": {
           "includePaths": ["apps/dsp-app/src/styles"]
         },
-        "assets": [{ "glob": "**/*", "input": "apps/dsp-app/src/assets", "output": "assets" }]
+        "assets": [
+          {
+            "glob": "**/*",
+            "input": "apps/dsp-app/src/assets",
+            "output": "assets"
+          }
+        ]
       },
       "configurations": {
         "ci": {
@@ -250,7 +252,13 @@
         "stylePreprocessorOptions": {
           "includePaths": ["apps/dsp-app/src/styles"]
         },
-        "assets": [{ "glob": "**/*", "input": "apps/dsp-app/src/assets", "output": "assets" }]
+        "assets": [
+          {
+            "glob": "**/*",
+            "input": "apps/dsp-app/src/assets",
+            "output": "assets"
+          }
+        ]
       },
       "configurations": {
         "ci": {

--- a/libs/dsp-js/project.json
+++ b/libs/dsp-js/project.json
@@ -22,10 +22,6 @@
         "jestConfig": "libs/dsp-js/jest.config.ts",
         "tsConfig": "libs/dsp-js/tsconfig.spec.json"
       }
-    },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
     }
   }
 }

--- a/libs/dsp-js/project.json
+++ b/libs/dsp-js/project.json
@@ -16,11 +16,15 @@
       }
     },
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/dsp-js/jest.config.ts",
-        "tsConfig": "libs/dsp-js/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     }
   }

--- a/libs/vre/3rd-party-services/analytics/project.json
+++ b/libs/vre/3rd-party-services/analytics/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/3rd-party-services/analytics/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/3rd-party-services/analytics/project.json
+++ b/libs/vre/3rd-party-services/analytics/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/3rd-party-services/analytics/jest.config.ts",
-        "tsConfig": "libs/vre/3rd-party-services/analytics/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/3rd-party-services/api/project.json
+++ b/libs/vre/3rd-party-services/api/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/3rd-party-services/api/jest.config.ts",
-        "tsConfig": "libs/vre/3rd-party-services/api/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/3rd-party-services/api/project.json
+++ b/libs/vre/3rd-party-services/api/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/3rd-party-services/api/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/3rd-party-services/open-api/project.json
+++ b/libs/vre/3rd-party-services/open-api/project.json
@@ -24,11 +24,16 @@
       }
     },
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "dependsOn": ["generate"],
       "options": {
-        "jestConfig": "libs/vre/3rd-party-services/open-api/jest.config.ts"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     }
   }

--- a/libs/vre/3rd-party-services/open-api/project.json
+++ b/libs/vre/3rd-party-services/open-api/project.json
@@ -14,26 +14,22 @@
       }
     },
     "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": [
-        "{options.outputFile}"
-      ],
       "dependsOn": ["generate"]
     },
     "tsc-errors": {
       "executor": "nx:run-commands",
+      "dependsOn": ["generate"],
       "options": {
         "command": "tsc --noEmit --project {projectRoot}/tsconfig.lib.json"
-      },
-      "dependsOn": ["generate"]
+      }
     },
     "test": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "dependsOn": ["generate"],
       "options": {
         "jestConfig": "libs/vre/3rd-party-services/open-api/jest.config.ts"
-      },
-      "dependsOn": ["generate"]
+      }
     }
   }
 }

--- a/libs/vre/core/config/project.json
+++ b/libs/vre/core/config/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/core/config/jest.config.ts",
-        "tsConfig": "libs/vre/core/config/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/core/config/project.json
+++ b/libs/vre/core/config/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/core/config/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/core/error-handler/project.json
+++ b/libs/vre/core/error-handler/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/core/error-handler/jest.config.ts",
-        "tsConfig": "libs/vre/core/error-handler/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/core/error-handler/project.json
+++ b/libs/vre/core/error-handler/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/core/error-handler/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/core/session/project.json
+++ b/libs/vre/core/session/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/core/session/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/core/session/project.json
+++ b/libs/vre/core/session/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/core/session/jest.config.ts",
-        "tsConfig": "libs/vre/core/session/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/data-browser/project.json
+++ b/libs/vre/pages/data-browser/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/data-browser/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/data-browser/project.json
+++ b/libs/vre/pages/data-browser/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/data-browser/jest.config.ts",
-        "tsConfig": "libs/vre/pages/data-browser/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/ontology/list/project.json
+++ b/libs/vre/pages/ontology/list/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/ontology/list/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/ontology/list/project.json
+++ b/libs/vre/pages/ontology/list/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/ontology/list/jest.config.ts",
-        "tsConfig": "libs/vre/pages/ontology/list/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/ontology/ontology/project.json
+++ b/libs/vre/pages/ontology/ontology/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/ontology/ontology/jest.config.ts",
-        "tsConfig": "libs/vre/pages/ontology/ontology/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/ontology/ontology/project.json
+++ b/libs/vre/pages/ontology/ontology/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/ontology/ontology/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/project/project/project.json
+++ b/libs/vre/pages/project/project/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/project/project/jest.config.ts",
-        "tsConfig": "libs/vre/pages/project/project/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/project/project/project.json
+++ b/libs/vre/pages/project/project/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/project/project/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/search/advanced-search/project.json
+++ b/libs/vre/pages/search/advanced-search/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/search/advanced-search/jest.config.ts",
-        "tsConfig": "libs/vre/pages/search/advanced-search/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/search/advanced-search/project.json
+++ b/libs/vre/pages/search/advanced-search/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/search/advanced-search/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/search/search/project.json
+++ b/libs/vre/pages/search/search/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/search/search/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/search/search/project.json
+++ b/libs/vre/pages/search/search/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/search/search/jest.config.ts",
-        "tsConfig": "libs/vre/pages/search/search/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/system/system/project.json
+++ b/libs/vre/pages/system/system/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/system/system/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/system/system/project.json
+++ b/libs/vre/pages/system/system/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/system/system/jest.config.ts",
-        "tsConfig": "libs/vre/pages/system/system/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/pages/user-settings/user/project.json
+++ b/libs/vre/pages/user-settings/user/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/pages/user-settings/user/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/pages/user-settings/user/project.json
+++ b/libs/vre/pages/user-settings/user/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/pages/user-settings/user/jest.config.ts",
-        "tsConfig": "libs/vre/pages/user-settings/user/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/resource-editor/resource-editor/project.json
+++ b/libs/vre/resource-editor/resource-editor/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/resource-editor/resource-editor/jest.config.ts",
-        "tsConfig": "libs/vre/resource-editor/resource-editor/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/resource-editor/resource-editor/project.json
+++ b/libs/vre/resource-editor/resource-editor/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/resource-editor/resource-editor/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/shared/app-common-to-move/project.json
+++ b/libs/vre/shared/app-common-to-move/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/shared/app-common-to-move/jest.config.ts",
-        "tsConfig": "libs/vre/shared/app-common-to-move/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/shared/app-common-to-move/project.json
+++ b/libs/vre/shared/app-common-to-move/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/shared/app-common-to-move/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/shared/app-common/project.json
+++ b/libs/vre/shared/app-common/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/shared/app-common/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/shared/app-common/project.json
+++ b/libs/vre/shared/app-common/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/shared/app-common/jest.config.ts",
-        "tsConfig": "libs/vre/shared/app-common/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/shared/app-help-page/project.json
+++ b/libs/vre/shared/app-help-page/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/shared/app-help-page/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/shared/app-help-page/project.json
+++ b/libs/vre/shared/app-help-page/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/shared/app-help-page/jest.config.ts",
-        "tsConfig": "libs/vre/shared/app-help-page/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/shared/app-helper-services/project.json
+++ b/libs/vre/shared/app-helper-services/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/shared/app-helper-services/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/shared/app-helper-services/project.json
+++ b/libs/vre/shared/app-helper-services/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/shared/app-helper-services/jest.config.ts",
-        "tsConfig": "libs/vre/shared/app-helper-services/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/shared/assets/status-msg/project.json
+++ b/libs/vre/shared/assets/status-msg/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/shared/assets/status-msg/jest.config.ts",
-        "tsConfig": "libs/vre/shared/assets/status-msg/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/shared/assets/status-msg/project.json
+++ b/libs/vre/shared/assets/status-msg/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/shared/assets/status-msg/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/shared/calendar/project.json
+++ b/libs/vre/shared/calendar/project.json
@@ -15,9 +15,6 @@
         "assets": ["libs/vre/shared/calendar/*.md"]
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint"
-    },
     "test": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],

--- a/libs/vre/shared/calendar/project.json
+++ b/libs/vre/shared/calendar/project.json
@@ -16,10 +16,15 @@
       }
     },
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/shared/calendar/jest.config.ts"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     }
   }

--- a/libs/vre/ui/date-picker/project.json
+++ b/libs/vre/ui/date-picker/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/ui/date-picker/jest.config.ts",
-        "tsConfig": "libs/vre/ui/date-picker/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/ui/date-picker/project.json
+++ b/libs/vre/ui/date-picker/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/ui/date-picker/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/ui/nested-menu/project.json
+++ b/libs/vre/ui/nested-menu/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/ui/nested-menu/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/ui/nested-menu/project.json
+++ b/libs/vre/ui/nested-menu/project.json
@@ -7,11 +7,15 @@
   "tags": ["type:ui"],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/ui/nested-menu/jest.config.ts",
-        "tsConfig": "libs/vre/ui/nested-menu/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/ui/notification/project.json
+++ b/libs/vre/ui/notification/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/ui/notification/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/ui/notification/project.json
+++ b/libs/vre/ui/notification/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/ui/notification/jest.config.ts",
-        "tsConfig": "libs/vre/ui/notification/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/ui/progress-indicator/project.json
+++ b/libs/vre/ui/progress-indicator/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/ui/progress-indicator/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/ui/progress-indicator/project.json
+++ b/libs/vre/ui/progress-indicator/project.json
@@ -7,11 +7,15 @@
   "tags": [],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/ui/progress-indicator/jest.config.ts",
-        "tsConfig": "libs/vre/ui/progress-indicator/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/ui/string-literal/project.json
+++ b/libs/vre/ui/string-literal/project.json
@@ -7,11 +7,15 @@
   "tags": ["type:ui"],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/ui/string-literal/jest.config.ts",
-        "tsConfig": "libs/vre/ui/string-literal/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/libs/vre/ui/string-literal/project.json
+++ b/libs/vre/ui/string-literal/project.json
@@ -14,10 +14,6 @@
         "tsConfig": "libs/vre/ui/string-literal/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/vre/ui/ui/project.json
+++ b/libs/vre/ui/ui/project.json
@@ -14,15 +14,11 @@
         "tsConfig": "libs/vre/ui/ui/tsconfig.spec.json"
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "tsc-errors": {
       "executor": "nx:run-commands",
       "options": {
         "command": "tsc --noEmit --project {projectRoot}/tsconfig.lib.json"
       }
-    },
+    }
   }
 }

--- a/libs/vre/ui/ui/project.json
+++ b/libs/vre/ui/ui/project.json
@@ -7,11 +7,15 @@
   "tags": ["type:ui"],
   "targets": {
     "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "libs/vre/ui/ui/jest.config.ts",
-        "tsConfig": "libs/vre/ui/ui/tsconfig.spec.json"
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "runInBand": true,
+          "coverage": true
+        }
       }
     },
     "tsc-errors": {

--- a/nx.json
+++ b/nx.json
@@ -44,10 +44,6 @@
         }
       }
     },
-    "@nx/eslint:lint": {
-      "inputs": ["default", "^default", "{workspaceRoot}/eslint.config.mjs", "{workspaceRoot}/tools/eslint-rules/**/*"],
-      "cache": true
-    },
     "@nx/js:tsc": {
       "cache": true,
       "dependsOn": ["^build"],
@@ -133,5 +129,44 @@
   },
   "defaultBase": "main",
   "useInferencePlugins": false,
-  "analytics": false
+  "analytics": false,
+  "plugins": [
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      },
+      "include": [
+        "apps/dsp-app/**/*",
+        "libs/dsp-js/**/*",
+        "libs/vre/3rd-party-services/analytics/**/*",
+        "libs/vre/3rd-party-services/api/**/*",
+        "libs/vre/3rd-party-services/open-api/**/*",
+        "libs/vre/core/config/**/*",
+        "libs/vre/core/error-handler/**/*",
+        "libs/vre/core/session/**/*",
+        "libs/vre/pages/data-browser/**/*",
+        "libs/vre/pages/ontology/list/**/*",
+        "libs/vre/pages/ontology/ontology/**/*",
+        "libs/vre/pages/project/project/**/*",
+        "libs/vre/pages/search/advanced-search/**/*",
+        "libs/vre/pages/search/search/**/*",
+        "libs/vre/pages/system/system/**/*",
+        "libs/vre/pages/user-settings/user/**/*",
+        "libs/vre/resource-editor/resource-editor/**/*",
+        "libs/vre/shared/app-common/**/*",
+        "libs/vre/shared/app-common-to-move/**/*",
+        "libs/vre/shared/app-help-page/**/*",
+        "libs/vre/shared/app-helper-services/**/*",
+        "libs/vre/shared/assets/status-msg/**/*",
+        "libs/vre/shared/calendar/**/*",
+        "libs/vre/ui/date-picker/**/*",
+        "libs/vre/ui/nested-menu/**/*",
+        "libs/vre/ui/notification/**/*",
+        "libs/vre/ui/progress-indicator/**/*",
+        "libs/vre/ui/string-literal/**/*",
+        "libs/vre/ui/ui/**/*"
+      ]
+    }
+  ]
 }

--- a/nx.json
+++ b/nx.json
@@ -30,20 +30,6 @@
       "inputs": ["default", "^production"],
       "cache": true
     },
-    "@nx/jest:jest": {
-      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
-      "cache": true,
-      "options": {
-        "passWithNoTests": true
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true,
-          "runInBand": true
-        }
-      }
-    },
     "@nx/js:tsc": {
       "cache": true,
       "dependsOn": ["^build"],
@@ -167,6 +153,12 @@
         "libs/vre/ui/string-literal/**/*",
         "libs/vre/ui/ui/**/*"
       ]
+    },
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
         "wait-on": "^9.0.4"
       },
       "engines": {
-        "node": "^22.12.0",
+        "node": "^22.13.0",
         "npm": "^10.9.0"
       },
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/dasch-swiss/dsp-app.git"
   },
   "engines": {
-    "node": "^22.12.0",
+    "node": "^22.13.0",
     "npm": "^10.9.0"
   },
   "scripts": {


### PR DESCRIPTION
[DEV-6686](https://linear.app/dasch/issue/DEV-6686)

Follow-up to the Angular 21 / NX 23 upgrade. NX 23 deprecates the `@nx/eslint:lint` and `@nx/jest:jest` executors (removed in NX 24); converting now de-risks the NX 24 `nx migrate`.

## Summary
- Migrate lint + test off the deprecated explicit executors to inferred targets (`@nx/eslint/plugin`, `@nx/jest/plugin`).
- Bump `engines.node` floor `^22.12.0` → `^22.13.0` to match `.nvmrc` (22.23.1) and devDep `EBADENGINE` requirements.

## Changes
**eslint → inferred** (`nx g @nx/eslint:convert-to-inferred`)
- Registers `@nx/eslint/plugin` in `nx.json`; removes explicit `lint` targets from all 29 `project.json` files and the now-dead `@nx/eslint:lint` `targetDefault`.
- The inferred target runs `eslint .` from each project's dir. Flat-config `ignores` resolve relative to cwd, so the workspace-root-relative `apps/dsp-app/cypress/` ignore in the base config stopped matching and E2E specs leaked into linting. Re-added `cypress/` to `apps/dsp-app/eslint.config.mjs` to preserve the prior exclusion.

**jest → inferred** (`nx g @nx/jest:convert-to-inferred`)
- Registers `@nx/jest/plugin` in `nx.json`; converts `test` targets (drops executor/outputs/jestConfig/tsConfig — now inferred) and removes the dead `@nx/jest:jest` `targetDefault`.
- `passWithNoTests` and the `ci` configuration (coverage + runInBand) migrated inline per project. Coverage output paths (`coverage/<projectRoot>`) unchanged.

**engines**
- `package.json` `engines.node` → `^22.13.0`; `package-lock.json` regenerated to match.

## Test Plan
- `nx run-many --all --target=lint` → 29/29 pass.
- `nx run-many --all --target=test` → 29/29 pass.
- `nx run <proj>:test --configuration=ci` → produces `coverage-final.json` under `coverage/<projectRoot>`; confirms the `unit-test-coverage-ci` → `merge-coverage.js` → `lcov.info` path used by CI/Codecov is intact.
- Confirmed no remaining `@nx/eslint:lint` / `@nx/jest:jest` references; CI workflows use target names (unaffected).

## Follow-up (out of scope)
- `CLAUDE.md` references `npm run lint-ci-all`, which doesn't exist (script is `lint-all`). Pre-existing doc typo, unrelated to this conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)