### PR TITLE
feat(resource-editor): legal-metadata title + loading spinner, trim Incoming Links spinner padding (DEV-6740)

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -749,6 +749,7 @@
       "goToSegment": "Zum Segment gehen"
     },
     "legal": {
+      "title": "Rechtliches",
       "copyrightHolder": "Urheberrechtsinhaber",
       "authorship": "Autorenschaft"
     },

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -555,6 +555,7 @@
       "goToSegment": "Go to segment"
     },
     "legal": {
+      "title": "Legal",
       "copyrightHolder": "Copyright holder",
       "authorship": "Authorship"
     },

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -555,6 +555,7 @@
       "goToSegment": "Aller au segment"
     },
     "legal": {
+      "title": "Informations légales",
       "copyrightHolder": "Titulaire des droits d'auteur",
       "authorship": "Auteur·ice"
     },

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -555,6 +555,7 @@
       "goToSegment": "Vai al segmento"
     },
     "legal": {
+      "title": "Informazioni legali",
       "copyrightHolder": "Titolare del copyright",
       "authorship": "Autore"
     },

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/incoming-links-property.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/incoming-links-property.component.ts
@@ -39,7 +39,7 @@ import { sortByKeys } from './property-value/sortByKeys';
         [label]="'resourceEditor.propertiesDisplay.incomingLinkLabel' | translate"
         [borderBottom]="true"
         [isEmptyRow]="true">
-        <app-progress-indicator />
+        <app-progress-indicator [compact]="true" />
       </app-property-row>
     }
   `,

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ReadFileValue } from '@dasch-swiss/dsp-js';
 import { AdminAPIApiService, ProjectLicenseDto } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
 import { TranslatePipe } from '@ngx-translate/core';
 import { switchMap, take } from 'rxjs';
 import { ResourceFetcherService } from './resource-fetcher.service';
@@ -15,6 +16,7 @@ import { ResourceLegalLicenseComponent } from './resource-legal-license.componen
         style="border: 1px solid #292929; text-align: left;
     background: #292929; border-radius: 8px;
     color: #e4e9ed; padding: 8px; padding-bottom: 16px; margin-top: 8px; position: relative; top: 12px">
+        <div style="font-weight: bold; margin-bottom: 8px">{{ 'resourceEditor.legal.title' | translate }}</div>
         <div style="display: flex; justify-content: space-between">
           <div>
             @if (fileValue.copyrightHolder) {
@@ -34,9 +36,11 @@ import { ResourceLegalLicenseComponent } from './resource-legal-license.componen
               </div>
             }
           </div>
-          <div style="display: flex; justify-content: flex-end">
+          <div style="display: flex; justify-content: flex-end; align-items: center">
             @if (license) {
               <app-resource-legal-license [license]="license" />
+            } @else if (isLoadingLicense) {
+              <app-progress-indicator [compact]="true" size="xsmall" />
             }
           </div>
         </div>
@@ -44,12 +48,13 @@ import { ResourceLegalLicenseComponent } from './resource-legal-license.componen
     }
   `,
   styles: ['.label { display: inline-block; width: 170px; font-weight: bold}'],
