### PR TITLE
fix(project): build the Description edit form without waiting on the all-projects fetch

### DIFF
--- a/libs/vre/pages/project/project/src/lib/reusable-project-form/reusable-project-form.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/reusable-project-form/reusable-project-form.component.spec.ts
@@ -1,0 +1,61 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AllProjectsService } from '@dasch-swiss/vre/pages/user-settings/user';
+import { TranslateService } from '@ngx-translate/core';
+import { NEVER, Observable, Subject } from 'rxjs';
+import { ReusableProjectFormComponent } from './reusable-project-form.component';
+
+describe('ReusableProjectFormComponent - form build gating (DEV-6765)', () => {
+  let fixture: ComponentFixture<ReusableProjectFormComponent>;
+  let component: ReusableProjectFormComponent;
+
+  const baseFormData = {
+    shortname: 'test',
+    longname: 'Test project',
+    description: [{ language: 'en', value: 'A description' }],
+    keywords: ['k'],
+  };
+
+  async function createComponent(allProjects$: Observable<unknown>) {
+    await TestBed.configureTestingModule({
+      imports: [ReusableProjectFormComponent],
+      providers: [
+        { provide: AllProjectsService, useValue: { allProjects$ } },
+        { provide: TranslateService, useValue: { instant: jest.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReusableProjectFormComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('builds the edit form immediately, without waiting on the all-projects fetch', async () => {
+    // allProjects$ never emits, so a built form proves the edit path does not depend on that fetch.
+    await createComponent(NEVER);
+    component.formData = { ...baseFormData, shortcode: '0001' } as any; // existing project → shortcode disabled
+
+    const emitted: unknown[] = [];
+    component.afterFormInit.subscribe(form => emitted.push(form));
+
+    component.ngOnInit();
+
+    expect(component.form).toBeDefined();
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('waits for the all-projects fetch before building the create form', async () => {
+    const allProjects$ = new Subject<any>();
+    await createComponent(allProjects$);
+    component.formData = { ...baseFormData, shortcode: '' } as any; // new project → shortcode enabled
+
+    const emitted: unknown[] = [];
+    component.afterFormInit.subscribe(form => emitted.push(form));
+
+    component.ngOnInit();
+    expect(component.form).toBeUndefined();
+    expect(emitted).toHaveLength(0);
+
+    allProjects$.next([{ shortcode: '0002' }]);
+    expect(component.form).toBeDefined();
+    expect(emitted).toHaveLength(1);
+  });
+});

--- a/libs/vre/pages/project/project/src/lib/reusable-project-form/reusable-project-form.component.ts
+++ b/libs/vre/pages/project/project/src/lib/reusable-project-form/reusable-project-form.component.ts
@@ -90,6 +90,16 @@ export class ReusableProjectFormComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    // The all-projects list is only needed to validate a *new* shortcode's uniqueness. When editing
+    // an existing project the shortcode field is disabled, so build the form immediately instead of
+    // blocking the render on the uncached "fetch every project" request. See DEV-6765.
+    const isEditingExistingProject = this.formData.shortcode !== '';
+    if (isEditingExistingProject) {
+      this._buildForm([]);
+      this.afterFormInit.emit(this.form);
+      return;
+    }
+
     this._allProjectsService.allProjects$
       .pipe(map(projects => projects.map(project => project.shortcode)))
       .subscribe(shortcodes => {


### PR DESCRIPTION
Fixes https://linear.app/dasch/issue/DEV-6765

## Motivation

Opening **Settings → Description** took a noticeable moment before the form fields appeared: the form was gated on a full, uncached `GET admin/projects` (the entire project list), fetched fresh on every open — even though that data isn't needed when editing.

## Summary

`ReusableProjectFormComponent` waited on `AllProjectsService.allProjects$` before building the form. That list is used only for the shortcode-uniqueness validator, which is moot on the edit page because the shortcode field is disabled there. Build the edit form immediately, and only wait on the all-projects fetch when creating (where the shortcode is editable and must be unique).

## Key Changes

- `reusable-project-form.component.ts`: in `ngOnInit`, when the shortcode is non-empty (editing an existing project), build the form synchronously and emit `afterFormInit`; keep the `allProjects$` subscription only for the create path.
- Add `reusable-project-form.component.spec.ts`: edit builds synchronously with `allProjects$ = NEVER`; create stays gated until `allProjects$` emits.

## Challenges and Decisions

- Scoped the fix to the edit path rather than caching `AllProjectsService.allProjects$` globally (`shareReplay`), to avoid changing refresh behaviour for other consumers. App-wide caching remains an optional follow-up noted in DEV-6765.
- `shortcodeExistsValidator([])` is harmless on edit — the field is disabled, so validators don't run.

## Gotchas

- The create page passes `shortcode: ''` (field enabled → needs the uniqueness check); the edit page passes the existing shortcode (field disabled). `formData.shortcode !== ''` is the create-vs-edit signal.

## Test Plan

- `nx lint vre-pages-project-project` — pass
- `nx test vre-pages-project-project` — 145/145 pass (incl. 2 new cases; verified the edit test fails if the fix is bypassed)
- Served locally against stage from this branch.

Related to DEV-6746 (same Description edit form).
