### PR TITLE
chore(deps): update prettier 3.8.5 → 3.9.5 and reformat

### DIFF
--- a/libs/dsp-js/src/models/v2/ontologies/class-definition.ts
+++ b/libs/dsp-js/src/models/v2/ontologies/class-definition.ts
@@ -9,22 +9,22 @@ export enum Cardinality {
   /**
    * Cardinality 1 (required).
    */
-  '_1' = 0,
+  _1 = 0,
 
   /**
    * Cardinality 0-1 (optional).
    */
-  '_0_1' = 1,
+  _0_1 = 1,
 
   /**
    * Cardinality 0-n (may have many)
    */
-  '_0_n' = 2,
+  _0_n = 2,
 
   /**
    * Cardinality 1-n (at least one).
    */
-  '_1_n' = 3,
+  _1_n = 3,
 }
 
 /**

--- a/libs/vre/3rd-party-services/api/src/lib/services/v2/ontology/i-has-property.interface.ts
+++ b/libs/vre/3rd-party-services/api/src/lib/services/v2/ontology/i-has-property.interface.ts
@@ -2,22 +2,22 @@ export enum Cardinality {
   /**
    * Cardinality 1 (required).
    */
-  '_1' = 0,
+  _1 = 0,
 
   /**
    * Cardinality 0-1 (optional).
    */
-  '_0_1' = 1,
+  _0_1 = 1,
 
   /**
    * Cardinality 0-n (may have many)
    */
-  '_0_n' = 2,
+  _0_n = 2,
 
   /**
    * Cardinality 1-n (at least one).
    */
-  '_1_n' = 3,
+  _1_n = 3,
 }
 
 export interface IHasProperty {

--- a/libs/vre/pages/project/project/src/lib/project-settings/legal/legal-settings.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/legal/legal-settings.component.ts
@@ -129,11 +129,10 @@ export class LegalSettingsComponent {
         first(),
         switchMap(currentProject =>
           this._dialog
-            .open<
+            .open<CreateCopyrightHolderDialogComponent, CreateCopyrightHolderDialogProps, boolean>(
               CreateCopyrightHolderDialogComponent,
-              CreateCopyrightHolderDialogProps,
-              boolean
-            >(CreateCopyrightHolderDialogComponent, { data: { projectShortcode: currentProject.shortcode } })
+              { data: { projectShortcode: currentProject.shortcode } }
+            )
             .afterClosed()
         )
       )

--- a/libs/vre/pages/system/system/src/lib/users/create-user-dialog.component.spec.ts
+++ b/libs/vre/pages/system/system/src/lib/users/create-user-dialog.component.spec.ts
@@ -103,12 +103,7 @@ describe('CreateUserDialogComponent', () => {
   it('should not create user when form is invalid', () => {
     // Initialize form with empty controls that will be invalid
     const mockUserForm = new FormBuilder().group({
-      givenName: [
-        '',
-        [
-          /* add required validator to make it invalid */
-        ],
-      ],
+      givenName: ['', [/* add required validator to make it invalid */]],
       familyName: [''],
       email: [''],
       username: [''],

--- a/libs/vre/pages/user-settings/user/src/lib/account/account.component.ts
+++ b/libs/vre/pages/user-settings/user/src/lib/account/account.component.ts
@@ -68,11 +68,10 @@ export class AccountComponent {
 
   onEditPassword(user: ReadUser) {
     this._matDialog
-      .open<
+      .open<EditPasswordDialogComponent, EditPasswordDialogProps, boolean>(
         EditPasswordDialogComponent,
-        EditPasswordDialogProps,
-        boolean
-      >(EditPasswordDialogComponent, DspDialogConfig.dialogDrawerConfig({ user }, true))
+        DspDialogConfig.dialogDrawerConfig({ user }, true)
+      )
       .afterClosed()
       .subscribe();
   }

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/segments/segment-api.service.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/segments/segment-api.service.ts
@@ -157,8 +157,7 @@ OFFSET ${page}
           const data = {
             hasSegmentBounds: resource.properties[`${endpoint}hasSegmentBounds`] as ReadIntervalValue[],
             [`has${type}OfValue`]: resource.properties[`${endpoint}has${type}OfValue`] as
-              | ReadTextValueAsString[]
-              | undefined,
+              ReadTextValueAsString[] | undefined,
             hasComment: resource.properties[`${endpoint}hasComment`] as ReadTextValueAsString[] | undefined,
             hasDescription: resource.properties[`${endpoint}hasDescription`] as ReadTextValueAsString[] | undefined,
             hasKeyword: resource.properties[`${endpoint}hasKeyword`] as ReadTextValueAsString[] | undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "postcss-import": "~16.1.0",
         "postcss-preset-env": "~11.3.0",
         "postcss-url": "~10.1.3",
-        "prettier": "^3.8.1",
+        "prettier": "^3.9.5",
         "reflect-metadata": "^0.2.2",
         "storybook": "10.4.6",
         "ts-jest": "29.4.11",
@@ -29914,9 +29914,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
-      "integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "postcss-import": "~16.1.0",
     "postcss-preset-env": "~11.3.0",
     "postcss-url": "~10.1.3",
-    "prettier": "^3.8.1",
+    "prettier": "^3.9.5",
     "reflect-metadata": "^0.2.2",
     "storybook": "10.4.6",
     "ts-jest": "29.4.11",


### PR DESCRIPTION
## What

Bumps **prettier `3.8.5` → `3.9.5`** and reformats the 6 source files affected by 3.9.x's new formatting rules.

## Why

Prettier 3.9.x changed several formatting rules. Since this repo enforces formatting through the `prettier/prettier` **ESLint rule as an error**, code formatted under 3.8.5 no longer matches 3.9.5's output — so `DSP-APP Linting` fails.

The lockfile-only Renovate bump (#3213) hit exactly this: it upgraded the dependency but couldn't reformat the source, so lint failed with 14 `prettier/prettier` errors across 6 files. **This PR supersedes #3213** (close it once this merges).

The bump and the reformat are **coupled and must be atomic**: the reformatted output is only valid under 3.9.x, so a reformat commit alone would fail lint on main (3.8.5 rejects the new format). Hence one commit.

## The formatting changes (all cosmetic, semantically identical)

| Files | 3.9.x change |
|---|---|
| `class-definition.ts`, `i-has-property.interface.ts` | Drop unnecessary quotes on enum members: `'_1' = 0` → `_1 = 0` (member names unchanged) |
| `account.component.ts`, `legal-settings.component.ts` | Keep generic type args inline, break the call args instead |
| `create-user-dialog.component.spec.ts` | Collapse a comment-only array to one line |
| `segment-api.service.ts` | Collapse a leading-pipe multiline union cast |

Generated OpenAPI files (`src/generated/**`) are untouched — they're eslint-ignored and regenerated by the build.

## Verification

- `nx run-many --all --target=lint --skip-nx-cache --exclude=vre-open-api` → green
- Unit tests for all 6 affected projects → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3213