### PR TITLE
fix: clarify authorship input requires Enter, commit pending value on blur (DEV-6761)

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -5,6 +5,7 @@
       "license": "Lizenz",
       "copyrightHolder": "Rechteinhaber:in",
       "authorship": "Urheber:innen",
+      "authorshipHint": "Namen eingeben und mit Enter bestätigen, um Urheber:innen hinzuzufügen.",
       "edit": "Bearbeiten",
       "removeAuthor": "{{name}} entfernen",
       "uncategorized": "Die rechtlichen Angaben dieser Ressource wurden noch nicht festgelegt — bitte ergänzen.",

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -5,6 +5,7 @@
       "license": "License",
       "copyrightHolder": "Copyright holder",
       "authorship": "Authorship",
+      "authorshipHint": "Type a name and press Enter to add each author.",
       "edit": "Edit",
       "removeAuthor": "Remove {{name}}",
       "uncategorized": "This resource's legal information hasn't been set yet — please add it.",

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -5,6 +5,7 @@
       "license": "Licence",
       "copyrightHolder": "Titulaire des droits",
       "authorship": "Auteur·ice",
+      "authorshipHint": "Saisissez un nom et appuyez sur Entrée pour ajouter chaque auteur·ice.",
       "edit": "Modifier",
       "removeAuthor": "Supprimer {{name}}",
       "uncategorized": "Les informations légales de cette ressource n'ont pas encore été définies — veuillez les ajouter.",

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -5,6 +5,7 @@
       "license": "Licenza",
       "copyrightHolder": "Titolare dei diritti",
       "authorship": "Autore",
+      "authorshipHint": "Digita un nome e premi Invio per aggiungere ogni autore.",
       "edit": "Modifica",
       "removeAuthor": "Rimuovi {{name}}",
       "uncategorized": "Le informazioni legali di questa risorsa non sono ancora state definite — si prega di aggiungerle.",

--- a/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.ts
@@ -96,6 +96,7 @@ type ResourceSideForm = FormGroup<{
           [control]="form.controls.dataAuthorship"
           [label]="'legal.dataSide.authorship' | translate"
           [ariaLabel]="'legal.dataSide.authorship' | translate"
+          [hint]="'legal.dataSide.authorshipHint' | translate"
           [removeAuthorLabel]="removeAuthorLabel" />
 
         <div style="display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px">

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-creator/authorship-form-field.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-creator/authorship-form-field.component.ts
@@ -48,15 +48,9 @@ import { finalize } from 'rxjs/operators';
             {{ option }}
           </mat-option>
         }
-
-        @if (
-          filteredAuthorship.length === 0 && autocompleteFormControl.value && autocompleteFormControl.value.length > 0
-        ) {
-          <mat-option [disabled]="true">{{
-            'resourceEditor.resourceCreator.authorship.pressEnterOrTab' | translate
-          }}</mat-option>
-        }
       </mat-autocomplete>
