### PR TITLE
chore(renovate): treat eslint-plugin-storybook as part of the storybook monorepo set

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -162,6 +162,12 @@
       "enabled": false
     },
     {
+      "description": "eslint-plugin-storybook: major updates disabled — its peer dependency pins storybook to the same major, and storybook's own major is ceiling-locked by @nx/storybook (peer storybook <11.0.0) and @storybook/angular (peer @angular <23.0.0). It is therefore bound by the same nx + Angular major coupling that freezes the storybook packages above, and is upgraded in lockstep during nx migrate / ng update",
+      "matchPackageNames": ["eslint-plugin-storybook"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "@jscutlery/swc-angular: fully disabled — bridges frozen Angular with SWC; package is at v0.x so the major-disable rule is a no-op, and any update is a coordinated toolchain decision",
       "matchPackageNames": ["@jscutlery/swc-angular"],
       "enabled": false
@@ -270,11 +276,6 @@
         "ngx-color-picker"
       ],
       "groupName": "angular-ecosystem-deps"
-    },
-    {
-      "description": "Storybook packages — @storybook/test-runner lives in a separate repo (storybookjs/test-runner) and is not covered by the monorepo:storybook preset in config:recommended; explicit group prevents sync drift on minor/patch updates",
-      "matchPackageNames": ["storybook", "/^@storybook//"],
-      "groupName": "storybook-deps"
     },
     {
       "description": "Automerge all dev dependency updates (patch + minor) — 3-day age guard prevents adopting a broken release before it gets yanked; dev deps don't affect production",


### PR DESCRIPTION
## Background

PR #3262 (Renovate) failed the `update` job with an `ERESOLVE`: it bumped `eslint-plugin-storybook` to `10.5.2` alone, while `storybook` stayed at `10.4.6`, violating the plugin's peer dep `storybook@^10.5.2`. The immediate breakage was fixed by #3263 (version alignment). **This PR fixes the root cause in `renovate.json` so it can't recur.**

## Why Renovate split them

Renovate is **not** peer-dependency-aware — it never co-bumps a package because another's peer needs it. The mechanism that keeps a monorepo in sync is **source-based grouping**, via the built-in `monorepo:storybook` preset (from `config:recommended`). That preset groups by repository URL and correctly covers all three Storybook packages (all resolve to `github.com/storybookjs/storybook`).

The repo's own explicit `storybook-deps` rule broke it:

```json
"matchPackageNames": ["storybook", "/^@storybook//"],  // misses eslint-plugin-storybook
"groupName": "storybook-deps"
```

By re-grouping only `storybook` + `@storybook/*`, it left `eslint-plugin-storybook` in the preset group → **two groups** → independent updates → drift → the ERESOLVE.

## Fix

1. **Delete the `storybook-deps` rule.** The URL-based preset already groups all three (it's what grouped `eslint-plugin-storybook` correctly — branch `renovate/storybook-monorepo`). This matches the file's convention: other explicit groups (`prettier-deps`, `postcss-deps`, `webpack-deps`) are supersets that *add* packages presets miss; `storybook-deps` was the lone strict *subset*.
2. **Freeze `eslint-plugin-storybook` majors** alongside the existing storybook major freeze. Without it the same drift recurs at the next major: core majors are disabled, so a Storybook 11 release would open an `eslint-plugin-storybook@11` PR alone and re-break the peer.

Considered `keep the rule, add eslint-plugin-storybook to its matcher` instead — rejected: it keeps a rule whose only remaining job duplicates the preset under a nicer name, and whose stated rationale (`@storybook/test-runner`) is already moot since test-runner is disabled elsewhere.

## Audit

Checked every other explicit group against its preset and every peer-coupled package against the major-freeze rules — `swc-deps`, `postcss-deps`, `webpack-deps`, `jest-deps`, `grafana-faro-deps`, `ngx-translate-deps` are all correct supersets/full coverage, and other coupled packages (`ng-mocks`, `jest-preset-angular`, `ts-jest`, `@ngx-translate/*`, prettier/eslint plugins, ckeditor) already have their majors frozen with their partners. Only the two Storybook items above were real.

## Verification

`renovate-config-validator` → `Config validated successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)