### PR TITLE
fix(e2e): use unique entity names in data-model-class spec

### DIFF
--- a/apps/dsp-app/cypress/e2e/system-admin/data-model-class.cy.ts
+++ b/apps/dsp-app/cypress/e2e/system-admin/data-model-class.cy.ts
@@ -2,6 +2,7 @@ import { ResourceClassDefinitionWithAllLanguages } from '../../../../../libs/dsp
 import { faker } from '@faker-js/faker';
 import { DataModelClassProperty } from '../../models/data-model-class';
 import { CLASS_TYPES, PropertyType } from '../../support/helpers/constants';
+import { uniqueName } from '../../support/helpers/unique-name';
 import ProjectPage from '../../support/pages/project-page';
 
 describe('Data Model Class', () => {
@@ -19,7 +20,7 @@ describe('Data Model Class', () => {
     const classType = CLASS_TYPES.textRepresentation;
 
     const textClass: ResourceClassDefinitionWithAllLanguages = {
-      id: faker.lorem.word(),
+      id: uniqueName(),
       subClassOf: [],
       propertiesList: [],
       canBeInstantiated: true,
@@ -30,7 +31,7 @@ describe('Data Model Class', () => {
     };
 
     const resourceClass: ResourceClassDefinitionWithAllLanguages = {
-      id: faker.lorem.word(),
+      id: uniqueName(),
       subClassOf: [],
       propertiesList: [],
       canBeInstantiated: true,
@@ -77,7 +78,7 @@ describe('Data Model Class', () => {
   it('should create new class with object class constraints (e.g. page as part of a book)', () => {
     const bookType = CLASS_TYPES.objectWithoutRepresentation;
     const bookClass: ResourceClassDefinitionWithAllLanguages = {
-      id: faker.lorem.word(),
+      id: uniqueName(),
       subClassOf: [],
       propertiesList: [],
       canBeInstantiated: true,
@@ -89,7 +90,7 @@ describe('Data Model Class', () => {
 
     const stillImageType = CLASS_TYPES.stillImageRepresentation;
     const stillImageClass: ResourceClassDefinitionWithAllLanguages = {
-      id: faker.lorem.word(),
+      id: uniqueName(),
       subClassOf: [],
       propertiesList: [],
       canBeInstantiated: true,
@@ -135,13 +136,13 @@ describe('Data Model Class', () => {
 
     // link them
     const partOfProperty = <DataModelClassProperty>{
-      name: faker.lorem.word(),
+      name: uniqueName(),
       label: `B${faker.lorem.words(5)}`,
       comment: faker.lorem.words(10),
     };
 
     const linkToClassProperty = <DataModelClassProperty>{
-      name: faker.lorem.word(),
+      name: uniqueName(),
       label: `A${faker.lorem.words(5)}`,
       comment: faker.lorem.words(10),
     };
@@ -191,7 +192,7 @@ describe('Data Model Class', () => {
     cy.get('[data-cy=back-to-data-models]').should('be.visible').click();
     cy.get('[data-cy=create-list-button]').should('be.visible').click();
 
-    const listLabel = faker.lorem.word();
+    const listLabel = uniqueName();
 
     cy.get('[data-cy=create-list-button]').click({ force: true, multiple: false });
     cy.get('[data-cy=label-input]:visible').should('have.length', 1).type(listLabel);
@@ -208,7 +209,7 @@ describe('Data Model Class', () => {
     cy.get(`[data-cy=${PropertyType.List}]`).should('be.visible').click();
     cy.get(`[data-cy=${PropertyType.Dropdown}]`).should('be.visible').click();
 
-    cy.get('[data-cy=name-input]').clear().type(faker.lorem.word());
+    cy.get('[data-cy=name-input]').clear().type(uniqueName());
     cy.get('[data-cy=label-input] input').clear().type(faker.lorem.word({ length: 2 }));
     cy.get('[data-cy=comment-textarea]').type(faker.lorem.word({ length: 5 }));
     cy.get('[data-cy=object-attribute-list]').click(); // open dropdown
@@ -252,7 +253,7 @@ describe('Data Model Class', () => {
 
   it('should add property to a data model class', () => {
     const textProperty = <DataModelClassProperty>{
-      name: faker.lorem.word(),
+      name: uniqueName(),
       label: faker.lorem.words(5),
       comment: faker.lorem.words(10),
     };

--- a/apps/dsp-app/cypress/support/helpers/unique-name.ts
+++ b/apps/dsp-app/cypress/support/helpers/unique-name.ts
@@ -1,0 +1,27 @@
+import { faker } from '@faker-js/faker';
+
+// Monotonic counter guaranteeing uniqueness within a single spec run, even when
+// two names are generated in the same millisecond.
+let counter = 0;
+
+/**
+ * Generate a unique, valid ontology entity name (class or property `name`).
+ *
+ * Ontology names are validated in the app by `CustomRegex.ID_NAME_REGEX`
+ * (`/^(?![vV]+[0-9])+^([a-zA-Z])[a-zA-Z0-9_.-]*$/`) AND by an async
+ * "already exists" validator that keeps the submit button disabled on any
+ * collision with an existing entity name.
+ *
+ * Bare `faker.lorem.word()` draws from a ~1000-word dictionary, so two calls in
+ * the same test (or a clash with a reset-database default) intermittently
+ * collide, the submit button stays disabled, and `cy.click()` fails with
+ * "this element is `disabled`". This flakiness — not any API change — is what
+ * stalls the auto-generated OpenAPI spec-bump PRs.
+ *
+ * The counter suffix makes the name unique; the leading lowercase letter keeps
+ * it regex-valid and clear of the `v|V` + digit lookahead.
+ */
+export function uniqueName(): string {
+  counter += 1;
+  return `e2e${faker.string.alpha({ length: 6, casing: 'lower' })}${counter}`;
+}

--- a/libs/vre/3rd-party-services/open-api/dsp-api_spec.yaml
+++ b/libs/vre/3rd-party-services/open-api/dsp-api_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: DSP-API
-  version: v36.3.0-1-g9bd6eee
+  version: v36.4.0-5-g9df9bf5
   summary: DSP-API is part of the DaSCH Service Platform, a repository for the long-term
     preservation and reuse of data in the humanities.
   contact:
@@ -136,6 +136,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
+                    dataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -249,6 +250,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
+                    dataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -357,6 +359,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
+                    dataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -477,6 +480,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
+                    dataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -585,6 +589,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
+                    dataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -702,6 +707,7 @@ paths:
                       - http://rdfh.ch/licenses/cc-0-1.0
                       - http://rdfh.ch/licenses/cc-by-nc-4.0
                       - http://rdfh.ch/licenses/cc-by-sa-4.0
+                      dataAuthorship: []
                     status: true
                     selfjoin: false
                   projects:
@@ -735,6 +741,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
+                    dataAuthorship: []
                   permissions:
                     groupsPerProject: {}
                     administrativePermissionsPerProject: {}
@@ -851,6 +858,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
+                    dataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -3724,6 +3732,93 @@ paths:
       security:
       - httpAuth: []
       - httpAuth1: []
+  /admin/projects/shortcode/{projectShortcode}/legal-info/resource:
+    put:
+      tags:
+      - Admin API
+      description: 'Set the resource-side (data) legal info for this project: the
+        data license (Creative Commons only), the copyright holder and the default
+        authorship, each applied to every resource record in the project. Returns
+        the saved values. The user must be a system or project admin.'
+      operationId: putAdminProjectsShortcodeProjectshortcodeLegal-infoResource
+      parameters:
+      - name: projectShortcode
+        in: path
+        description: The shortcode of a project. Must be a 4 digit hexadecimal String.
+        required: true
+        schema:
+          type: string
+        example: '0001'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceSideLegalInfo'
+            example:
+              dataLicense: http://rdfh.ch/licenses/cc-by-4.0
+              dataCopyrightHolder: University of Basel
+              dataAuthorship:
+              - Lotte Reiniger
+              - Hilma af Klint
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceSideLegalInfo'
+              example:
+                dataLicense: http://rdfh.ch/licenses/cc-by-4.0
+                dataCopyrightHolder: University of Basel
+                dataAuthorship:
+                - Lotte Reiniger
+                - Hilma af Klint
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/OntologyConstraintException'
+                - $ref: '#/components/schemas/DuplicateValueException'
+                - $ref: '#/components/schemas/ValidationException'
+                - $ref: '#/components/schemas/BadRequestException'
+                - $ref: '#/components/schemas/GravsearchException'
+                - $ref: '#/components/schemas/EditConflictException'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadCredentialsException'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenException'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundException'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConflictException'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+      - httpAuth: []
+      - httpAuth1: []
   /admin/projects:
     get:
       tags:
@@ -5225,7 +5320,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       responses:
         '200':
           description: ''
@@ -5289,7 +5384,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       responses:
         '200':
           description: ''
@@ -5353,7 +5448,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       responses:
         '200':
           description: ''
@@ -5542,7 +5637,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       responses:
         '200':
           description: ''
@@ -5608,7 +5703,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       responses:
         '200':
           description: ''
@@ -5812,7 +5907,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -5885,7 +5980,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -5959,7 +6054,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -6032,7 +6127,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       - name: projectIri
         in: path
         description: The IRI of a project. Must be URL-encoded.
@@ -6106,7 +6201,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       - name: groupIri
         in: path
         description: The IRI of a group. Must be URL-encoded.
@@ -6179,7 +6274,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       - name: groupIri
         in: path
         description: The IRI of a group. Must be URL-encoded.
@@ -6253,7 +6348,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       requestBody:
         content:
           application/json:
@@ -6326,7 +6421,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       requestBody:
         content:
           application/json:
@@ -6399,7 +6494,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       requestBody:
         content:
           application/json:
@@ -6472,7 +6567,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/users/uKOlBV-ES7CfmpuAyPPP8A
+        example: http://rdfh.ch/users/q5KfSIXnRtygfY3e3cEUhg
       requestBody:
         content:
           application/json:
@@ -6743,7 +6838,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/lists/0001/GUwM_dH8R-yeYt_1im-mJQ
+        example: http://rdfh.ch/lists/0001/6a6FUHw_QDucPFKJWR8C-w
       - name: allLanguages
         in: query
         description: If true, return rdfs:label and rdfs:comment as JSON-LD arrays
@@ -6871,7 +6966,7 @@ paths:
         required: true
         schema:
           type: string
-        example: http://rdfh.ch/lists/0001/GUwM_dH8R-yeYt_1im-mJQ
+        example: http://rdfh.ch/lists/0001/6a6FUHw_QDucPFKJWR8C-w
       - name: allLanguages
         in: query
         description: If true, return rdfs:label and rdfs:comment as JSON-LD arrays
@@ -9216,6 +9311,125 @@ paths:
       description: Mark a resource as deleted. Requires appropriate object access
         permissions on the resource.
       operationId: postV2ResourcesDelete
+      parameters:
+      - name: x-knora-accept-schema
+        in: header
+        description: |-
+          The ontology schema to be used for the request.
+          If not specified, the default schema ApiV2Complex will be used.
+        required: false
+        schema:
+          type: string
+      - name: schema
+        in: query
+        description: |-
+          The ontology schema to be used for the request.
+          If not specified, the default schema ApiV2Complex will be used.
+        required: false
+        schema:
+          type: string
+      - name: x-knora-json-ld-rendering
+        in: header
+        description: |-
+          The JSON-LD rendering to be used for the request (flat or hierarchical).
+          If not specified, hierarchical JSON-LD will be used.
+        required: false
+        schema:
+          type: string
+      - name: markup
+        in: query
+        description: The markup rendering to be used for the request (XML or standoff).
+        required: false
+        schema:
+          type: string
+      - name: x-knora-accept-markup
+        in: header
+        description: The markup rendering to be used for the request (XML or standoff).
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        '200':
+          description: ''
+          headers:
+            Content-Type:
+              required: true
+              schema:
+                type: string
+          content:
+            application/ld+json:
+              schema:
+                type: string
+            text/turtle:
+              schema:
+                type: string
+            application/trig:
+              schema:
+                type: string
+            application/rdf+xml:
+              schema:
+                type: string
+            application/n-quads:
+              schema:
+                type: string
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/OntologyConstraintException'
+                - $ref: '#/components/schemas/DuplicateValueException'
+                - $ref: '#/components/schemas/ValidationException'
+                - $ref: '#/components/schemas/BadRequestException'
+                - $ref: '#/components/schemas/GravsearchException'
+                - $ref: '#/components/schemas/EditConflictException'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadCredentialsException'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenException'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundException'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConflictException'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+      - httpAuth: []
+      - httpAuth1: []
+  /v2/resources/authorship:
+    put:
+      tags:
+      - API v2
+      description: Update a resource's authorship (data side). Requires Modify object
+        access permission on the resource.
+      operationId: putV2ResourcesAuthorship
       parameters:
       - name: x-knora-accept-schema
         in: header
@@ -15875,9 +16089,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
               example:
-                webapi: v36.3.0-1-g9bd6eee
-                buildCommit: 9bd6eee4f
-                buildTime: '2026-06-26T16:03:25Z'
+                webapi: v36.4.0-5-g9df9bf5
+                buildCommit: 9df9bf5b6
+                buildTime: '2026-06-30T17:13:51Z'
                 fuseki: 6.1.0-0
                 scala: 3.3.7
                 sipi: v5.0.1
@@ -17429,6 +17643,14 @@ components:
           uniqueItems: true
           items:
             type: string
+        dataLicense:
+          type: string
+        dataCopyrightHolder:
+          type: string
+        dataAuthorship:
+          type: array
+          items:
+            type: string
     ProjectAdminMembersGetResponseADM:
       title: ProjectAdminMembersGetResponseADM
       type: object
@@ -17720,6 +17942,18 @@ components:
           format: date-time
         isDeleted:
           type: boolean
+    ResourceSideLegalInfo:
+      title: ResourceSideLegalInfo
+      type: object
+      properties:
+        dataLicense:
+          type: string
+        dataCopyrightHolder:
+          type: string
+        dataAuthorship:
+          type: array
+          items:
+            type: string
     RestrictedViewResponse:
       title: RestrictedViewResponse
       type: object


### PR DESCRIPTION
## Context

While investigating *\"why CI does not open a new PR for OpenAPI updates\"*, the automation turned out to be working correctly — it had already opened spec-bump PR #3214. That PR is **stuck** on a failing `DSP-APP E2E tests` check, so auto-merge never fires, and the workflow's one-open-PR dedup guard then blocks every subsequent spec-bump PR. Net effect: OpenAPI updates are frozen.

The failing check was **not** caused by the dsp-api spec change. The v36.3.0 → v36.4.0 diff is purely additive (new `PUT .../legal-info/resource`, `GET /v2/resources/authorship`, schema `ResourceSideLegalInfo`); every removed line is metadata only, and none of it touches the ontology flow the failing test exercises.

## Root cause

`data-model-class.cy.ts` → *"should create new class with object class"* fails with:

```
CypressError: cy.click() failed because this element is `disabled`
```

on the `[data-cy=submit-button]`. Ontology class/property `name` fields are validated by `existingNamesAsyncValidator`, which keeps submit **disabled** on any collision with an existing entity name. The test generates names with unseeded `faker.lorem.word()` (a ~1000-word dictionary) and creates several classes/properties in one run — so two names occasionally collide, submit stays disabled, and the click times out. This spec passes on `main` only because it happened not to hit a collision there; it's non-deterministic.

## Fix

- Add `cypress/support/helpers/unique-name.ts` — `uniqueName()` returns a regex-valid (`ID_NAME_REGEX`) name with a monotonic-counter suffix, so it's collision-free within a run.
- Use it for every `name-input`-bound field in `data-model-class.cy.ts` (class `id`s, property `name`s, the dropdown property name, and the list label referenced by `.contains()`). `label`/`comment` fields keep `faker` (no uniqueness constraint).

## Scope

Kept to the spec that blocks #3214. Sibling specs (`ontology.cy.ts`, `ontology-management.cy.ts`, `projects.cy.ts`) feed the same `name-input` but create only one entity per test, so their collision risk is far lower — flagged as follow-up, not changed here.

Once this merges, re-running #3214's E2E (or a fresh spec-bump PR) should go green and unfreeze the OpenAPI automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)