### PR TITLE
fix(ci): correct dsp-api wait-for-api.sh path in e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           cd dsp-api
           make init-db-test
           docker compose -f docker-compose.yml up -d sipi ingest api
-          ./webapi/scripts/wait-for-api.sh
+          ./modules/webapi/scripts/wait-for-api.sh
       - name: Wait for app to be ready
         run: timeout 180 bash -c 'until curl -sf http://localhost:4200 > /dev/null 2>&1; do sleep 3; done'
       - name: Run e2e tests in CI


### PR DESCRIPTION
No Linear issue — CI infrastructure fix.

## Motivation

The `DSP-APP E2E tests` jobs are failing on `main` and on every open PR. The "Start API" step checks out `dasch-swiss/dsp-api@main` and calls `./webapi/scripts/wait-for-api.sh`, which exits with code 127 (`No such file or directory`). dsp-api restructured its layout and moved that script under `modules/`, so the pinned-to-`main` path in our workflow no longer resolves. The E2E specs never run — CI dies in setup while waiting for the API to boot.

## Summary

Update the single stale path in the E2E workflow from `./webapi/scripts/wait-for-api.sh` to `./modules/webapi/scripts/wait-for-api.sh`, matching where the script now lives in dsp-api `main`.

## Key Changes

- `.github/workflows/ci.yml` — "Start API" step: `./webapi/scripts/wait-for-api.sh` → `./modules/webapi/scripts/wait-for-api.sh`.

## Challenges and Decisions

- Verified against dsp-api `main`: `wait-for-api.sh` is now at `modules/webapi/scripts/wait-for-api.sh`, and dsp-api's own Makefile already invokes it from that path. `make init-db-test`, `docker-compose.yml`, and the `sipi ingest api` compose services all still resolve at the dsp-api root — the script path was the only broken reference.
- Fixing this on `main` (rather than inside a feature branch) because the break is global: `main` and all open PRs are affected. Feature branches inherit the fix on rebase.

## Gotchas

- Root cause is cross-repo coupling: our E2E job pins dsp-api to `main`, so any upstream file move can break this workflow with no change on our side. A follow-up to make this more robust (pin a known-good ref, or resolve the script path dynamically) is worth considering but is out of scope here.

## Test Plan

- CI on this PR runs the E2E matrix (heavy + rest); both should get past the "Start API" step and execute the Cypress specs, where they previously failed with exit 127.