### PR TITLE
fix: restore DaSCH blue save-confirmation snackbar (DEV-6747)

### DIFF
--- a/apps/dsp-app/src/styles.scss
+++ b/apps/dsp-app/src/styles.scss
@@ -30,11 +30,11 @@ $theme: mat.m2-define-light-theme((
 // Include all theme styles for the components.
 @include mat.all-component-themes($theme);
 
-// Global snack-bar theme override for Angular Material v18
+// Global snack-bar theme override (DaSCH blue)
 :root {
   --mat-snack-bar-button-color: rgba(51, 103, 144, 1);
-  --mat-snackbar-container-color: rgba(51, 103, 144, 0.9);
-  --mat-snackbar-supporting-text-color: rgb(255, 255, 255);
+  --mat-snack-bar-container-color: rgba(51, 103, 144, 0.9);
+  --mat-snack-bar-supporting-text-color: rgb(255, 255, 255);
 }
 
 body {

--- a/apps/dsp-app/src/styles/_elements.scss
+++ b/apps/dsp-app/src/styles/_elements.scss
@@ -102,23 +102,22 @@ a {
   z-index: 1000;
 }
 
-// SNACK BAR
-// Angular Material v18 snack-bar styles - Using correct CSS custom properties
+// SNACK BAR — DaSCH blue / red / amber by panelClass
 .mat-mdc-snack-bar-container.success {
-  --mat-snackbar-container-color: rgba(51, 103, 144, 0.9) !important;
-  --mat-snackbar-supporting-text-color: rgb(255, 255, 255) !important;
+  --mat-snack-bar-container-color: rgba(51, 103, 144, 0.9) !important;
+  --mat-snack-bar-supporting-text-color: rgb(255, 255, 255) !important;
   --mat-snack-bar-button-color: rgb(255, 255, 255) !important;
 }
 
 .mat-mdc-snack-bar-container.error {
-  --mat-snackbar-container-color: rgba(225, 29, 72, 0.9) !important;
-  --mat-snackbar-supporting-text-color: rgb(255, 255, 255) !important;
+  --mat-snack-bar-container-color: rgba(225, 29, 72, 0.9) !important;
+  --mat-snack-bar-supporting-text-color: rgb(255, 255, 255) !important;
   --mat-snack-bar-button-color: rgb(255, 255, 255) !important;
 }
 
 .mat-mdc-snack-bar-container.note {
-  --mat-snackbar-container-color: rgba(251, 191, 36, 0.9) !important;
-  --mat-snackbar-supporting-text-color: rgb(255, 255, 255) !important;
+  --mat-snack-bar-container-color: rgba(251, 191, 36, 0.9) !important;
+  --mat-snack-bar-supporting-text-color: rgb(255, 255, 255) !important;
   --mat-snack-bar-button-color: rgb(255, 255, 255) !important;
 }
 


### PR DESCRIPTION
Fixes DEV-6747

## Motivation
After saving in dsp-app (e.g. Project → Settings → Submit), the "Project updated"
confirmation snackbar renders on a grey/charcoal background instead of DaSCH blue —
a styling regression observed on Stage 2026.07.02.

## Summary
The DaSCH-blue snackbar override targeted a CSS custom property that Angular Material
no longer reads, so the override was inert and Material's dark default showed through.
Correcting the token name restores the intended colours. Pure SCSS, no logic changes.

## Key Changes
- `apps/dsp-app/src/styles.scss` — fix the `:root` global snackbar override tokens.
- `apps/dsp-app/src/styles/_elements.scss` — fix the same tokens in the `.success` /
  `.error` / `.note` panelClass blocks.
- Rename `--mat-snackbar-container-color` → `--mat-snack-bar-container-color` and
  `--mat-snackbar-supporting-text-color` → `--mat-snack-bar-supporting-text-color`
  (the missing hyphen). The button token was already correct.
- Tidied two outdated "Angular Material v18" comments.

## Challenges and Decisions
- **Root cause:** Material renders the surface as
  `background-color: var(--mat-snack-bar-container-color, var(--mat-sys-inverse-surface))`.
  The override used the non-hyphenated `--mat-snackbar-*` spelling, which exists nowhere
  in `@angular/material`, so it fell back to the charcoal `--mat-sys-inverse-surface`.
  Introduced by the Angular 20 upgrade (`b976abd94`), surfaced by the Angular 21 upgrade
  (`baef357a0`) in the 2026.07.02 release.
- **Scope:** fixed all three panelClass variants — `.error` and `.note` had the identical
  dead token, so error snackbars were also grey; they're red/amber again.
- **Opacity left unchanged** at the original `0.9` — faithful to how it looked before the regression.
- **Close-button hover highlight left as-is** — Material's standard hover state layer
  (required affordance), not part of this bug.

## Gotchas
- CSS-custom-property rename only; no template/TS/behaviour changes. Version-stable across
  Angular Material 20 and 21 (identical token name).

## Test Plan
- dsp-app against dev backend → project → Settings → Description → change → Submit →
  "Project updated" snackbar is DaSCH blue (`rgb(51,103,144)`), white text. ✅ verified locally.
- Error snackbar → red.
- DevTools: `.mat-mdc-snack-bar-container.success` → `--mat-snack-bar-container-color`
  resolves and `background-color` computes to blue (previously fell back to `#424242`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
