### PR TITLE
fix: CJS interop fixes after application builder upgrade

### DIFF
--- a/libs/dsp-js/src/api/v2/list/lists-endpoint-v2.ts
+++ b/libs/dsp-js/src/api/v2/list/lists-endpoint-v2.ts
@@ -1,10 +1,8 @@
+import jsonld from 'jsonld/dist/jsonld.js';
 import { catchError, map, mergeMap } from 'rxjs';
 import { AjaxResponse } from 'rxjs/ajax';
 import { ListNodeV2 } from '../../../models/v2/lists/list-node-v2';
 import { Endpoint } from '../../endpoint';
-
-declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
-const jsonld = require('jsonld/dist/jsonld.js');
 
 /**
  * Handles requests to the lists route of the Knora API.

--- a/libs/dsp-js/src/api/v2/ontology/ontologies-endpoint-v2.ts
+++ b/libs/dsp-js/src/api/v2/ontology/ontologies-endpoint-v2.ts
@@ -1,3 +1,4 @@
+import jsonld from 'jsonld/dist/jsonld.js';
 import { catchError, map, mergeMap } from 'rxjs';
 import { AjaxResponse } from 'rxjs/ajax';
 import { ApiResponseError } from '../../../models/api-response-error';
@@ -35,9 +36,6 @@ import { UpdateResourcePropertyGuiElement } from '../../../models/v2/ontologies/
 import { UpdateResourcePropertyLabel } from '../../../models/v2/ontologies/update/update-resource-property-label';
 import { CardinalityUtil } from '../../../models/v2/resources/cardinality-util';
 import { Endpoint } from '../../endpoint';
-
-declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
-const jsonld = require('jsonld/dist/jsonld.js');
 
 /**
  * Handles requests to the ontologies route of the Knora API.

--- a/libs/dsp-js/src/api/v2/resource/resources-endpoint-v2.ts
+++ b/libs/dsp-js/src/api/v2/resource/resources-endpoint-v2.ts
@@ -1,3 +1,4 @@
+import jsonld from 'jsonld/dist/jsonld.js';
 import { Observable, catchError, map, mergeMap } from 'rxjs';
 import { AjaxResponse } from 'rxjs/ajax';
 import { ListNodeV2Cache } from '../../../cache/ListNodeV2Cache';
@@ -15,9 +16,6 @@ import { UpdateResourceMetadata } from '../../../models/v2/resources/update/upda
 import { UpdateResourceMetadataResponse } from '../../../models/v2/resources/update/update-resource-metadata-response';
 import { Endpoint } from '../../endpoint';
 import { V2Endpoint } from '../v2-endpoint';
-
-declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
-const jsonld = require('jsonld/dist/jsonld.js');
 
 /**
  * Handles requests to the resources route of the Knora API.

--- a/libs/dsp-js/src/api/v2/search/search-endpoint-v2.ts
+++ b/libs/dsp-js/src/api/v2/search/search-endpoint-v2.ts
@@ -1,3 +1,4 @@
+import jsonld from 'jsonld/dist/jsonld.js';
 import { catchError, map, mergeMap } from 'rxjs';
 import { AjaxResponse } from 'rxjs/ajax';
 import { ListNodeV2Cache } from '../../../cache/ListNodeV2Cache';
@@ -8,9 +9,6 @@ import { KnoraApiConfig } from '../../../knora-api-config';
 import { ResourcesConversionUtil } from '../../../models/v2/resources/ResourcesConversionUtil';
 import { Endpoint } from '../../endpoint';
 import { V2Endpoint } from '../v2-endpoint';
-
-declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
-const jsonld = require('jsonld/dist/jsonld.js');
 
 /**
  * Handles requests to the search route of the Knora API.

--- a/libs/dsp-js/src/api/v2/values/values-endpoint-v2.ts
+++ b/libs/dsp-js/src/api/v2/values/values-endpoint-v2.ts
@@ -1,3 +1,4 @@
+import jsonld from 'jsonld/dist/jsonld.js';
 import { catchError, map, mergeMap } from 'rxjs';
 import { AjaxResponse } from 'rxjs/ajax';
 import { ListNodeV2Cache } from '../../../cache/ListNodeV2Cache';
@@ -14,9 +15,6 @@ import { UpdateValue } from '../../../models/v2/resources/values/update/update-v
 import { WriteValueResponse } from '../../../models/v2/resources/values/write-value-response';
 import { Endpoint } from '../../endpoint';
 import { V2Endpoint } from '../v2-endpoint';
-
-declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
-const jsonld = require('jsonld/dist/jsonld.js');
 
 /**
  * Handles requests to the values route of the Knora API.


### PR DESCRIPTION
Follow-up to #3195 (`migrate esbuild application builder, drop ngx-build-plus`).
The new `@angular-devkit/build-angular:application` executor uses esbuild for
`build` and Vite for `ng serve`. Both follow strict ESM interop for CommonJS
modules — the old webpack-based builder silently collapsed those imports.
Three places in the codebase were relying on the old behaviour. This PR fixes
all of them.

## What it does

### 1. `libs/dsp-js/src/api/v2/**` — drop CJS `require` of jsonld

Five v2 endpoints replace

```ts
declare let require: any;
const jsonld = require('jsonld/dist/jsonld.js');
```

with a single static ESM import:

```ts
import jsonld from 'jsonld/dist/jsonld.js';
```

### 2. `libs/vre/ui/ui/src/lib/ck-editor/ck-editor.component.ts` — unwrap CKEditor default export

`ckeditor5-custom-build` is a UMD bundle that assigns `ClassicEditor` to
`module.exports` (and ends with `module.exports = module.exports.default`).
`import * as Editor` collapsed to the class under webpack; under esbuild it
becomes `{ default: ClassicEditor, ... }` and `editor.create(...)` throws
`TypeError: this.editor.create is not a function` the moment a rich-text
value is edited. Replaced with a defensive `EditorNs.default ?? EditorNs`
unwrap that works under either builder.

### 3. `libs/vre/resource-editor/.../osd-drawer.service.ts` — align openseadragon import

Same CJS-default-export shape as ckeditor. Two sibling files in the same
folder already use the default-import form (`import OpenSeadragon from 'openseadragon'`);
this one was still on `import * as OpenSeadragon`, a latent regression that
would only fire when drawing regions over an image. Aligned with the
siblings.

## Impact

### Consumers of `@dasch-swiss/dsp-js` on npm

No behavioural change. Bundler-based consumers (webpack, esbuild, Rollup,
Vite) get the same binding as before. Pure-ESM consumers (Node ESM, Deno) —
who previously hit `Dynamic require of "jsonld/dist/jsonld.js" is not
supported` — now work too. The published JS is now standards-compliant ESM
instead of ESM-with-embedded-`require()`-calls.

### This repo

- Local `npm run start-dev` boots again on a clean tree (no more `Dynamic
  require of jsonld/dist/jsonld.js`).
- Editing any rich-text value (and indirectly the parent forms that mount
  CKEditor) works again, locally and on `app.dev.dasch.swiss` once deployed.
- Region drawing on still images is protected against the same regression.

## Technical details

The published `@dasch-swiss/dsp-js` package is compiled with `module: ES2020`
and ships as ESM. The old `require()` pattern emitted literal `require()`
calls inside that ESM output — invalid by the spec, but tolerated because
every known consumer bundled the result, and bundlers rewrite `require()` at
build time. Vite (introduced as the local dev server by #3195) serves modules
as native browser ESM and does not rewrite `require()` calls — so the same
literal that bundlers silently fixed now reaches the browser unchanged and
throws.

The CKEditor / OpenSeadragon issue is the symmetric case: those UMD modules
expose the class via `module.exports`, and webpack's `import * as`
implementation collapsed the namespace to the class. esbuild follows the
spec — `import * as X` on a CJS module yields a Module Namespace Object with
the CJS shape as the `default` key. Whatever the old code accessed on `X`
directly is now on `X.default`. Defensive unwrap (`X.default ?? X`) covers
both behaviours.

`esModuleInterop: true` in `tsconfig.base.json` is the load-bearing setting
throughout — it lets the static `import jsonld from …` resolve to the same
`module.exports` object that `require()` returned, and lets the default
import on openseadragon resolve to the class.