### PR TITLE
fix(project): truncate long project name in header (DEV-6842)

### DIFF
--- a/libs/vre/pages/project/project/src/lib/project-page-header.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-page-header.component.ts
@@ -11,7 +11,7 @@ import { ProjectPageService } from './project-page.service';
 @Component({
   selector: 'app-project-page-header',
   template: ` <mat-toolbar style="background-color: inherit; height: 56px">
-      <span style="flex: 1; display: flex; align-items: center">
+      <span style="flex: 1; display: flex; align-items: center; min-width: 0">
         <app-header-logo />
         <a class="title" [routerLink]="projectLink$ | async">{{ currentProjectName$ | async }}</a>
       </span>
@@ -34,9 +34,17 @@ import { ProjectPageService } from './project-page.service';
         text-decoration: none;
         color: inherit;
         display: inline-block;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         &:hover {
           background-color: #e8e9eb;
         }
+      }
+
+      app-header-user-actions {
+        flex-shrink: 0;
       }
     `,
   ],


### PR DESCRIPTION
## Problem

When a project has a long name and the browser window is narrow-ish, the full project name was rendered in the project-page header without truncation. This pushed the top-right user controls (account menu, language switcher, help) out of the overflow-hidden `mat-toolbar`, making them unreachable.

Fixes [DEV-6842](https://linear.app/dasch/issue/DEV-6842/long-project-name-overflows-header-hiding-top-right-controls).

## Fix

CSS-only change in `ProjectPageHeaderComponent` (no template logic / TS changes):

- `min-width: 0` on the left group and on `.title` so it can shrink below the name's intrinsic width (flex items default to `min-width: auto`, which prevented shrinking).
- `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` on `.title` for a clean ellipsis.
- `flex-shrink: 0` on `app-header-user-actions` so the top-right controls always keep their space and the name is what yields.

## Scope

- Targets the reported "small-ish window" case. True mobile widths (where logo + right controls alone exceed the viewport) would need further responsive work — out of scope here.
- Only the project-page header is affected; the global `app-header` ("DaSCH Service Platform") is a separate component and was not touched.

## Testing

Not yet verified in-browser. Reproduce with project `0846` at a narrow window width — the name should truncate with an ellipsis and the account menu should stay visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr4gYEaYquzPcfBwyfEyyG