+
+      <mat-hint>{{ 'resourceEditor.resourceCreator.authorship.pressEnterOrTab' | translate }}</mat-hint>
 
       @if (control.invalid && control.touched && control.errors![0]; as error) {
         <mat-error>

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-creator/create-resource-form.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-creator/create-resource-form.component.ts
@@ -106,6 +106,7 @@ import { CreateResourceFormInterface } from './create-resource-form.interface';
             [control]="form.controls.resourceAuthorship"
             [ariaLabel]="'legal.dataSide.authorship' | translate"
             [placeholder]="'resourceEditor.resourceCreator.authorship.placeholder' | translate"
+            [hint]="'legal.dataSide.authorshipHint' | translate"
             [removeAuthorLabel]="removeDataAuthorLabel"
             dataCy="data-authorship-chips" />
         </app-create-resource-form-row>

--- a/libs/vre/ui/ui/src/lib/authorship-chip-editor.component.ts
+++ b/libs/vre/ui/ui/src/lib/authorship-chip-editor.component.ts
@@ -10,6 +10,10 @@ import { MatIconModule } from '@angular/material/icon';
  * Kept small and focused: no autocomplete, no seeded defaults — the caller wires the control shape,
  * label and placeholder. Add/remove operations mutate the bound control and mark it dirty so
  * `[disabled]="form.pristine"` on Save behaves naturally.
+ *
+ * The input commits a pending value on blur (`matChipInputAddOnBlur`) as well as on Enter, so a
+ * typed-but-un-confirmed author isn't silently dropped when the user clicks away. Pass an optional
+ * `hint` to make the "press Enter" affordance explicit.
  */
 @Component({
   selector: 'app-authorship-chip-editor',
@@ -33,8 +37,12 @@ import { MatIconModule } from '@angular/material/icon';
           [attr.data-cy]="dataCy"
           [placeholder]="placeholder"
           [matChipInputFor]="chipGrid"
+          [matChipInputAddOnBlur]="true"
           (matChipInputTokenEnd)="add($event)" />
       </mat-chip-grid>
+      @if (hint) {
+        <mat-hint>{{ hint }}</mat-hint>
+      }
     </mat-form-field>
   `,
   imports: [MatChipsModule, MatFormFieldModule, MatIconModule, ReactiveFormsModule],
@@ -49,6 +57,8 @@ export class AuthorshipChipEditorComponent {
   @Input() label?: string;
   /** Placeholder rendered inside the input when the chip list is empty. */
   @Input() placeholder = '';
+  /** Optional helper text shown under the field (e.g. "Type a name and press Enter to add each author"). */
+  @Input() hint?: string;
   /** Optional data-cy hook for E2E tests. */
   @Input() dataCy?: string;
 

--- a/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
+++ b/libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts
@@ -80,8 +80,10 @@ import { TranslatePipe } from '@ngx-translate/core';
                       #chipInput
                       autocomplete="off"
                       [matChipInputFor]="chipGrid"
+                      [matChipInputAddOnBlur]="true"
                       (matChipInputTokenEnd)="addEditAuthor($event)" />
                   </mat-chip-grid>
+                  <mat-hint>{{ 'legal.dataSide.authorshipHint' | translate }}</mat-hint>
                 </mat-form-field>
                 <button
                   type="button"


### PR DESCRIPTION
Fixes https://linear.app/dasch/issue/DEV-6761

## Motivation

Reported via customer support (Plain thread T-192): in the legal-metadata **Authorship** field, a typed author name was silently dropped unless the user pressed **Enter**, and on *Legal Settings → Resource side* the **Save changes** button stayed greyed out because typing never dirtied the form. It is not a functional bug — the "press Enter" affordance was invisible.

## Summary

Make committing an author obvious and safe wherever authorship is entered: commit a pending value on blur, and show a persistent hint. The same commit-on-Enter-only pattern lived in three chip inputs; this brings them in line with the existing `chip-list-input` component, which already uses `matChipInputAddOnBlur`.

## Key Changes

- **`authorship-chip-editor`** (shared `ui/ui`): add `[matChipInputAddOnBlur]="true"` + an optional `hint` input. Reused by **both** the Legal Settings resource-side form and the data-resource creator, so one change covers both surfaces.
- **`resource-rights-statement`** (per-resource inline editor): add `addOnBlur` + a `mat-hint`. Clicking the Save (💾) icon now flushes the pending name before `saveEdit()` emits.
- **`authorship-form-field`** (file/asset resource creator, has autocomplete): add a persistent `mat-hint`; remove a dead disabled-autocomplete-option that never actually rendered. **No** `addOnBlur` here — with an open suggestion list, blur can double-commit the typed value alongside the selected option.
- New i18n key `legal.dataSide.authorshipHint` in `en/de/fr/it` (domain terms per language: *Urheber:innen* / *auteur·ice* / *autore*).

## Challenges and Decisions

- Deliberately did **not** add COMMA as a chip separator — author names are often written "Last, First", which a comma separator would wrongly split into two chips.
- Residual micro-case: on the settings page the Save button is disabled until the form is dirty, and clicking a *disabled* button doesn't blur the input — so pure "type → click greyed Save" (with no other interaction) still needs Enter, which the now-visible hint instructs.

## Gotchas

- Romansh (`rm`) has no i18n file — it falls back to English at runtime (DEV-6629), so only `en/de/fr/it` were touched.

## Test Plan

- *Legal Settings → Resource side*: type an author, click into another field **without** pressing Enter → the name becomes a chip and **Save changes** enables; save + reload confirms persistence.
- *Resource Rights Statement*: edit authorship (✏️), type a name, click the save (💾) icon without pressing Enter → the pending name is included.
- Hint text visible under each authorship field (checked EN + FR).
- App compiles and serves cleanly against the dev API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
