### PR TITLE
fix: left-align License row in project description "Read more" slider

### DIFF
--- a/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
+++ b/libs/vre/pages/project/project/src/lib/description/project-description-page.component.html
@@ -50,6 +50,7 @@
             [copyrightHolder]="rights.copyrightHolder"
             [showAuthorship]="false"
             [isAdmin]="(hasProjectAdminRights$ | async) ?? false"
+            labelAlign="start"
             (editLegalInfo)="goToLegalSettings()" />
         </section>
       }


### PR DESCRIPTION
Fixes DEV-6745

## Motivation

On a project's **Data** tab, clicking **Read more** opens a drawer with the full description and, at the bottom, the **Resource Rights Statement**. Its **License** row was indented toward the centre of the panel instead of lining up left with the section heading — unlike the collapsed description card, where it is correctly left-aligned.

## Summary

Pass `labelAlign="start"` to `<app-resource-rights-statement>` in the "Read more" drawer template, matching the collapsed short-description view. Pure template/CSS alignment fix — no logic changes.

## Key Changes

- `libs/vre/pages/project/project/src/lib/description/project-description-page.component.html`: add `labelAlign="start"` to `<app-resource-rights-statement>`.

## Challenges and Decisions

- Root cause: the shared `ResourceRightsStatementComponent` defaults `labelAlign` to `'end'` (right-aligned label column, to match property rows in the resource viewer). The collapsed card passed `labelAlign="start"`; the drawer omitted it, so the two project-level displays diverged. Passing the same input keeps them consistent and prevents future drift.
- No new test: the defect was a missing call-site input, not component behaviour (the component's `label-start` variant is already covered by its stories). Consistent with the repo's testing guidance.

## Gotchas

- None. Single-attribute template change.

## Test Plan

- Reproduced on prod (project 0806, Anton Webern Gesamtausgabe): License row indented in the drawer.
- Served the fixed build against the dev API, opened project 0806 → Data → Read more: License row now sits flush-left with the "Resource Rights Statement" heading, matching the collapsed card.
- `nx run vre-pages-project-project:lint` passes; the dev-server build compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
