### PR TITLE
fix(legal): show the already-set license immediately in Legal Settings

### DIFF
--- a/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LegalInfoApiService } from '@dasch-swiss/vre/3rd-party-services/api';
+import { ProjectDataRightsService } from '@dasch-swiss/vre/shared/app-helper-services';
+import { NotificationService } from '@dasch-swiss/vre/ui/notification';
+import { TranslateService } from '@ngx-translate/core';
+import { NEVER, of } from 'rxjs';
+import { ResourceSideLegalFormComponent } from './resource-side-legal-form.component';
+
+const CC_BY_40 = 'http://rdfh.ch/licenses/cc-by-4.0';
+const CC_BY_NC_40 = 'http://rdfh.ch/licenses/cc-by-nc-4.0';
+const CC0_10 = 'http://rdfh.ch/licenses/cc0-1.0';
+
+describe('ResourceSideLegalFormComponent - license dropdown seeding (DEV-6763)', () => {
+  let component: ResourceSideLegalFormComponent;
+  let fixture: ComponentFixture<ResourceSideLegalFormComponent>;
+  let mockLegalInfoApiService: jest.Mocked<LegalInfoApiService>;
+
+  const mockProject = {
+    shortcode: '0001',
+    id: 'http://rdfh.ch/projects/0001',
+    longname: 'Test project',
+    dataLicense: CC_BY_40,
+    dataCopyrightHolder: 'DaSCH',
+    defaultDataAuthorship: ['DaSCH'],
+  };
+
+  beforeEach(async () => {
+    mockLegalInfoApiService = {
+      getLicenses: jest.fn().mockReturnValue(of([])),
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [ResourceSideLegalFormComponent],
+      providers: [
+        { provide: LegalInfoApiService, useValue: mockLegalInfoApiService },
+        { provide: ProjectDataRightsService, useValue: {} },
+        { provide: NotificationService, useValue: { openSnackBar: jest.fn() } },
+        { provide: TranslateService, useValue: { instant: jest.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ResourceSideLegalFormComponent);
+    component = fixture.componentInstance;
+    component.project = mockProject as any;
+  });
+
+  it('emits the already-set license synchronously, before the catalog request resolves', () => {
+    // getLicenses never emits, so any option present can only come from the synchronous seed.
+    mockLegalInfoApiService.getLicenses.mockReturnValue(NEVER);
+
+    component.ngOnInit();
+
+    const emissions: unknown[] = [];
+    component.ccLicenses$.subscribe(value => emissions.push(value));
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0]).toEqual([{ iri: CC_BY_40, summaryKey: 'ccBy40', fallbackLabel: '' }]);
+  });
+
+  it('supersedes the seed with the fetched CC-BY licenses once they load', () => {
+    mockLegalInfoApiService.getLicenses.mockReturnValue(
+      of([
+        { id: CC_BY_40, labelEn: 'CC BY 4.0' },
+        { id: CC_BY_NC_40, labelEn: 'CC BY-NC 4.0' },
+        { id: CC0_10, labelEn: 'CC0 1.0' },
+      ] as any)
+    );
+
+    component.ngOnInit();
+
+    const emissions: any[] = [];
+    component.ccLicenses$.subscribe(value => emissions.push(value));
+
+    // seed first, then the mapped catalog filtered to the CC-BY family (CC0 dropped)
+    expect(emissions[0]).toEqual([{ iri: CC_BY_40, summaryKey: 'ccBy40', fallbackLabel: '' }]);
+    expect(emissions[emissions.length - 1]).toEqual([
+      { iri: CC_BY_40, summaryKey: 'ccBy40', fallbackLabel: 'CC BY 4.0' },
+      { iri: CC_BY_NC_40, summaryKey: 'ccByNc40', fallbackLabel: 'CC BY-NC 4.0' },
+    ]);
+    expect(mockLegalInfoApiService.getLicenses).toHaveBeenCalledWith('0001');
+  });
+
+  it('seeds no option when the project has no license set', () => {
+    mockLegalInfoApiService.getLicenses.mockReturnValue(NEVER);
+    component.project = { ...mockProject, dataLicense: undefined } as any;
+
+    component.ngOnInit();
+
+    const emissions: unknown[] = [];
+    component.ccLicenses$.subscribe(value => emissions.push(value));
+
+    expect(emissions).toEqual([[]]);
+  });
+});

--- a/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/legal/resource-side-legal-form.component.ts
@@ -14,7 +14,7 @@ import { ProjectDataRightsService } from '@dasch-swiss/vre/shared/app-helper-ser
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { AuthorshipChipEditorComponent } from '@dasch-swiss/vre/ui/ui';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { map, Observable } from 'rxjs';
+import { map, Observable, startWith } from 'rxjs';
 
 /**
  * Localized summary translation keys for the CC-BY family, keyed by license IRI.
@@ -156,15 +156,29 @@ export class ResourceSideLegalFormComponent implements OnInit {
       dataAuthorship: new FormControl<string[]>(this.project.defaultDataAuthorship ?? [], { nonNullable: true }),
     });
 
-    this.ccLicenses$ = this._legalInfoApi
-      .getLicenses(this.project.shortcode)
-      .pipe(
-        map(licenses =>
-          licenses
-            .filter(l => l.id.startsWith(CC_BY_IRI_PREFIX))
-            .map(l => ({ iri: l.id, summaryKey: CC_BY_SUMMARY_KEYS[l.id], fallbackLabel: l.labelEn }))
-        )
-      );
+    // Seed the dropdown with the already-selected license so mat-select can render its label
+    // immediately, before the (uncached) license catalog request resolves. Otherwise the field
+    // shows blank for a round-trip, because mat-select only renders a selected value's label once a
+    // matching <mat-option> exists. The label comes from the static CC_BY_SUMMARY_KEYS map, so the
+    // seed needs no network. The fetched list then supersedes it. See DEV-6763.
+    const preselected = this.project.dataLicense ? [this._toCcLicenseOption(this.project.dataLicense)] : [];
+
+    this.ccLicenses$ = this._legalInfoApi.getLicenses(this.project.shortcode).pipe(
+      map(licenses =>
+        licenses.filter(l => l.id.startsWith(CC_BY_IRI_PREFIX)).map(l => this._toCcLicenseOption(l.id, l.labelEn))
+      ),
+      startWith(preselected)
+    );
+  }
+
+  /**
+   * Maps a license IRI to a dropdown option. The CC-BY family label comes from the static
+   * CC_BY_SUMMARY_KEYS map (translated in the template), so a preselected license can be shown
+   * without waiting for the catalog fetch; `fallbackLabel` (the API's labelEn) is only used for
+   * licenses not registered in that map.
+   */
+  private _toCcLicenseOption(iri: string, fallbackLabel = ''): CcLicenseOption {
+    return { iri, summaryKey: CC_BY_SUMMARY_KEYS[iri], fallbackLabel };
   }
 
   /** Builds the per-chip remove-button aria-label; arrow so it binds correctly when passed as an @Input. */


### PR DESCRIPTION
Fixes https://linear.app/dasch/issue/DEV-6763

## Motivation

In **Settings → Legal Settings → Resource side**, when a project already has a license set, the **License** field renders blank for a moment when the tab opens and the label only appears after a short delay — it looks as though no license is set. Reported as DEV-6763 (same "renders before async data" family as DEV-6746).

## Summary

The selected license value is available immediately from the loaded project, but the `<mat-select>` options are loaded from a separate, uncached request. `mat-select` can only render a selected value's label once a matching `<mat-option>` exists, so the field stays blank for one round-trip. Seed the dropdown with the already-selected license so its option exists on first render; the fetched catalog then supersedes the seed.

## Key Changes

- `resource-side-legal-form.component.ts`: build a synchronous seed option for `project.dataLicense` and `startWith` it on `ccLicenses$`; extract a shared `_toCcLicenseOption` helper used by both the seed and the fetched list.
- Add `resource-side-legal-form.component.spec.ts`: regression coverage — with `getLicenses` mocked to `NEVER`, `ccLicenses$` must still emit the selected license synchronously; plus the fetched list superseding the seed and the no-license case.

## Challenges and Decisions

- The CC-BY label comes from the static `CC_BY_SUMMARY_KEYS` map, so the seed needs **no** network — no caching or spinner required.
- Chose seeding over a loading spinner or a root-level catalog cache: it is the smallest change that fixes the resting-state blank, adds no new DI (so no Storybook/spec fallout), and `track lic.iri` keeps the option stable when the seed is swapped for the full list (no flicker).

## Gotchas

- Not a `compareWith` issue — the option values and the form control are both string IRIs, so matching is correct; the label was merely late.

## Test Plan

- `nx lint vre-pages-project-project` — pass
- `nx test vre-pages-project-project` — 146/146 pass (incl. 3 new regression cases; the `NEVER` case fails if the `startWith` seed is removed)
- Built and served locally from this branch against the stage backend (compiles and runs). Reviewer visual check: open a project that has a resource-side license set → Settings → Legal Settings → Resource side; the License label now shows immediately instead of appearing after the `.../legal-info/licenses` request resolves.
