### PR TITLE
chore(ci): extend PR preview stale-teardown from 4 to 90 days

### DIFF
--- a/.github/workflows/cloud-run-pr-preview.yml
+++ b/.github/workflows/cloud-run-pr-preview.yml
@@ -138,7 +138,7 @@ jobs:
           | **Commit** | ${COMMIT} |
           | **Backend** | DEV API (\`api.dev.dasch.swiss\`) |
 
-          _Updated on every push. Deleted when PR closes or after 4 days._
+          _Updated on every push. Deleted when PR closes or after 90 days._
           EOF
 
           echo "${METHOD} ${ENDPOINT}"
@@ -285,7 +285,7 @@ jobs:
           | **Branch** | \`${BRANCH}\` |
           | **Backend** | DEV API (\`api.dev.dasch.swiss\`) |
 
-          _Deployed manually via workflow_dispatch. Deleted when PR closes or after 4 days._
+          _Deployed manually via workflow_dispatch. Deleted when PR closes or after 90 days._
           EOF
 
           echo "${METHOD} ${ENDPOINT}"
@@ -324,7 +324,7 @@ jobs:
             --delete-tags --quiet 2>/dev/null || echo "Image not found, nothing to clean up."
 
   cleanup-stale:
-    name: Clean up stale (>4 days)
+    name: Clean up stale (>90 days)
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
@@ -339,9 +339,9 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
-      - name: Delete stale PR preview services older than 4 days
+      - name: Delete stale PR preview services older than 90 days
         run: |
-          CUTOFF=$(date -u -d '4 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          CUTOFF=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
           SERVICES=$(gcloud run services list \
             --region="${{ secrets.GCP_REGION }}" \
             --filter="metadata.name:dsp-app-pr-" \


### PR DESCRIPTION
## What

Bumps the scheduled stale-cleanup threshold for PR preview deployments from **4 days → 90 days** in `.github/workflows/cloud-run-pr-preview.yml`.

## Why

The daily `cleanup-stale` cron deletes `dsp-app-pr-*` Cloud Run services by age, keyed off `metadata.creationTimestamp` and **not** PR state. At 4 days this tore down previews for PRs that were still open and in review — the preview would vanish mid-review and only come back on the next push.

## What changed

- **Functional:** cutoff is now `date -u -d '90 days ago'` (was `'4 days ago'`).
- **Cosmetic (kept consistent):** job name, step name, and both PR-comment bodies now say "90 days" instead of "4 days".

## What did NOT change

- The on-close cleanup (`cleanup-preview`) is untouched — previews are still deleted **immediately** when their PR merges/closes.
- The daily cron schedule is unchanged.
- Age is still measured from service creation (`metadata.creationTimestamp`), not last activity.

## Notes

- Net effect: an open PR's preview now survives up to 90 days from first deploy instead of 4.
- Cost impact is low — previews use `max-instances=1` / default `min-instances=0`, so they scale to zero and cost ~nothing while idle. The main accumulating cost of a longer window is Artifact Registry image storage (one image per PR).
- Takes effect once merged to `main`, since the scheduled job runs from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)