### PR TITLE
test: stop flaky e2e ontology names colliding with reserved words (DEV-6764)

### DIFF
--- a/apps/dsp-app/cypress/e2e/project-member/ontology-management.cy.ts
+++ b/apps/dsp-app/cypress/e2e/project-member/ontology-management.cy.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { UserProfiles } from '../../models/user-profiles';
+import { uniqueName } from '../../support/helpers/unique-name';
 import { Project0001Page } from '../../support/pages/existing-ontology-class-page';
 
 describe('Project Member - Ontology management', () => {
@@ -18,7 +19,7 @@ describe('Project Member - Ontology management', () => {
   describe('Ontology Management', () => {
     it('should create new ontology and edit the ontology', () => {
       const createData = {
-        name: faker.string.alpha({ length: { min: 3, max: 16 } }),
+        name: uniqueName(),
         label: faker.lorem.words(5),
         comment: faker.lorem.words(10),
       };

--- a/apps/dsp-app/cypress/e2e/system-admin/ontology.cy.ts
+++ b/apps/dsp-app/cypress/e2e/system-admin/ontology.cy.ts
@@ -1,5 +1,6 @@
 import { CreateOntology } from '../../../../../libs/dsp-js/src';
 import { faker } from '@faker-js/faker';
+import { uniqueName } from '../../support/helpers/unique-name';
 import ProjectPage from '../../support/pages/project-page';
 
 describe('Ontology', () => {
@@ -11,7 +12,7 @@ describe('Ontology', () => {
 
   it('should create new ontology', () => {
     const data = {
-      name: faker.string.alpha({ length: { min: 3, max: 16 } }),
+      name: uniqueName(),
       label: faker.lorem.words(5),
       comment: faker.lorem.words(10),
     };
@@ -47,7 +48,7 @@ describe('Ontology', () => {
 
   it('should update ontology', () => {
     const data = <CreateOntology>{
-      name: faker.string.alpha({ length: { min: 3, max: 16 } }).replace(' ', ''),
+      name: uniqueName(),
       label: faker.lorem.words(5),
       comment: faker.lorem.words(10),
     };

--- a/apps/dsp-app/cypress/support/commands/ontology-command.ts
+++ b/apps/dsp-app/cypress/support/commands/ontology-command.ts
@@ -1,6 +1,7 @@
 import { CreateOntology, OntologyMetadata } from '../../../../../libs/dsp-js/src';
 import { faker } from '@faker-js/faker';
 import { JsonConvert } from 'json2typescript';
+import { uniqueName } from '../helpers/unique-name';
 import ProjectPage from '../pages/project-page';
 
 const getAuthHeaders = () => ({
@@ -12,7 +13,7 @@ Cypress.Commands.add(
   (
     projectPage: ProjectPage,
     ontology: CreateOntology = {
-      name: faker.string.alpha({ length: { min: 3, max: 16 } }),
+      name: uniqueName(),
       attachedToProject: projectPage.projectIri,
       comment: faker.lorem.words(10),
       label: faker.lorem.words(5),

--- a/apps/dsp-app/cypress/support/helpers/unique-name.ts
+++ b/apps/dsp-app/cypress/support/helpers/unique-name.ts
@@ -4,13 +4,25 @@ import { faker } from '@faker-js/faker';
 // two names are generated in the same millisecond.
 let counter = 0;
 
+// dsp-api rejects any ontology name that *contains* one of these as a substring
+// (case-insensitive), e.g. an `rdf` hidden inside `FhWrDfSouF`. A raw random
+// alpha string embeds one by chance every few hundred draws, which 400s
+// `POST /v2/ontologies` and flakes any ontology-creating spec. See DEV-6764.
+const RESERVED_WORDS = ['rdf', 'rdfs', 'owl', 'xsd', 'schema', 'shared', 'simple', 'ontology'];
+
+const containsReservedWord = (name: string): boolean => {
+  const lower = name.toLowerCase();
+  return RESERVED_WORDS.some(word => lower.includes(word));
+};
+
 /**
- * Generate a unique, valid ontology entity name (class or property `name`).
+ * Generate a unique, valid ontology entity name (ontology, class or property `name`).
  *
  * Ontology names are validated in the app by `CustomRegex.ID_NAME_REGEX`
  * (`/^(?![vV]+[0-9])+^([a-zA-Z])[a-zA-Z0-9_.-]*$/`) AND by an async
  * "already exists" validator that keeps the submit button disabled on any
- * collision with an existing entity name.
+ * collision with an existing entity name. Ontology `name`s are additionally
+ * rejected by dsp-api if they contain a reserved word as a substring.
  *
  * Bare `faker.lorem.word()` draws from a ~1000-word dictionary, so two calls in
  * the same test (or a clash with a reset-database default) intermittently
@@ -19,9 +31,14 @@ let counter = 0;
  * stalls the auto-generated OpenAPI spec-bump PRs.
  *
  * The counter suffix makes the name unique; the leading lowercase letter keeps
- * it regex-valid and clear of the `v|V` + digit lookahead.
+ * it regex-valid and clear of the `v|V` + digit lookahead; the reserved-word
+ * guard re-draws the random part until it embeds none.
  */
 export function uniqueName(): string {
   counter += 1;
-  return `e2e${faker.string.alpha({ length: 6, casing: 'lower' })}${counter}`;
+  let candidate = `e2e${faker.string.alpha({ length: 6, casing: 'lower' })}${counter}`;
+  while (containsReservedWord(candidate)) {
+    candidate = `e2e${faker.string.alpha({ length: 6, casing: 'lower' })}${counter}`;
+  }
+  return candidate;
 }


### PR DESCRIPTION
Fixes DEV-6764

## Motivation
dsp-app e2e specs that create ontologies intermittently fail in CI with a `cy.request()` 400 from `POST /v2/ontologies`:

> OntologyName must not contain reserved words: rdf, shared, ontology, owl, simple, xsd, schema, rdfs.

The failure is unrelated to whatever PR is under test — it hits any run that happens to draw a colliding name, including the auto-generated OpenAPI spec-bump PRs. Most recently observed on #3244, where the generated name `FhWrDfSouF` contains `rdf` as a substring.

## Summary
Ontology names were generated with raw `faker.string.alpha({ length: { min: 3, max: 16 } })`. dsp-api rejects any ontology name that *contains* a reserved word as a substring (case-insensitive), so a random alpha string occasionally embeds `rdf`/`owl`/`xsd`/… and 400s. This hardens the existing `uniqueName()` helper with a reserved-word guard and routes all ontology-name generation through it. Test-infra only, no app code.

## Key Changes
- `cypress/support/helpers/unique-name.ts` — add a reserved-word guard that re-draws the random part until the candidate embeds none of `rdf, rdfs, owl, xsd, schema, shared, simple, ontology`; doc comment updated.
- `cypress/support/commands/ontology-command.ts` — `createOntology` default name → `uniqueName()`.
- `cypress/e2e/system-admin/ontology.cy.ts` — both ontology-name generators → `uniqueName()`.
- `cypress/e2e/project-member/ontology-management.cy.ts` — ontology-name generator → `uniqueName()`.

## Challenges and Decisions
- **Root cause is a substring match, not equality** — `FhWrDfSouF` was rejected for containing `rdf`. So simply switching to `uniqueName()` as-is would only reduce the flakiness (~4×), because its own 6-letter random middle can still embed a reserved word. The guard makes the guarantee total.
- **Regenerate-until-clean** over a restricted alphabet: keeps the `e2e` prefix + monotonic counter (regex-valid start + uniqueness) and only re-draws the random middle. A clean draw happens ~99.9% of the time, so the loop terminates immediately.
- **Scope** — fixed all three live ontology-name sites (plus one dead `name` field aligned for consistency), not just the one that failed on #3244, so the class of flakiness is gone for everyone. Class/property name generators in `resource*.cy.ts` are out of scope (prefixed, alphanumeric, different validator).

## Gotchas
- Test-only change; no template/TS/behaviour changes in the app.
- `uniqueName()` is also used for class/property names — the guard only ever makes those safer, never breaks them.

## Test Plan
- Simulated the hardened generator over 2,000,000 draws: 0 reserved-word violations, 0 duplicate names; guard confirmed to reject known-bad candidates (`e2ewrdfoo1`, `e2eowlxyz2`).
- CI e2e (heavy) suite — the previously flaky `data-model-class.cy.ts › should cancel to create data model class` and the `ontology*` specs should now be deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)