### PR TITLE
fix(ci): deploy PR preview by image digest so pushes roll out

### DIFF
--- a/.github/workflows/cloud-run-pr-preview.yml
+++ b/.github/workflows/cloud-run-pr-preview.yml
@@ -69,6 +69,7 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -84,7 +85,14 @@ jobs:
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ secrets.GCP_REGION }}
-          image: ${{ secrets.GCP_ARTIFACT_REGISTRY }}/dsp-app:${{ env.IMAGE_TAG }}
+          # Deploy by immutable digest, not the mutable :pr-N tag. Re-deploying
+          # the same tag string is a no-op on Cloud Run (the revision is pinned
+          # to the digest resolved at the previous deploy), so pushes would not
+          # roll out. The digest changes on every build, forcing a new revision.
+          image: ${{ secrets.GCP_ARTIFACT_REGISTRY }}/dsp-app@${{ steps.build.outputs.digest }}
+          # Wait for the new revision to become ready and take traffic so the
+          # job status reflects deploy success instead of always going green.
+          wait: true
           flags: >-
             --port=4200
             --allow-unauthenticated
@@ -208,6 +216,7 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -223,7 +232,14 @@ jobs:
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ secrets.GCP_REGION }}
-          image: ${{ secrets.GCP_ARTIFACT_REGISTRY }}/dsp-app:${{ env.IMAGE_TAG }}
+          # Deploy by immutable digest, not the mutable :pr-N tag. Re-deploying
+          # the same tag string is a no-op on Cloud Run (the revision is pinned
+          # to the digest resolved at the previous deploy), so pushes would not
+          # roll out. The digest changes on every build, forcing a new revision.
+          image: ${{ secrets.GCP_ARTIFACT_REGISTRY }}/dsp-app@${{ steps.build.outputs.digest }}
+          # Wait for the new revision to become ready and take traffic so the
+          # job status reflects deploy success instead of always going green.
+          wait: true
           flags: >-
             --port=4200
             --allow-unauthenticated


### PR DESCRIPTION
## Problem

PR preview deployments were not updating when new commits were pushed, even though the **PR Preview** workflow passed green. Example: [run 28502468005](https://github.com/dasch-swiss/dsp-app/actions/runs/28502468005/job/84484973342).

## Root cause

The workflow pushed the image to a **mutable tag** (`dsp-app:pr-N`) and deployed that same tag. `gcloud run deploy` compares the image *reference string* against the running revision — since `dsp-app:pr-N` is byte-for-byte identical every time, Cloud Run decided nothing changed and **created no new revision**. The running service kept serving the old revision's pinned digest while the new code sat unused in the registry.

`wait: false` compounded it: the deploy step returned success without checking the result, so the job went green regardless.

## Fix

- **Deploy by immutable digest** (`dsp-app@${{ steps.build.outputs.digest }}`) instead of the `:pr-N` tag, in both the `pull_request` and `workflow_dispatch` jobs. The digest changes on every build, forcing a new revision. The tag is still pushed so the cleanup jobs can delete `:pr-N`.
- **Set `wait: true`** so the job status reflects the new revision becoming healthy and taking traffic.

## Testing

YAML validated locally. Real verification happens when this merges and a subsequent push to a PR rolls out a new revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)