### PR TITLE
refactor(legal): rename dataAuthorship to defaultDataAuthorship

### DIFF
--- a/libs/dsp-js/src/models/admin/project.ts
+++ b/libs/dsp-js/src/models/admin/project.ts
@@ -72,6 +72,6 @@ export class Project {
   /**
    * The data-side default authorship of the project (applied to resource records).
    */
-  @JsonProperty('dataAuthorship', [String], true)
-  dataAuthorship?: string[] = undefined;
+  @JsonProperty('defaultDataAuthorship', [String], true)
+  defaultDataAuthorship?: string[] = undefined;
 }

--- a/libs/vre/3rd-party-services/open-api/dsp-api_spec.yaml
+++ b/libs/vre/3rd-party-services/open-api/dsp-api_spec.yaml
@@ -136,7 +136,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
-                    dataAuthorship: []
+                    defaultDataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -250,7 +250,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
-                    dataAuthorship: []
+                    defaultDataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -359,7 +359,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
-                    dataAuthorship: []
+                    defaultDataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -480,7 +480,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
-                    dataAuthorship: []
+                    defaultDataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -589,7 +589,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
-                    dataAuthorship: []
+                    defaultDataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -707,7 +707,7 @@ paths:
                       - http://rdfh.ch/licenses/cc-0-1.0
                       - http://rdfh.ch/licenses/cc-by-nc-4.0
                       - http://rdfh.ch/licenses/cc-by-sa-4.0
-                      dataAuthorship: []
+                      defaultDataAuthorship: []
                     status: true
                     selfjoin: false
                   projects:
@@ -741,7 +741,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
-                    dataAuthorship: []
+                    defaultDataAuthorship: []
                   permissions:
                     groupsPerProject: {}
                     administrativePermissionsPerProject: {}
@@ -858,7 +858,7 @@ paths:
                     - http://rdfh.ch/licenses/cc-0-1.0
                     - http://rdfh.ch/licenses/cc-by-nc-4.0
                     - http://rdfh.ch/licenses/cc-by-sa-4.0
-                    dataAuthorship: []
+                    defaultDataAuthorship: []
                   status: true
                   selfjoin: false
         '400':
@@ -3757,7 +3757,7 @@ paths:
             example:
               dataLicense: http://rdfh.ch/licenses/cc-by-4.0
               dataCopyrightHolder: University of Basel
-              dataAuthorship:
+              defaultDataAuthorship:
               - Lotte Reiniger
               - Hilma af Klint
         required: true
@@ -3771,7 +3771,7 @@ paths:
               example:
                 dataLicense: http://rdfh.ch/licenses/cc-by-4.0
                 dataCopyrightHolder: University of Basel
-                dataAuthorship:
+                defaultDataAuthorship:
                 - Lotte Reiniger
                 - Hilma af Klint
         '400':
@@ -17647,7 +17647,7 @@ components:
           type: string
         dataCopyrightHolder:
           type: string
-        dataAuthorship:
+        defaultDataAuthorship:
           type: array
           items:
             type: string
@@ -17950,7 +17950,7 @@ components:
           type: string
         dataCopyrightHolder:
           type: string
-        dataAuthorship:
+        defaultDataAuthorship:
           type: array
           items:
             type: string

--- a/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
+++ b/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
@@ -47,7 +47,7 @@
         [licenseLabel]="rights.licenseLabel"
         [licenseUrl]="rights.licenseUrl"
         [copyrightHolder]="rights.project.dataCopyrightHolder"
-        [authorship]="rights.project.dataAuthorship ?? []"
+        [authorship]="rights.project.defaultDataAuthorship ?? []"
         [isAdmin]="(hasProjectAdminRights$ | async) ?? false"
         (editLegalInfo)="goToLegalSettings()" />
     </section>

--- a/libs/vre/pages/project/project/src/lib/description/project-short-description.component.ts
+++ b/libs/vre/pages/project/project/src/lib/description/project-short-description.component.ts
@@ -59,7 +59,7 @@ import { ProjectDescriptionPageComponent } from './project-description-page.comp
               [licenseLabel]="rights.licenseLabel"
               [licenseUrl]="rights.licenseUrl"
               [copyrightHolder]="rights.project.dataCopyrightHolder"
-              [authorship]="rights.project.dataAuthorship ?? []"
+              [authorship]="rights.project.defaultDataAuthorship ?? []"
               [isAdmin]="false"
               labelAlign="start" />
           </div>

