### PR TITLE
fix(legal): correct the project Rights Statement display and holder clearing

### DIFF
--- a/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
+++ b/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
@@ -48,7 +48,7 @@
             [licenseLabel]="rights.licenseLabel"
             [licenseUrl]="rights.licenseUrl"
             [copyrightHolder]="rights.copyrightHolder"
-            [defaultResourceAuthorship]="rights.defaultDataAuthorship"
+            [showAuthorship]="false"
             [isAdmin]="(hasProjectAdminRights$ | async) ?? false"
             (editLegalInfo)="goToLegalSettings()" />
         </section>

--- a/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
+++ b/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
@@ -41,7 +41,7 @@
 
     <!-- Data-side Resource Rights Statement (project-level). Distinct from the hand-typed caption above. -->
     @if (dataRights$ | async; as rights) {
-      @if (rights.licenseLabel || (hasProjectAdminRights$ | async)) {
+      @if (rights.licenseLabel || rights.copyrightHolder || (hasProjectAdminRights$ | async)) {
         <mat-divider style="margin: 24px 0" />
         <section class="project rights">
           <app-resource-rights-statement

--- a/libs/vre/pages/project/project/src/lib/description/project-short-description.component.ts
+++ b/libs/vre/pages/project/project/src/lib/description/project-short-description.component.ts
@@ -53,7 +53,7 @@ import { ProjectDescriptionPageComponent } from './project-description-page.comp
       </button>
 
       @if (dataRights$ | async; as rights) {
-        @if (rights.licenseLabel) {
+        @if (rights.licenseLabel || rights.copyrightHolder) {
           <div style="border-top: 1px solid #ebebeb; margin: 0 16px; text-align: left">
             <app-resource-rights-statement
               [licenseLabel]="rights.licenseLabel"

--- a/libs/vre/pages/project/project/src/lib/description/project-short-description.component.ts
+++ b/libs/vre/pages/project/project/src/lib/description/project-short-description.component.ts
@@ -59,7 +59,7 @@ import { ProjectDescriptionPageComponent } from './project-description-page.comp
               [licenseLabel]="rights.licenseLabel"
               [licenseUrl]="rights.licenseUrl"
               [copyrightHolder]="rights.copyrightHolder"
-              [defaultResourceAuthorship]="rights.defaultDataAuthorship"
+              [showAuthorship]="false"
               [isAdmin]="false"
               labelAlign="start" />
           </div>

--- a/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.ts
@@ -195,7 +195,9 @@ export class ResourceSideLegalFormComponent implements OnInit {
     this._dataRights
       .updateResourceSideLegalInfo(this.project.shortcode, {
         dataLicense: license ?? undefined,
-        dataCopyrightHolder: copyrightHolder ?? undefined,
+        // Omit an empty holder so the PUT clears it (the endpoint replaces, so a missing field ⇒ None).
+        // Sending "" instead would be rejected by the CopyrightHolder value object (must be non-empty).
+        dataCopyrightHolder: copyrightHolder?.trim() ? copyrightHolder : undefined,
         defaultDataAuthorship: dataAuthorship ?? [],
       })
       .pipe(takeUntilDestroyed(this._destroyRef))

--- a/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
+++ b/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
@@ -16,7 +16,8 @@ import { TranslatePipe } from '@ngx-translate/core';
  * - When NOT configured (no `licenseLabel`): renders the admins-only "uncategorized — please
  *   review" callout for admins, and renders nothing for everyone else (no public regression).
  * - When configured: shows the license (linked to its Creative Commons deed), the copyright
- *   holder and the authorship.
+ *   holder and — unless `showAuthorship` is false — the authorship. Project-level displays pass
+ *   `showAuthorship=false`, since authorship is per-resource, not a property of the whole project.
  * - In a per-resource context, when the resource has no own authorship, shows a labeled fallback
  *   ("No authorship recorded for this resource. Project default: …") rather than asserting the default.
  * - For users with edit rights (`canEditAuthorship`), the authorship row edits inline in place
@@ -53,80 +54,82 @@ import { TranslatePipe } from '@ngx-translate/core';
           </div>
         }
 
-        <div class="row">
-          <span class="label mat-subtitle-2">{{ 'legal.dataSide.authorship' | translate }}</span>
-          @if (editing) {
-            <!-- Inline editor: opens in place (no dialog) with a chip input and save/undo, like a property row. -->
-            <span class="value value-editing">
-              <mat-form-field class="authorship-edit-field" subscriptSizing="dynamic">
-                <mat-chip-grid #chipGrid [attr.aria-label]="'legal.dataSide.authorship' | translate">
-                  @for (author of editAuthorshipList; track $index) {
-                    <mat-chip-row (removed)="removeEditAuthor($index)">
-                      {{ author }}
-                      <button
-                        type="button"
-                        matChipRemove
-                        [attr.aria-label]="'legal.dataSide.removeAuthor' | translate: { name: author }">
-                        <mat-icon>cancel</mat-icon>
-                      </button>
-                    </mat-chip-row>
+        @if (showAuthorship) {
+          <div class="row">
+            <span class="label mat-subtitle-2">{{ 'legal.dataSide.authorship' | translate }}</span>
+            @if (editing) {
+              <!-- Inline editor: opens in place (no dialog) with a chip input and save/undo, like a property row. -->
+              <span class="value value-editing">
+                <mat-form-field class="authorship-edit-field" subscriptSizing="dynamic">
+                  <mat-chip-grid #chipGrid [attr.aria-label]="'legal.dataSide.authorship' | translate">
+                    @for (author of editAuthorshipList; track $index) {
+                      <mat-chip-row (removed)="removeEditAuthor($index)">
+                        {{ author }}
+                        <button
+                          type="button"
+                          matChipRemove
+                          [attr.aria-label]="'legal.dataSide.removeAuthor' | translate: { name: author }">
+                          <mat-icon>cancel</mat-icon>
+                        </button>
+                      </mat-chip-row>
+                    }
+                    <input
+                      #chipInput
+                      autocomplete="off"
+                      [matChipInputFor]="chipGrid"
+                      (matChipInputTokenEnd)="addEditAuthor($event)" />
+                  </mat-chip-grid>
+                </mat-form-field>
+                <button
+                  type="button"
+                  class="edit-action"
+                  [matTooltip]="'legal.dataSide.settings.cancel' | translate"
+                  [attr.aria-label]="'legal.dataSide.settings.cancel' | translate"
+                  (click)="cancelEdit()">
+                  <mat-icon>undo</mat-icon>
+                </button>
+                <button
+                  type="button"
+                  class="edit-action save"
+                  [matTooltip]="'legal.dataSide.settings.save' | translate"
+                  [attr.aria-label]="'legal.dataSide.settings.save' | translate"
+                  (click)="saveEdit()">
+                  <mat-icon>save</mat-icon>
+                </button>
+              </span>
+            } @else {
+              <span class="value">
+                @if (resourceAuthorship && !resourceAuthorship.length) {
+                  @if (defaultResourceAuthorship.length) {
+                    <em>{{
+                      'legal.dataSide.noAuthorshipFallback' | translate: { default: defaultResourceAuthorship.join(', ') }
+                    }}</em>
+                  } @else {
+                    <em>{{ 'legal.dataSide.noAuthorshipFallbackNoDefault' | translate }}</em>
                   }
-                  <input
-                    #chipInput
-                    autocomplete="off"
-                    [matChipInputFor]="chipGrid"
-                    (matChipInputTokenEnd)="addEditAuthor($event)" />
-                </mat-chip-grid>
-              </mat-form-field>
-              <button
-                type="button"
-                class="edit-action"
-                [matTooltip]="'legal.dataSide.settings.cancel' | translate"
-                [attr.aria-label]="'legal.dataSide.settings.cancel' | translate"
-                (click)="cancelEdit()">
-                <mat-icon>undo</mat-icon>
-              </button>
-              <button
-                type="button"
-                class="edit-action save"
-                [matTooltip]="'legal.dataSide.settings.save' | translate"
-                [attr.aria-label]="'legal.dataSide.settings.save' | translate"
-                (click)="saveEdit()">
-                <mat-icon>save</mat-icon>
-              </button>
-            </span>
-          } @else {
-            <span class="value">
-              @if (resourceAuthorship && !resourceAuthorship.length) {
-                @if (defaultResourceAuthorship.length) {
-                  <em>{{
-                    'legal.dataSide.noAuthorshipFallback' | translate: { default: defaultResourceAuthorship.join(', ') }
-                  }}</em>
+                } @else if (resourceAuthorship) {
+                  {{ resourceAuthorship.join(', ') }}
+                } @else if (defaultResourceAuthorship.length) {
+                  {{ defaultResourceAuthorship.join(', ') }}
                 } @else {
                   <em>{{ 'legal.dataSide.noAuthorshipFallbackNoDefault' | translate }}</em>
                 }
-              } @else if (resourceAuthorship) {
-                {{ resourceAuthorship.join(', ') }}
-              } @else if (defaultResourceAuthorship.length) {
-                {{ defaultResourceAuthorship.join(', ') }}
-              } @else {
-                <em>{{ 'legal.dataSide.noAuthorshipFallbackNoDefault' | translate }}</em>
-              }
-              @if (canEditAuthorship) {
-                <!-- Inline, always-visible edit affordance, right after the value (discoverable, close to the text). -->
-                <button
-                  #editButton
-                  type="button"
-                  class="edit-authorship"
-                  [matTooltip]="'legal.dataSide.edit' | translate"
-                  [attr.aria-label]="'legal.dataSide.edit' | translate"
-                  (click)="startEdit()">
-                  <mat-icon>edit</mat-icon>
-                </button>
-              }
-            </span>
-          }
-        </div>
+                @if (canEditAuthorship) {
+                  <!-- Inline, always-visible edit affordance, right after the value (discoverable, close to the text). -->
+                  <button
+                    #editButton
+                    type="button"
+                    class="edit-authorship"
+                    [matTooltip]="'legal.dataSide.edit' | translate"
+                    [attr.aria-label]="'legal.dataSide.edit' | translate"
+                    (click)="startEdit()">
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                }
+              </span>
+            }
+          </div>
+        }
       </section>
     } @else if (isAdmin) {
       <section class="rights-statement uncategorized" role="status">
@@ -263,6 +266,8 @@ export class ResourceRightsStatementComponent {
   @Input() canEditAuthorship = false;
   /** Label alignment: 'end' (right — matches property rows in the viewer) or 'start' (left — for the project card). */
   @Input() labelAlign: 'start' | 'end' = 'end';
+  /** Whether to render the authorship row. Authorship is per-resource; project-level displays pass `false`. */
+  @Input() showAuthorship = true;
 
   /** Emitted when an admin clicks "Edit legal info" on the unconfigured callout (routes to Settings → Legal). */
   @Output() editLegalInfo = new EventEmitter<void>();

--- a/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
+++ b/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
@@ -104,7 +104,8 @@ import { TranslatePipe } from '@ngx-translate/core';
                 @if (resourceAuthorship && !resourceAuthorship.length) {
                   @if (defaultResourceAuthorship.length) {
                     <em>{{
-                      'legal.dataSide.noAuthorshipFallback' | translate: { default: defaultResourceAuthorship.join(', ') }
+                      'legal.dataSide.noAuthorshipFallback'
+                        | translate: { default: defaultResourceAuthorship.join(', ') }
                     }}</em>
                   } @else {
                     <em>{{ 'legal.dataSide.noAuthorshipFallbackNoDefault' | translate }}</em>

--- a/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
+++ b/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
@@ -13,11 +13,11 @@ import { TranslatePipe } from '@ngx-translate/core';
  * Used on the resource viewer, the create-resource form (preview) and the project description.
  *
  * Behaviour (per spec §1b):
- * - When NOT configured (no `licenseLabel`): renders the admins-only "uncategorized — please
- *   review" callout for admins, and renders nothing for everyone else (no public regression).
- * - When configured: shows the license (linked to its Creative Commons deed), the copyright
- *   holder and — unless `showAuthorship` is false — the authorship. Project-level displays pass
- *   `showAuthorship=false`, since authorship is per-resource, not a property of the whole project.
+ * - When NOT configured (neither a license nor a copyright holder): renders the admins-only
+ *   "uncategorized — please review" callout for admins, and renders nothing for everyone else.
+ * - When configured: shows whichever of the license (linked to its Creative Commons deed) and the
+ *   copyright holder are set — each independently — and, unless `showAuthorship` is false, the
+ *   authorship. Project-level displays pass `showAuthorship=false`, since authorship is per-resource.
  * - In a per-resource context, when the resource has no own authorship, shows a labeled fallback
  *   ("No authorship recorded for this resource. Project default: …") rather than asserting the default.
  * - For users with edit rights (`canEditAuthorship`), the authorship row edits inline in place
@@ -30,22 +30,24 @@ import { TranslatePipe } from '@ngx-translate/core';
       <section class="rights-statement" [class.label-start]="labelAlign === 'start'">
         <h3 class="mat-subtitle-2">{{ 'legal.dataSide.heading' | translate }}</h3>
 
-        <div class="row">
-          <span class="label mat-subtitle-2">{{ 'legal.dataSide.license' | translate }}</span>
-          <span class="value">
-            @if (licenseUrl) {
-              <a
-                [href]="licenseUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                [attr.aria-label]="licenseLabel + ', ' + ('legal.dataSide.opensInNewTab' | translate)">
+        @if (licenseLabel) {
+          <div class="row">
+            <span class="label mat-subtitle-2">{{ 'legal.dataSide.license' | translate }}</span>
+            <span class="value">
+              @if (licenseUrl) {
+                <a
+                  [href]="licenseUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  [attr.aria-label]="licenseLabel + ', ' + ('legal.dataSide.opensInNewTab' | translate)">
+                  {{ licenseLabel }}
+                </a>
+              } @else {
                 {{ licenseLabel }}
-              </a>
-            } @else {
-              {{ licenseLabel }}
-            }
-          </span>
-        </div>
+              }
+            </span>
+          </div>
+        }
 
         @if (copyrightHolder) {
           <div class="row">
@@ -250,7 +252,7 @@ import { TranslatePipe } from '@ngx-translate/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ResourceRightsStatementComponent {
-  /** The human-readable license label, e.g. "CC BY 4.0". Its presence means the project is "configured". */
+  /** The human-readable license label, e.g. "CC BY 4.0". Rendered only when set (see `configured`). */
   @Input() licenseLabel?: string;
   /** The license deed URL (Creative Commons), rendered as a link. */
   @Input() licenseUrl?: string;
@@ -283,7 +285,7 @@ export class ResourceRightsStatementComponent {
   @ViewChild('editButton') private _editButton?: ElementRef<HTMLButtonElement>;
 
   get configured(): boolean {
-    return !!this.licenseLabel;
+    return !!this.licenseLabel || !!this.copyrightHolder;
   }
 
   /** Open the inline editor, seeded with the currently displayed authorship. */

--- a/libs/vre/ui/ui/src/lib/resource-rights-statement.stories.ts
+++ b/libs/vre/ui/ui/src/lib/resource-rights-statement.stories.ts
@@ -33,6 +33,10 @@ const meta: Meta<ResourceRightsStatementComponent> = {
       control: { type: 'radio' },
       options: ['start', 'end'],
     },
+    showAuthorship: {
+      description: 'Render the authorship row. Project-level displays pass false — authorship is per-resource.',
+      control: 'boolean',
+    },
     editLegalInfo: { description: 'Emitted when an admin clicks "Edit legal info" on the unconfigured callout.' },
     saveAuthorship: { description: 'Emitted with the new authorship list when a Modify user saves the inline editor.' },
   },
@@ -61,6 +65,29 @@ export const ShowsLicenseHolderAndAuthorshipWhenConfigured: Story = {
     });
     await step('Authorship is listed', async () => {
       await expect(canvas.getByText('Lotte Reiniger, Hilma af Klint')).toBeInTheDocument();
+    });
+  },
+};
+
+export const HidesAuthorshipOnProjectLevelDisplay: Story = {
+  name: 'Hides the authorship row on a project-level display',
+  args: {
+    licenseLabel: 'CC BY 4.0',
+    licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+    copyrightHolder: 'University of Basel',
+    defaultResourceAuthorship: ['Lotte Reiniger', 'Hilma af Klint'],
+    showAuthorship: false,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('License and copyright holder still render', async () => {
+      await expect(canvas.getByRole('link', { name: /CC BY 4\.0/ })).toBeInTheDocument();
+      await expect(canvas.getByText('University of Basel')).toBeInTheDocument();
+    });
+    await step('The authorship row is gated out, even though a default authorship was provided', async () => {
+      // Only the license and copyright-holder rows remain; on project-level displays authorship is per-resource.
+      await expect(canvasElement.querySelectorAll('.row')).toHaveLength(2);
+      await expect(canvas.queryByText('Lotte Reiniger, Hilma af Klint')).toBeNull();
     });
   },
 };

--- a/libs/vre/ui/ui/src/lib/resource-rights-statement.stories.ts
+++ b/libs/vre/ui/ui/src/lib/resource-rights-statement.stories.ts
@@ -69,6 +69,43 @@ export const ShowsLicenseHolderAndAuthorshipWhenConfigured: Story = {
   },
 };
 
+export const ShowsCopyrightHolderOnlyWhenNoLicense: Story = {
+  name: 'Shows the copyright holder alone when no license is set',
+  args: {
+    copyrightHolder: 'University of Basel',
+    showAuthorship: false,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('The copyright holder renders even without a license', async () => {
+      await expect(canvas.getByText('University of Basel')).toBeInTheDocument();
+    });
+    await step('No (empty) license row is rendered', async () => {
+      // Only the copyright-holder row remains; the license row is gated on its own licenseLabel.
+      await expect(canvasElement.querySelectorAll('.row')).toHaveLength(1);
+      await expect(canvas.queryByRole('link')).toBeNull();
+    });
+  },
+};
+
+export const ShowsLicenseOnlyWhenNoCopyrightHolder: Story = {
+  name: 'Shows the license alone when no copyright holder is set',
+  args: {
+    licenseLabel: 'CC BY 4.0',
+    licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+    showAuthorship: false,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('The license renders as a link', async () => {
+      await expect(canvas.getByRole('link', { name: /CC BY 4\.0/ })).toBeInTheDocument();
+    });
+    await step('No copyright-holder row is rendered', async () => {
+      await expect(canvasElement.querySelectorAll('.row')).toHaveLength(1);
+    });
+  },
+};
+
 export const HidesAuthorshipOnProjectLevelDisplay: Story = {
   name: 'Hides the authorship row on a project-level display',
   args: {


### PR DESCRIPTION
Fixes [DEV-6718](https://linear.app/dasch/issue/DEV-6718), [DEV-6720](https://linear.app/dasch/issue/DEV-6720) and [DEV-6722](https://linear.app/dasch/issue/DEV-6722)

## Motivation

Three correctness fixes to the project **Data view / legal settings** "Resource Rights Statement":

1. **Authorship leaked onto the project view** (DEV-6718). The authorship row rendered on the project card and dialog. Authorship is per-resource; at the project level it's only a default template, not a property of the whole project.
2. **License and copyright holder weren't independent** (DEV-6720). The whole statement was gated on having a license, so a project with only a copyright holder (no license) showed nothing.
3. **Couldn't clear the copyright holder** (DEV-6722). Once set, clearing the holder in Settings → Legal and saving didn't persist.

## Summary

- **Authorship**: new `showAuthorship` input (default `true`); the two project surfaces pass `[showAuthorship]="false"`. Resource views keep showing authorship.
- **License / holder independence**: `configured` is now `licenseLabel || copyrightHolder`; the License row is guarded by its own `@if (licenseLabel)`; the two project-surface `@if`s include `rights.copyrightHolder`. The admin "uncategorized" callout appears only when neither is set.
- **Clearing the holder**: the settings form now omits an empty/whitespace holder from the PUT so the (replace-semantics) endpoint clears it via `None` — exactly as the license clears through its `null` "none" option. Previously it sent `dataCopyrightHolder: ""`, which the backend `CopyrightHolder` value object rejects (`nonEmpty`) → 400.

## Key Changes

- `resource-rights-statement.component.ts`: `showAuthorship` input + gated authorship row; `configured = licenseLabel || copyrightHolder`; License row guarded by `@if (licenseLabel)`; doc comments.
- `project-description-page.component.html` & `project-short-description.component.ts`: `[showAuthorship]="false"`; outer `@if` broadened to include `rights.copyrightHolder`.
- `resource-side-legal-form.component.ts`: omit an empty copyright holder from the update payload so it can be cleared.
- `resource-rights-statement.stories.ts`: regression stories — `HidesAuthorshipOnProjectLevelDisplay`, `ShowsCopyrightHolderOnlyWhenNoLicense`, `ShowsLicenseOnlyWhenNoCopyrightHolder`.

## Challenges and Decisions

- **Explicit `showAuthorship`** over reusing context state — keeps resource-side behaviour untouched and the project-level intent obvious; breaks no existing stories.
- **Clear via omission**: the resource-side PUT replaces, so a missing field becomes `None` and clears. The backend already supports this — the fix is purely to stop sending `""`.

## Gotchas

- The `defaultResourceAuthorship` binding on the two project surfaces was removed (dead once authorship is hidden there).
- The resource-side container and `ProjectDataRightsService` need no changes — the container delegates visibility to `configured`, and the service derives holder/license independently.

## Test Plan

- **Storybook**: existing stories stay green; new stories assert authorship hidden at project level, holder-only renders the holder row, license-only renders the license row.
- **Manual** (project Data view, card + "Read more"): license-only → license; holder-only → holder; both → both; neither → nothing (admins see the callout); no Authorship row in any case. On a resource → Authorship still renders.
- **Manual** (Settings → Legal): set a copyright holder, save; then clear it, save → it is removed and stays blank on reload.

_Note: the PR preview serves unhashed bundles with a long cache — hard-refresh (Cmd+Shift+R) after each deploy to see changes._
