### PR TITLE
chore(ci): use 'just init-db-test' after dsp-api Makefile removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,10 +216,12 @@ jobs:
           repository: dasch-swiss/dsp-api
           ref: main
           path: dsp-api
+      - name: Set up just
+        uses: extractions/setup-just@v2
       - name: Start API
         run: |
           cd dsp-api
-          make init-db-test
+          just init-db-test
           docker compose -f docker-compose.yml up -d sipi ingest api
           ./modules/webapi/scripts/wait-for-api.sh
       - name: Wait for app to be ready


### PR DESCRIPTION
## Problem

The `dsp-app-e2e-tests` job's **Start API** step checks out `dsp-api@main` and seeds the test triplestore with `make init-db-test`. dsp-api **removed its Makefile** (replaced by a `justfile`) during the Bazel migration ([dsp-api#4187](https://github.com/dasch-swiss/dsp-api/pull/4187)), so the step now fails:

```
make init-db-test
make: *** No rule to make target 'init-db-test'.  Stop.
##[error]Process completed with exit code 2.
```

## Fix

Add a `setup-just` step (matching dsp-api's own CI convention, which uses `extractions/setup-just@v2`) and call `just init-db-test`.

The `just` recipe is behaviourally identical to the removed Makefile target — same `stack-down-delete-volumes` → `stack-db-only` → `fuseki-init-knora-test.sh` chain — so this is purely a build-tool invocation change.

```diff
+      - name: Set up just
+        uses: extractions/setup-just@v2
       - name: Start API
         run: |
           cd dsp-api
-          make init-db-test
+          just init-db-test
           docker compose -f docker-compose.yml up -d sipi ingest api
           ./modules/webapi/scripts/wait-for-api.sh
```

## Notes

- Scoped to the one broken line — the rest of the step (`docker compose up`, `wait-for-api.sh`) already tracks dsp-api's `modules/` layout and is unaffected.
- The stack still runs against the published `daschswiss/knora-api:latest` (etc.) images pulled from Docker Hub; nothing is built locally.
- Verified this is the only reference to the removed dsp-api Makefile in dsp-app's workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)