--- a/libs/vre/pages/project/project/src/lib/project-settings/legal/legal-settings.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/legal/legal-settings.component.ts
@@ -35,7 +35,7 @@ const CC_LICENSES: { iri: string; summaryKey: string }[] = [
 type ResourceSideForm = FormGroup<{
   license: FormControl<string | null>;
   copyrightHolder: FormControl<string | null>;
-  dataAuthorship: FormControl<string[]>;
+  defaultDataAuthorship: FormControl<string[]>;
 }>;
 
 @Component({
@@ -75,7 +75,7 @@ type ResourceSideForm = FormGroup<{
             <mat-form-field style="width: 100%">
               <mat-label>{{ 'legal.dataSide.authorship' | translate }}</mat-label>
               <mat-chip-grid #chipGrid>
-                @for (author of resourceSideForm.controls.dataAuthorship.value; track $index) {
+                @for (author of resourceSideForm.controls.defaultDataAuthorship.value; track $index) {
                   <mat-chip-row (removed)="removeAuthor($index)">
                     {{ author }}
                     <button
@@ -195,7 +195,7 @@ export class LegalSettingsComponent implements OnInit {
   readonly resourceSideForm: ResourceSideForm = new FormGroup({
     license: new FormControl<string | null>(null),
     copyrightHolder: new FormControl<string | null>(null),
-    dataAuthorship: new FormControl<string[]>([], { nonNullable: true }),
+    defaultDataAuthorship: new FormControl<string[]>([], { nonNullable: true }),
   });
 
   readonly project$ = this._reloadSubject
@@ -226,7 +226,7 @@ export class LegalSettingsComponent implements OnInit {
       license: project.dataLicense ?? null,
       // Pre-fill the holder from the official project name when not yet set.
       copyrightHolder: project.dataCopyrightHolder ?? project.longname ?? null,
-      dataAuthorship: project.dataAuthorship ?? [],
+      defaultDataAuthorship: project.defaultDataAuthorship ?? [],
     });
   }
 
@@ -235,26 +235,26 @@ export class LegalSettingsComponent implements OnInit {
     if (!trimmed) {
       return;
     }
-    const control = this.resourceSideForm.controls.dataAuthorship;
+    const control = this.resourceSideForm.controls.defaultDataAuthorship;
     control.setValue([...control.value, trimmed]);
     control.markAsDirty();
   }
 
   removeAuthor(index: number): void {
-    const control = this.resourceSideForm.controls.dataAuthorship;
+    const control = this.resourceSideForm.controls.defaultDataAuthorship;
     control.setValue(control.value.filter((_, i) => i !== index));
     control.markAsDirty();
   }
 
   saveResourceSide(): void {
     const shortcode = this._projectPageService.currentProject.shortcode;
-    const { license, copyrightHolder, dataAuthorship } = this.resourceSideForm.getRawValue();
+    const { license, copyrightHolder, defaultDataAuthorship } = this.resourceSideForm.getRawValue();
     this.saving = true;
     this._paginatedApi
       .updateResourceSideLegalInfo(shortcode, {
         dataLicense: license,
         dataCopyrightHolder: copyrightHolder,
-        dataAuthorship: dataAuthorship ?? [],
+        defaultDataAuthorship: defaultDataAuthorship ?? [],
       })
       .subscribe({
         next: () => {

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/resource-default-tabs.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/resource-default-tabs.component.stories.ts
@@ -56,7 +56,7 @@ const meta: Meta<ResourceDefaultTabsComponent> = {
         provideRouter([{ path: '**', component: class {} }]),
         {
           provide: ProjectApiService,
-          useValue: { get: () => of({ project: { shortcode: '0001', dataAuthorship: [] } }) },
+          useValue: { get: () => of({ project: { shortcode: '0001', defaultDataAuthorship: [] } }) },
         },
         { provide: PaginatedApiService, useValue: { getLicenses: () => of([]) } },
         { provide: ResourceLegalV2ApiService, useValue: { updateResourceAuthorship: () => of(undefined) } },

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/resource-rights-statement-container.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/resource-rights-statement-container.component.ts
@@ -73,7 +73,7 @@ export class ResourceRightsStatementContainerComponent implements OnInit {
         const project = response.project;
         const base = {
           copyrightHolder: project.dataCopyrightHolder,
-          authorship: project.dataAuthorship ?? [],
+          authorship: project.defaultDataAuthorship ?? [],
         };
         if (!project.dataLicense) {
           return of({ ...base, licenseLabel: undefined, licenseUrl: undefined } as DataRights);

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-creator/create-resource-form.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-creator/create-resource-form.component.ts
@@ -90,7 +90,7 @@ import { CreateResourceFormInterface } from './create-resource-form.interface';
         </app-create-resource-form-row>
         <app-create-resource-form-row [label]="'legal.dataSide.authorship' | translate">
           <mat-form-field style="width: 100%">
-            <mat-chip-grid #dataAuthorshipGrid [attr.aria-label]="'legal.dataSide.authorship' | translate">
+            <mat-chip-grid #defaultDataAuthorshipGrid [attr.aria-label]="'legal.dataSide.authorship' | translate">
               @for (author of form.controls.resourceAuthorship.value; track $index) {
                 <mat-chip-row (removed)="removeDataAuthor($index)">
                   {{ author }}
@@ -105,7 +105,7 @@ import { CreateResourceFormInterface } from './create-resource-form.interface';
               <input
                 data-cy="data-authorship-chips"
                 [placeholder]="'resourceEditor.resourceCreator.authorship.placeholder' | translate"
-                [matChipInputFor]="dataAuthorshipGrid"
+                [matChipInputFor]="defaultDataAuthorshipGrid"
                 (matChipInputTokenEnd)="addDataAuthor($event.value); $event.chipInput!.clear()" />
             </mat-chip-grid>
           </mat-form-field>
@@ -222,9 +222,9 @@ export class CreateResourceFormComponent implements OnInit {
         switchMap(response => {
           const project = response.project;
           this.dataCopyrightHolder = project.dataCopyrightHolder;
-          if (project.dataAuthorship && project.dataAuthorship.length > 0) {
+          if (project.defaultDataAuthorship && project.defaultDataAuthorship.length > 0) {
             // Programmatic seed keeps the control pristine; the user confirms (submits) or edits these.
-            this.form.controls.resourceAuthorship.setValue(project.dataAuthorship);
+            this.form.controls.resourceAuthorship.setValue(project.defaultDataAuthorship);
           }
           return project.dataLicense
             ? this._paginatedApi

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-image-tabs.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-image-tabs.component.stories.ts
@@ -61,7 +61,7 @@ const meta: Meta<ResourceImageTabsComponent> = {
         provideRouter([{ path: '**', component: class {} }]),
         {
           provide: ProjectApiService,
-          useValue: { get: () => of({ project: { shortcode: '0001', dataAuthorship: [] } }) },
+          useValue: { get: () => of({ project: { shortcode: '0001', defaultDataAuthorship: [] } }) },
         },
         { provide: PaginatedApiService, useValue: { getLicenses: () => of([]) } },
         { provide: ResourceLegalV2ApiService, useValue: { updateResourceAuthorship: () => of(undefined) } },

--- a/libs/vre/shared/app-common/src/lib/paginated-api.service.ts
+++ b/libs/vre/shared/app-common/src/lib/paginated-api.service.ts
@@ -11,7 +11,7 @@ import { EMPTY, expand, map, reduce } from 'rxjs';
 export interface ResourceSideLegalInfoUpdate {
   dataLicense: string | null;
   dataCopyrightHolder: string | null;
-  dataAuthorship: string[];
+  defaultDataAuthorship: string[];
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Summary

Stacked on #3178 (merges into `feature/dev-6663-app-resource-side-legal`). Renames the project-level authorship default `dataAuthorship` → `defaultDataAuthorship`, following the dsp-api payload key rename in dasch-swiss/dsp-api#4174 — consistent with the `default_permissions` precedent. Sibling PRs: dasch-swiss/dsp-tools#2358, dasch-swiss/dasch-specs#138.

Covers the dsp-js `Project` model wire key, `dsp-api_spec.yaml` (the build-time OpenAPI codegen input — renamed together with the TS code so the generated client and its consumers agree), and all components/tests/stories.

## ⚠️ Sequencing — do not merge before the dsp-api deploy

The app can only work against an API that serves the new key. Until dasch-swiss/dsp-api#4174 is **merged and deployed to dev**, this PR's `check-openapi-sync` and E2E jobs (which run against the DEV server) stay red — same acknowledged cross-repo dependency as dasch-swiss/dsp-tools#2358. After the deploy, re-run CI here; the sync bot may also bump the spec snapshot, in which case rebase this on the refreshed base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iLHUkaKhAacsGLiNdem55