### PR TITLE
fix(project): render the Description settings submit button with the form

### DIFF
--- a/libs/vre/pages/project/project/src/lib/reusable-project-form/edit-project-form-page.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/reusable-project-form/edit-project-form-page.component.spec.ts
@@ -1,0 +1,79 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { ProjectApiService } from '@dasch-swiss/vre/3rd-party-services/api';
+import { LocalizationService } from '@dasch-swiss/vre/shared/app-helper-services';
+import { NotificationService } from '@dasch-swiss/vre/ui/notification';
+import { TranslateModule } from '@ngx-translate/core';
+import { ReplaySubject } from 'rxjs';
+import { ProjectPageService } from '../project-page.service';
+import { EditProjectFormPageComponent } from './edit-project-form-page.component';
+import { ReusableProjectFormComponent } from './reusable-project-form.component';
+
+// Stub for the heavy form child so we can drive `afterFormInit` timing without its dependency tree.
+@Component({ selector: 'app-reusable-project-form', standalone: true, template: '' })
+class StubReusableProjectFormComponent {
+  @Input() formData: unknown;
+  @Output() afterFormInit = new EventEmitter<unknown>();
+}
+
+describe('EditProjectFormPageComponent - submit button render order (DEV-6746)', () => {
+  let fixture: ComponentFixture<EditProjectFormPageComponent>;
+  let currentProject$: ReplaySubject<any>;
+
+  const project = {
+    id: 'http://rdfh.ch/projects/0001',
+    shortcode: '0001',
+    shortname: 'test',
+    longname: 'Test project',
+    description: [{ language: 'en', value: 'A description' }],
+    keywords: ['k'],
+  };
+
+  const submitButton = () => fixture.nativeElement.querySelector('[data-cy=submit-button]');
+  const stub = () => fixture.debugElement.query(By.directive(StubReusableProjectFormComponent)).componentInstance;
+
+  beforeEach(async () => {
+    currentProject$ = new ReplaySubject<any>(1);
+
+    await TestBed.configureTestingModule({
+      imports: [EditProjectFormPageComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: ProjectPageService, useValue: { currentProject$, reloadProject: jest.fn() } },
+        { provide: ProjectApiService, useValue: { update: jest.fn() } },
+        { provide: NotificationService, useValue: { openSnackBar: jest.fn() } },
+        { provide: LocalizationService, useValue: { currentLanguage: 'en' } },
+      ],
+    })
+      .overrideComponent(EditProjectFormPageComponent, {
+        remove: { imports: [ReusableProjectFormComponent] },
+        add: { imports: [StubReusableProjectFormComponent] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(EditProjectFormPageComponent);
+  });
+
+  it('does not render the submit button before the project has loaded', () => {
+    fixture.detectChanges();
+    expect(submitButton()).toBeNull();
+  });
+
+  it('does not render the submit button after the project loads but before the form is built', () => {
+    currentProject$.next(project);
+    fixture.detectChanges();
+    // The form child exists, but has not emitted afterFormInit yet, so `form` is still unset.
+    expect(submitButton()).toBeNull();
+  });
+
+  it('renders the submit button once the form is built', () => {
+    currentProject$.next(project);
+    fixture.detectChanges();
+
+    stub().afterFormInit.emit(new FormGroup({}));
+    fixture.detectChanges();
+
+    expect(submitButton()).not.toBeNull();
+  });
+});

--- a/libs/vre/pages/project/project/src/lib/reusable-project-form/edit-project-form-page.component.ts
+++ b/libs/vre/pages/project/project/src/lib/reusable-project-form/edit-project-form-page.component.ts
@@ -20,18 +20,23 @@ import { ReusableProjectFormComponent } from './reusable-project-form.component'
       <app-reusable-project-form [formData]="formData" (afterFormInit)="form = $event" />
     }
 
-    <div style="display: flex; justify-content: space-between">
-      <button
-        mat-raised-button
-        type="submit"
-        color="primary"
-        (click)="onSubmit()"
-        appLoadingButton
-        [isLoading]="loading"
-        data-cy="submit-button">
-        {{ 'ui.common.actions.submit' | translate }}
-      </button>
-    </div>
+    <!-- Gate the submit button on the built form so it appears together with the fields, not before
+         them. Without this it renders on the first pass, ahead of the async project fetch and form
+         build, leaving a lone Submit button over empty content. See DEV-6746. -->
+    @if (form) {
+      <div style="display: flex; justify-content: space-between">
+        <button
+          mat-raised-button
+          type="submit"
+          color="primary"
+          (click)="onSubmit()"
+          appLoadingButton
+          [isLoading]="loading"
+          data-cy="submit-button">
+          {{ 'ui.common.actions.submit' | translate }}
+        </button>
+      </div>
+    }
   `,
   imports: [AsyncPipe, MatButton, TranslatePipe, LoadingButtonDirective, ReusableProjectFormComponent],
 })


### PR DESCRIPTION
Fixes https://linear.app/dasch/issue/DEV-6746

## Motivation

On a project's **Settings → Description** (the tab it lands on), the **Submit** button rendered before the Description form appeared — for a moment the user saw a lone Submit button over empty content, which looked broken.

## Summary

`EditProjectFormPageComponent` gated the form on the async project fetch but left the Submit button ungated, so the button painted on the first change-detection pass while the form only appeared after the project GET resolved (and the child form finished building). Gate the button on the built `form` so it renders together with the fields.

## Key Changes

- `edit-project-form-page.component.ts`: wrap the Submit button in `@if (form)` so it appears with the form fields (both keyed on the built `FormGroup`).
- Add `edit-project-form-page.component.spec.ts`: asserts the submit button is absent before the project loads and before the form is built, and present once built.

## Challenges and Decisions

- Gated on `form` (the built `FormGroup`, set via the child's `afterFormInit`) rather than only `formData$`, because `form` is the exact readiness signal for the fields — this also closes the residual `allProjects$`/`_buildForm` sub-gap and removes a latent NPE (`onSubmit()` reads `this.form.value`, and the always-present button could be clicked before `form` existed).
- No behaviour change to the enabled/disabled state; matches the `@if (project$ | async)` gating already used in the sibling `LegalSettingsComponent`.

## Gotchas

- The misleadingly-named `description/` folder is the read-only view; the Settings edit tab is `EditProjectFormPageComponent` in `reusable-project-form/`.

## Test Plan

- `nx lint vre-pages-project-project` — pass
- `nx test vre-pages-project-project` — 146/146 pass (incl. 3 new cases; verified the spec fails if the `@if (form)` gate is removed)
- Served locally against stage and confirmed the Submit button no longer appears ahead of the form.
