### PR TITLE
fix(legal): show rights statement to logged-out users and when any field is set (DEV-6723)

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/resource-rights-statement-container.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/resource-rights-statement-container.component.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 import { ResourceLegalV2ApiService } from '@dasch-swiss/vre/3rd-party-services/api';
 import { RouteConstants } from '@dasch-swiss/vre/core/config';
 import { UserService } from '@dasch-swiss/vre/core/session';
-import { DspResource, filterNull, UserPermissions } from '@dasch-swiss/vre/shared/app-common';
+import { DspResource, UserPermissions } from '@dasch-swiss/vre/shared/app-common';
 import {
   ProjectDataRights,
   ProjectDataRightsService,
@@ -76,8 +76,14 @@ export class ResourceRightsStatementContainerComponent implements OnInit {
       switchMap(projectIri => this._dataRights.forProject(projectIri))
     );
 
-    const isAdmin$ = combineLatest([resource$, this._userService.user$.pipe(filterNull())]).pipe(
-      map(([resource, user]) => UserPermissions.hasProjectAdminRights(user, resource.res.attachedToProject))
+    // The rights statement is public and must render for logged-out users too. Treat "no user" as
+    // "not admin" (emit false) rather than filtering the stream, which would stall viewModel$ and
+    // hide the statement entirely for anonymous visitors.
+    const isAdmin$ = combineLatest([resource$, this._userService.user$]).pipe(
+      map(
+        ([resource, user]) =>
+          user !== null && UserPermissions.hasProjectAdminRights(user, resource.res.attachedToProject)
+      )
     );
 
     this.viewModel$ = combineLatest([resource$, rights$, isAdmin$]).pipe(

--- a/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
+++ b/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
@@ -13,8 +13,9 @@ import { TranslatePipe } from '@ngx-translate/core';
  * Used on the resource viewer, the create-resource form (preview) and the project description.
  *
  * Behaviour (per spec §1b):
- * - When NOT configured (neither a license nor a copyright holder): renders the admins-only
- *   "uncategorized — please review" callout for admins, and renders nothing for everyone else.
+ * - Renders as soon as any field is set (license, copyright holder, or — in a per-resource context —
+ *   authorship). When NOTHING is set: renders the admins-only "uncategorized — please review" callout
+ *   for admins, and renders nothing for everyone else (including logged-out visitors).
  * - When configured: shows whichever of the license (linked to its Creative Commons deed) and the
  *   copyright holder are set — each independently — and, unless `showAuthorship` is false, the
  *   authorship. Project-level displays pass `showAuthorship=false`, since authorship is per-resource.
@@ -286,7 +287,16 @@ export class ResourceRightsStatementComponent {
   @ViewChild('editButton') private _editButton?: ElementRef<HTMLButtonElement>;
 
   get configured(): boolean {
-    return !!this.licenseLabel || !!this.copyrightHolder;
+    return !!this.licenseLabel || !!this.copyrightHolder || this._hasDisplayableAuthorship;
+  }
+
+  /** Per-resource authorship worth showing: only in an authorship context (`showAuthorship`), and
+   *  only when there are actual authors (own or project default). Lets a resource that has only
+   *  authorship set still render the statement. */
+  private get _hasDisplayableAuthorship(): boolean {
+    return (
+      this.showAuthorship && ((this.resourceAuthorship?.length ?? 0) > 0 || this.defaultResourceAuthorship.length > 0)
+    );
   }
 
   /** Open the inline editor, seeded with the currently displayed authorship. */


### PR DESCRIPTION
Fixes https://linear.app/dasch/issue/DEV-6723

> [!NOTE]
> Stacked on #3230 (`feature/dev-6718-project-view-authorship-row`). Review after #3230; the base retargets to `main` automatically once it merges. Only the two commits on top of #3230 belong to this PR.

## Motivation

When resource-side legal metadata is set, the Rights Statement showed for logged-in users but **not** for logged-out (anonymous) visitors. Reuse information is inherently public — a visitor needs to see the license, copyright holder and authorship *before* deciding whether to access or download the data, often without an account. Separately, the statement only appeared when a **license** was set, so a resource with only a copyright holder or only authorship showed nothing.

## Summary

The Rights Statement now renders regardless of authentication state, and as soon as **any** single legal field (license, copyright holder, or authorship) is set. When nothing is set, nothing is shown (unchanged); admins still get the "uncategorized — please review" callout.

## Key Changes

- **`resource-rights-statement-container.component.ts`** — `isAdmin$` was derived from `user$` via `filterNull()`, so for anonymous users it never emitted, stalling the `viewModel$` `combineLatest` and hiding the whole statement. A `null` user now maps to `isAdmin=false`, so the (public) statement renders for everyone.
- **`resource-rights-statement.component.ts`** — `configured` now also returns `true` when displayable authorship is present (gated by `showAuthorship`, so the project-level card is unchanged), alongside license and copyright holder.

## Challenges and Decisions

- **Stacked on #3230**, which already made license/copyright holder display independently and added the `showAuthorship` input. This PR adds only the auth-gate fix and the authorship term in `configured`, avoiding duplicated/conflicting edits to the shared file.
- **No backend change needed**: the license catalog endpoint is public (`publicEndpoint` — "Publicly accessible"), and copyright holder / authorship come from the public project read and resource read, not the secured catalog endpoints.

## Gotchas

- The per-resource **authorship** row depends on the resource-side legal backend being deployed; the license/copyright-holder path is independent of it, and is enough to confirm the logged-out fix.

## Test Plan

- Lint + unit tests for `vre-ui-ui` and `vre-resource-editor-resource-editor` — green.
- Manually verified against the DEV backend: a resource with legal info set now shows the Rights Statement when logged out, identical to the logged-in view; a resource with no legal info shows nothing.
- Storybook (`ResourceRightsStatement`): section renders with only a license, only a copyright holder, or only authorship; project-level (`showAuthorship=false`) unchanged.
