### PR TITLE
chore(deps): update uuid to v14 

### DIFF
--- a/libs/vre/pages/search/advanced-search/jest.config.ts
+++ b/libs/vre/pages/search/advanced-search/jest.config.ts
@@ -4,7 +4,8 @@ module.exports = {
   preset: '../../../../../jest.preset.js',
   coverageDirectory: '../../../../../coverage/libs/vre/pages/search/advanced-search',
   transformIgnorePatterns: [
-    'node_modules/(?!.*\\.mjs$|@angular|@dasch-swiss|@ngx-translate|@ckeditor|ngx-color-picker|lodash-es)',
+    // uuid is ESM-only since v12 — let SWC transform it instead of ignoring it.
+    'node_modules/(?!.*\\.mjs$|@angular|@dasch-swiss|@ngx-translate|@ckeditor|ngx-color-picker|lodash-es|uuid)',
   ],
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.d.ts', '!src/test-setup.ts', '!src/index.ts'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "rxjs": "^7.8.0",
         "ts-md5": "^2.0.0",
         "tslib": "^2.8.1",
-        "uuid": "9.0.1",
+        "uuid": "14.0.1",
         "zod": "^4.0.0",
         "zone.js": "0.16.2"
       },
@@ -75,7 +75,6 @@
         "@swc/jest": "^0.2.39",
         "@types/jest": "30.0.0",
         "@types/node": "^22.18.11",
-        "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
         "@typescript-eslint/utils": "^8.40.0",
@@ -14343,13 +14342,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
     },
@@ -34715,17 +34707,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "rxjs": "^7.8.0",
     "ts-md5": "^2.0.0",
     "tslib": "^2.8.1",
-    "uuid": "9.0.1",
+    "uuid": "14.0.1",
     "zod": "^4.0.0",
     "zone.js": "0.16.2"
   },
@@ -105,7 +105,6 @@
     "@swc/jest": "^0.2.39",
     "@types/jest": "30.0.0",
     "@types/node": "^22.18.11",
-    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
     "@typescript-eslint/utils": "^8.40.0",


### PR DESCRIPTION
Completes the `uuid` major update (supersedes the Renovate PR #3194), fixing the two CI jobs it broke.

## Root cause
The Renovate major bump (`uuid` 9 → 14, `@types/uuid` ^9 → ^11) failed CI in two ways, both consequences of uuid's modern packaging:

- **DSP-APP Unit tests** — uuid is **ESM-only** since v12. The `advanced-search` jest project overrides `transformIgnorePatterns` and excluded uuid, so SWC skipped it and jest failed to parse `export` syntax → 6 suites died with `SyntaxError: Unexpected token 'export'`.
- **Storybook Interaction Tests (Build)** — `@types/uuid@11` is now an **empty deprecated stub** (uuid ships its own types). TypeScript auto-including it from `node_modules/@types` couldn't resolve an entry file → `TS2688: Cannot find type definition file for 'uuid'`.

## Changes
- **`chore(deps)`** — bump `uuid` 9.0.1 → 14.0.1; **remove** `@types/uuid` (the stub is `you do not need this installed`), rather than bumping it as Renovate proposed.
- **`test(advanced-search)`** — add `uuid` to that lib's jest `transformIgnorePatterns` allow-list so SWC transforms the ESM package (same treatment as the existing `lodash-es`).

uuid stays a direct dependency only for the **v5** namespace hash that pseudonymises user IRIs in the analytics Faro service (`crypto.randomUUID()` has no v5 equivalent, and changing it would break existing telemetry user ids). Verified `v5.URL` still works at runtime in v14. The v4 id generation in `advanced-search` is unchanged.

## Test plan
- `nx run vre-pages-search-advanced-search:test` → 6 suites / 54 tests pass (failed before the jest fix)
- `nx run vre-3rd-party-services-analytics:test` → passes (dynamic `import('uuid')` consumer)
- `nx run dsp-app:build-storybook:ci` → builds successfully (TS2688 gone, `v5.URL` typechecks against uuid's own types)
- `nx run vre-pages-search-advanced-search:lint` → passes

closes #3196 

🤖 Generated with [Claude Code](https://claude.com/claude-code)