-  imports: [TranslatePipe, ResourceLegalLicenseComponent],
+  imports: [TranslatePipe, ResourceLegalLicenseComponent, AppProgressIndicatorComponent],
 })
 export class ResourceLegalComponent implements OnInit {
   @Input({ required: true }) fileValue!: ReadFileValue;
 
   licenses: ProjectLicenseDto[] = [];
+  isLoadingLicense = false;
 
   get license() {
     return this.licenses.find(license => license.id === this.fileValue.license?.id);
@@ -61,7 +66,10 @@ export class ResourceLegalComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this._fetchLicense();
+    if (this.fileValue.license) {
+      this.isLoadingLicense = true;
+      this._fetchLicense();
+    }
   }
 
   private _fetchLicense() {
@@ -72,8 +80,14 @@ export class ResourceLegalComponent implements OnInit {
         ),
         take(1)
       )
-      .subscribe(data => {
-        this.licenses = data.data;
+      .subscribe({
+        next: data => {
+          this.licenses = data.data;
+          this.isLoadingLicense = false;
+        },
+        error: () => {
+          this.isLoadingLicense = false;
+        },
       });
   }
 }

--- a/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.component.ts
+++ b/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.component.ts
@@ -7,7 +7,7 @@ import { ProgressSize, SIZE_TO_PXL } from './progress-indicator.type';
   imports: [MatIconModule],
 
   template: `
-    <div class="app-progress-indicator default" data-cy="loader">
+    <div class="app-progress-indicator default" [class.compact]="compact" data-cy="loader">
       <svg
         class="loader"
         [attr.width]="widthAndHeight"
@@ -45,6 +45,10 @@ import { ProgressSize, SIZE_TO_PXL } from './progress-indicator.type';
       .app-progress-indicator.default {
         margin: 48px auto;
 
+        &.compact {
+          margin: 12px auto;
+        }
+
         .loader {
           display: block;
           margin: 0 auto;
@@ -68,6 +72,7 @@ import { ProgressSize, SIZE_TO_PXL } from './progress-indicator.type';
 })
 export class AppProgressIndicatorComponent implements OnInit {
   @Input() size: ProgressSize = 'small';
+  @Input() compact = false;
   widthAndHeight!: string;
 
   ngOnInit() {


### PR DESCRIPTION
Fixes DEV-6740

## Motivation

Two small loading-state inconsistencies in the resource viewer. The legal-metadata box shows nothing where the license logo will appear while the license resolves (it can look empty), and the Incoming Links loading spinner reserves an excessive amount of vertical space. A section should reserve its space and signal loading instead of popping in late.

## Summary

- Legal box now always shows a title and renders a compact spinner in the license corner while the license loads, then swaps in the license logo — mirroring the existing Incoming Links pattern.
- Incoming Links loading spinner padding is trimmed.
- The shared progress indicator gains an opt-in `compact` mode so callers can trim its padding without affecting the ~18 other usages.

## Key Changes

- `app-progress-indicator.component.ts`: new `@Input() compact` (`[class.compact]`), `.default.compact { margin: 12px auto }` overriding the default `48px auto`. Defaults to `false`, so existing usages are unchanged.
- `incoming-links-property.component.ts`: loading `@else` branch now uses `<app-progress-indicator [compact]="true" />`.
- `resource-legal.component.ts`: adds an always-present title, an `isLoadingLicense` flag (set only when the file references a license, cleared on fetch `next`/`error`), and `<app-progress-indicator [compact]="true" size="xsmall" />` in the license corner while loading.
- i18n: new `resourceEditor.legal.title` key in de/en/fr/it.

## Challenges and Decisions

- The original issue suggested reusing `PropertyRowComponent`. That component is built for the light properties list (gray right-aligned label column, `$primary` border) and would clash inside the legal box, which is a dark `#292929` caption strip overlaid above the media — not a properties-list row. I kept the dark-box design and added the title + spinner within it, which is the faithful interpretation of the intent.
- The always-present title is a small design addition beyond the pure loading state: it now shows on the legal box in every media viewer (image, audio, video, pdf, document, archive, text, compound). Flagging it here as a conscious change.
- Padding fix is scoped locally via the opt-in `compact` input rather than changing the shared `48px` default, to avoid regressing the other spinner usages (several are full-page loaders where the generous margin is intentional).

## Gotchas

- The spinner only appears when the file actually references a license; there is no spinner when there is nothing to load.
- EN title is terse ("Legal") while DE/FR/IT are fuller ("Rechtliches" / "Informations légales" / "Informazioni legali") — easy to adjust if a different EN wording is preferred.

## Test Plan

- `nx lint` and Angular compile (`strictTemplates`) pass clean on `vre-resource-editor-resource-editor` and `vre-ui-progress-indicator`.
- On stage: open a resource whose file has a license — the legal box shows the title immediately and a brief compact spinner in the license corner before the license logo appears (throttle the network to observe it). Open a resource with incoming links — the loading spinner's vertical padding is visibly trimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
