### PR TITLE
chore(renovate): run npm install twice for lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "prConcurrentLimit: 2 — allows one automated PR and one unmerged major PR to coexist. A single slot would let a major PR waiting for manual merge block the entire automated queue. rebaseWhen: behind-base-branch on automated rules makes the automated slot effectively serial (each merge triggers a rebase + CI re-run on the next), so two slots do not cause package-lock.json race conditions.",
     "schedule: before 5am on monday through friday — Renovate opens new PRs only during the midnight-to-5am window on weekdays (Europe/Zurich). platformAutomerge merges a PR the moment CI passes, so the last batch (Fri 00:00-05:00) runs CI during Friday and merges before the weekend. lockFileMaintenance keeps its own Monday schedule.",
     "rebaseWhen: conflicted (global) — major PRs sit unmerged intentionally; rebasing them on every automated merge would waste CI runs on a PR nobody is about to merge. Automated rules override this with behind-base-branch to keep the automerge chain moving.",
-    "vulnerabilityAlerts disabled — Dependabot handles security advisories instead. Its native GitHub Security Advisory integration links CVEs to the Security tab with GHSA references and co-locates with secret scanning and code scanning, which Renovate cannot replicate. Tradeoff: Dependabot covers only direct dependencies and is slower than Renovate would be, but the GitHub-native security workflow outweighs that for this project."
+    "vulnerabilityAlerts disabled — Dependabot handles security advisories instead. Its native GitHub Security Advisory integration links CVEs to the Security tab with GHSA references and co-locates with secret scanning and code scanning, which Renovate cannot replicate. Tradeoff: Dependabot covers only direct dependencies and is slower than Renovate would be, but the GitHub-native security workflow outweighs that for this project.",
+    "lockFileMaintenance.postUpdateOptions: npmInstallTwice — lock file maintenance deletes package-lock.json and regenerates it from scratch, and npm 10 gets that single pass wrong for the @noble/hashes conflict: pkijs (via webpack-dev-server > selfsigned) pins 1.4.0 exactly while @exodus/bytes (via jsdom 28, arrived with Angular 21 / NX 23 in #3189) peer-requires ^1.8.0 || ^2.0.0. npm hoists 1.4.0 to the root and drops the nested copy, leaving the peer unsatisfied, so every npm ci in CI fails with EUSAGE. A second install pass converges to the correct tree (2.2.0 hoisted, 1.4.0 nested under pkijs). Not skipInstalls: false — a full install reproduces the same broken lock. npm 11 resolves it correctly in one pass, so this workaround can be dropped once engines.npm moves off ^10.9.0."
   ],
   "extends": ["config:recommended"],
   "semanticCommitType": "chore",
@@ -22,7 +23,8 @@
     "schedule": ["before 9am on Monday"],
     "automerge": true,
     "platformAutomerge": true,
-    "rebaseWhen": "behind-base-branch"
+    "rebaseWhen": "behind-base-branch",
+    "postUpdateOptions": ["npmInstallTwice"]
   },
   "ignorePaths": ["libs/**/package.json"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Problem

Every weekly `chore(deps): Lock file maintenance` PR fails CI at **Install dependencies** — most recently [#3278](https://github.com/dasch-swiss/dsp-app/pull/3278) ([run](https://github.com/dasch-swiss/dsp-app/actions/runs/30243153213/job/89927036501)):

```
npm error code EUSAGE
npm error Invalid: lock file's @noble/hashes@1.4.0 does not satisfy @noble/hashes@2.2.0
npm error Missing: @noble/hashes@1.4.0 from lock file
```

Two transitive dev deps disagree about `@noble/hashes`:

- `jsdom@28.1.0` → `@exodus/bytes@1.15.1`, which **peer-requires** `@noble/hashes ^1.8.0 || ^2.0.0`
- `webpack-dev-server@5.2.5` → `selfsigned@5.5.0` → `pkijs@3.4.0`, which pins `@noble/hashes` to exactly **1.4.0**

The only valid tree is `2.2.0` hoisted at the root plus `1.4.0` nested under `node_modules/pkijs/` — what `main`'s lockfile has. Renovate deletes `package-lock.json` for lock file maintenance and regenerates it from scratch, and npm 10 gets that single pass wrong: it hoists `1.4.0` to the root and drops the nested copy, leaving the peer unsatisfied. `npm ci` correctly rejects the result.

`@exodus/bytes` entered the lock on 2026-06-25 with the Angular 21 / NX 23 upgrade (#3189). The last lock file maintenance PR that merged is #3183 (2026-06-22); every one since has failed.

## Fix

`postUpdateOptions: ["npmInstallTwice"]`, scoped to the `lockFileMaintenance` block — documented for exactly this bug class ("Run `npm install` commands _twice_ to work around bugs where `npm` generates invalid lock files if run only once"). Ordinary dependency PRs update the existing lock incrementally and are unaffected, so they keep their single pass. Cost: one extra resolution pass on Mondays only (~30s).

## Verification

Reproduced with npm 10.9.0 against `main`'s `package.json` in a scratch directory:

| How the lock was produced | `@noble/hashes` shape | `npm ci --dry-run` |
|---|---|---|
| `main`'s committed lock | 2.2.0 root + 1.4.0 under `pkijs` | passes |
| `npm install --package-lock-only`, no lock present (what Renovate does) | 1.4.0 root only | **same EUSAGE as CI** |
| full `npm install`, no lock present | 1.4.0 root only | **same EUSAGE** |
| …same command a **second** time | 2.2.0 root + 1.4.0 under `pkijs` | passes |
| `npm@11 install --package-lock-only`, single pass | 2.2.0 root + 1.4.0 under `pkijs` | passes |

`renovate-config-validator` passes on the changed config.

## Ruled out

- **`skipInstalls: false`** — the other documented npm-bug knob, but a full install reproduces the same broken lock (row 3 above).
- **Relaxing CI to `npm install`** — would hide a genuinely unsatisfied peer dep and lose lock reproducibility. The red check is accurate.
- **npm 11** resolves this correctly in one pass and is the real root-cause fix, but it needs `engines.npm` (`^10.9.0`) plus the CI toolchain bumped, and `renovate.json` deliberately blocks npm majors — a separate coordinated decision. The rationale comment notes this workaround can be dropped then.

## Follow-up

After merge, #3278 must be recreated (tick it on the Dependency Dashboard) — its existing branch still carries the bad lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)