### PR TITLE
fix: show "Image Annotation" instead of "Region" in the UI (DEV-6853)

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -378,7 +378,8 @@
         "commentPlaceholder": "Kommentar"
       },
       "service": {
-        "classCreated": "Die Klasse {{classLabel}} wurde erfolgreich erstellt."
+        "classCreated": "Die Klasse {{classLabel}} wurde erfolgreich erstellt.",
+        "imageAnnotationClass": "Bildannotation"
       }
     },
     "notAllowed": {
@@ -644,7 +645,7 @@
         "yesDelete": "Ja, löschen"
       },
       "annotationToolbar": {
-        "highlightRegion": "Region hervorheben",
+        "highlightAnnotation": "Annotation hervorheben",
         "openInNewTab": "Annotation in neuem Tab öffnen",
         "shareResource": "Annotation teilen: {{arkUrl}}",
         "copyArkUrl": "ARK-URL kopieren",

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -378,7 +378,8 @@
         "commentPlaceholder": "Description"
       },
       "service": {
-        "classCreated": "Successfully created the class {{classLabel}}."
+        "classCreated": "Successfully created the class {{classLabel}}.",
+        "imageAnnotationClass": "Image Annotation"
       }
     },
     "notAllowed": {
@@ -688,7 +689,7 @@
         "yesDelete": "Yes, delete"
       },
       "annotationToolbar": {
-        "highlightRegion": "Highlight Region",
+        "highlightAnnotation": "Highlight annotation",
         "openInNewTab": "Open annotation in new tab",
         "shareResource": "Share annotation: {{arkUrl}}",
         "copyArkUrl": "Copy ARK url",

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -378,7 +378,8 @@
         "commentPlaceholder": "Commentaire"
       },
       "service": {
-        "classCreated": "La classe {{classLabel}} a été créée avec succès."
+        "classCreated": "La classe {{classLabel}} a été créée avec succès.",
+        "imageAnnotationClass": "Annotation d'image"
       }
     },
     "notAllowed": {
@@ -688,7 +689,7 @@
         "yesDelete": "Oui, supprimer"
       },
       "annotationToolbar": {
-        "highlightRegion": "Surligner la région",
+        "highlightAnnotation": "Surligner l'annotation",
         "openInNewTab": "Ouvrir l'annotation dans un nouvel onglet",
         "shareResource": "Partager l'annotation : {{arkUrl}}",
         "copyArkUrl": "Copier l'URL ARK",

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -378,7 +378,8 @@
         "commentPlaceholder": "Commento"
       },
       "service": {
-        "classCreated": "La classe {{classLabel}} è stata creata con successo."
+        "classCreated": "La classe {{classLabel}} è stata creata con successo.",
+        "imageAnnotationClass": "Annotazione immagine"
       }
     },
     "notAllowed": {
@@ -688,7 +689,7 @@
         "yesDelete": "Sì, elimina"
       },
       "annotationToolbar": {
-        "highlightRegion": "Evidenzia regione",
+        "highlightAnnotation": "Evidenzia annotazione",
         "openInNewTab": "Apri annotazione in nuova scheda",
         "shareResource": "Condividi annotazione: {{arkUrl}}",
         "copyArkUrl": "Copia URL ARK",

--- a/libs/vre/pages/ontology/ontology/src/lib/services/ontology-edit.service.ts
+++ b/libs/vre/pages/ontology/ontology/src/lib/services/ontology-edit.service.ts
@@ -560,7 +560,7 @@ export class OntologyEditService {
         if (prop.objectType === Constants.Region) {
           propertyInfo.objectLabels = [
             {
-              value: 'Region',
+              value: this._translate.instant('pages.ontology.service.imageAnnotationClass'),
             } as StringLiteralV2,
           ];
           return propertyInfo;

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/annotation-toolbar.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/annotation-toolbar.component.ts
@@ -25,7 +25,7 @@ import { ColorViewerComponent } from './template-switcher/viewer-components/colo
       </span>
       <button
         mat-icon-button
-        [matTooltip]="'resourceEditor.propertiesDisplay.annotationToolbar.highlightRegion' | translate"
+        [matTooltip]="'resourceEditor.propertiesDisplay.annotationToolbar.highlightAnnotation' | translate"
         color="primary"
         matTooltipPosition="above"
         (click)="onPinPointClicked()">


### PR DESCRIPTION
## What

dsp-app part of [DEV-6853](https://linear.app/dasch/issue/DEV-6853). DEV-4393 renamed the annotation vocabulary but missed the user-facing "Region" strings that are hardcoded in dsp-app.

## Changes

- **Annotation toolbar tooltip** — renamed i18n key `annotationToolbar.highlightRegion` → `highlightAnnotation` (en/de/fr/it), lowercase noun matching the sibling keys ("Highlight annotation" / "Annotation hervorheben" / "Surligner l'annotation" / "Evidenzia annotazione"), and updated the reference in `annotation-toolbar.component.ts`.
- **Data Model "→ Region" label** — replaced the hardcoded `value: 'Region'` in `ontology-edit.service.ts` with a translatable `pages.ontology.service.imageAnnotationClass` key (en/de/fr/it). The knora-api ontology holding the real class label is not in the project ontologies stream, so it cannot be read synchronously there — this is the issue's sanctioned fallback, made translatable.

## Out of scope (handled in dsp-api)

The resource header "REGION" and Advanced Search class pickers are driven by the `knora-base:Region` class `rdfs:label`/`rdfs:comment`. Those changes live in dsp-api (ttl, `KnoraBaseVersion` bump, test fixtures) and are done separately; they resolve once the API deploys to dev.

## Verification

- Translation key parity holds across de/fr/it vs en (0 missing, 0 extra).
- Lint clean on both changed files.
- Tests pass: `vre-resource-editor-resource-editor` (379/380, 1 skipped) and `vre-pages-ontology-ontology` (1/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)