### PR TITLE
fix(error-handler): report API errors to telemetry instead of only the non-HTTP branch

### DIFF
--- a/libs/vre/core/error-handler/src/index.ts
+++ b/libs/vre/core/error-handler/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/app-error-handler';
 export * from './lib/app-error';
+export * from './lib/error-reporting.service';
 export * from './lib/user-feedback-error';
 export * from './lib/js-lib-parsed-error';

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { ApiResponseError } from '@dasch-swiss/dsp-js';
 import { AppConfigService } from '@dasch-swiss/vre/core/config';
@@ -5,6 +6,8 @@ import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { TranslateService } from '@ngx-translate/core';
 import { AjaxError } from 'rxjs/ajax';
 import { AppErrorHandler } from './app-error-handler';
+import { ErrorReportingService } from './error-reporting.service';
+import { UserFeedbackError } from './user-feedback-error';
 
 /**
  * Builds an `ApiResponseError` wrapping an `AjaxError` with the given status and JSON response body —
@@ -32,9 +35,11 @@ describe('AppErrorHandler', () => {
   let handler: AppErrorHandler;
   let openSnackBar: jest.Mock;
   let instant: jest.Mock;
+  let report: jest.Mock;
 
   beforeEach(() => {
     openSnackBar = jest.fn();
+    report = jest.fn();
     // Echo the key back so assertions can distinguish "showed a translated fallback" from "showed the API reason".
     instant = jest.fn((key: string) => key);
 
@@ -44,6 +49,7 @@ describe('AppErrorHandler', () => {
         { provide: NotificationService, useValue: { openSnackBar } },
         { provide: TranslateService, useValue: { instant } },
         { provide: AppConfigService, useValue: { dspInstrumentationConfig: { environment: 'dev' } } },
+        { provide: ErrorReportingService, useValue: { report } },
         // NgZone is the real one from the zone test env; its run() executes synchronously, so the
         // snackbar call inside displayNotification is observable in the assertions.
       ],
@@ -91,6 +97,51 @@ describe('AppErrorHandler', () => {
 
       expect(instant).toHaveBeenCalledWith('core.errorHandler.contactSupport');
       expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.contactSupport', 'error');
+    });
+  });
+
+  /**
+   * Telemetry used to be reached from the final `else` only, so the three branches that show a
+   * snackbar reported nothing: no ApiResponseError and no HttpErrorResponse had ever arrived in
+   * Sentry, and a snackbar is gone after five seconds (DEV-6872). Every branch must report, and
+   * notifying the user must not be the condition for it.
+   */
+  describe('telemetry reporting (DEV-6872)', () => {
+    it('reports an ApiResponseError and still shows the snackbar', () => {
+      const error = jsLibError(504, {});
+
+      handler.handleError(error);
+
+      expect(report).toHaveBeenCalledWith(error);
+      expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.timeout', 'error');
+    });
+
+    it('reports an HttpErrorResponse and still shows the snackbar', () => {
+      const error = new HttpErrorResponse({ status: 500, statusText: 'Server Error', url: '/v2/resources/xyz' });
+
+      handler.handleError(error);
+
+      expect(report).toHaveBeenCalledWith(error);
+      expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.contactSupport', 'error');
+    });
+
+    it('reports a UserFeedbackError and still shows its message', () => {
+      const error = new UserFeedbackError('the project has no ontology');
+
+      handler.handleError(error);
+
+      expect(report).toHaveBeenCalledWith(error);
+      expect(openSnackBar).toHaveBeenCalledWith('the project has no ontology', 'error');
+    });
+
+    it('reports an error of no recognised kind, as it always did', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const error = new Error('cannot read properties of undefined');
+
+      handler.handleError(error);
+
+      expect(report).toHaveBeenCalledWith(error);
+      expect(openSnackBar).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.ts
@@ -1,5 +1,3 @@
-/// <reference types="window" />
-
 import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler, inject, Injectable, NgZone } from '@angular/core';
 import { ApiResponseError } from '@dasch-swiss/dsp-js';
@@ -7,6 +5,7 @@ import { AppConfigService } from '@dasch-swiss/vre/core/config';
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { TranslateService } from '@ngx-translate/core';
 import { AjaxError } from 'rxjs/ajax';
+import { ErrorReportingService } from './error-reporting.service';
 import { UserFeedbackError } from './user-feedback-error';
 
 @Injectable({
@@ -18,12 +17,18 @@ export class AppErrorHandler implements ErrorHandler {
   constructor(
     private readonly _notification: NotificationService,
     private readonly _appConfig: AppConfigService,
-    private readonly _ngZone: NgZone
+    private readonly _ngZone: NgZone,
+    private readonly _errorReporting: ErrorReportingService
   ) {}
 
   badRequestRegexMatch = /dsp\.errors\.BadRequestException:(.*)$/;
 
   handleError(error: any): void {
+    // Reported before branching, so every branch reaches telemetry rather than only the last one.
+    // The snackbar branches used to report nothing at all, which left every dsp-api failure — a
+    // triplestore timeout, a 500, a 403 — with no trace beyond five seconds on screen (DEV-6872).
+    this._errorReporting.report(error);
+
     if (error instanceof ApiResponseError && error.error instanceof AjaxError) {
       // JS-LIB
       this.handleGenericError(error.error, error.url);
@@ -32,12 +37,8 @@ export class AppErrorHandler implements ErrorHandler {
       this.handleHttpErrorResponse(error);
     } else if (error instanceof UserFeedbackError) {
       this.displayNotification(error.message);
-    } else {
-      if (this._appConfig.dspInstrumentationConfig.environment !== 'prod') {
-        console.error(error);
-      }
-      this._sendErrorToSentry(error);
-      this._sendErrorToFaro(error);
+    } else if (this._appConfig.dspInstrumentationConfig.environment !== 'prod') {
+      console.error(error);
     }
   }
 
@@ -108,38 +109,6 @@ export class AppErrorHandler implements ErrorHandler {
     const invalidRequestRegexMatch = error.match(/\((.*)\)$/);
     if (invalidRequestRegexMatch) {
       this.displayNotification(invalidRequestRegexMatch[1]);
-    }
-  }
-
-  /**
-   * Send error to Sentry (lazy loaded)
-   * Sentry is only loaded in production environments
-   */
-  private async _sendErrorToSentry(error: any): Promise<void> {
-    try {
-      // Check if Sentry is available in the global window object
-      // It will be loaded by main.ts if the environment requires it
-      if (window.Sentry && typeof window.Sentry.captureException === 'function') {
-        window.Sentry.captureException(error);
-      }
-    } catch (sentryError) {
-      console.error('Failed to send error to Sentry:', sentryError);
-    }
-  }
-
-  /**
-   * Send error to Grafana Faro (lazy loaded)
-   * Faro is only loaded when enabled in configuration
-   */
-  private _sendErrorToFaro(error: any): void {
-    try {
-      // Check if Faro is available in the global window object
-      // It will be loaded by GrafanaFaroService if enabled
-      if (window.__FARO__ && typeof window.__FARO__.api?.pushError === 'function') {
-        window.__FARO__.api.pushError(error);
-      }
-    } catch (faroError) {
-      console.error('Failed to send error to Faro:', faroError);
     }
   }
 }

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
@@ -1,0 +1,195 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { ApiResponseError } from '@dasch-swiss/dsp-js';
+import { AjaxError } from 'rxjs/ajax';
+import { ErrorReportingService } from './error-reporting.service';
+
+/** Mirrors the service's own suppression window; the spec advances the clock past it deliberately. */
+const DEDUP_WINDOW_MS = 60_000;
+
+/**
+ * Builds the JS-LIB failure shape: an `ApiResponseError` wrapping an `AjaxError`. `ApiResponseError`
+ * has a private constructor, so `fromAjaxError` is the only way in — it copies status off the xhr and
+ * method/url off the request, which is exactly what the reporting service reads.
+ */
+function apiError(status: number, method: string, url: string): ApiResponseError {
+  const xhr = { status, responseType: 'json', response: {} } as unknown as XMLHttpRequest;
+  const ajaxError = new AjaxError('Error', xhr, {
+    url,
+    method,
+    async: true,
+    headers: {},
+    timeout: 0,
+    user: undefined,
+    password: undefined,
+    crossDomain: false,
+    responseType: 'json',
+    withCredentials: false,
+  });
+  return ApiResponseError.fromAjaxError(ajaxError);
+}
+
+describe('ErrorReportingService', () => {
+  let service: ErrorReportingService;
+  let captureException: jest.Mock;
+  let pushError: jest.Mock;
+  let now: number;
+
+  beforeEach(() => {
+    captureException = jest.fn();
+    pushError = jest.fn();
+    window.Sentry = { captureException } as unknown as typeof window.Sentry;
+    window.__FARO__ = { api: { pushError } } as unknown as typeof window.__FARO__;
+
+    // Drive the dedup window off a controllable clock rather than fake timers, which would also patch
+    // the zone the Angular test env runs in.
+    now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    TestBed.configureTestingModule({ providers: [ErrorReportingService] });
+    service = TestBed.inject(ErrorReportingService);
+  });
+
+  afterEach(() => {
+    delete window.Sentry;
+    delete window.__FARO__;
+    jest.restoreAllMocks();
+  });
+
+  describe('API failures', () => {
+    it('reports an ApiResponseError as a real Error, grouped by method, status and route', () => {
+      // Neither ApiResponseError nor HttpErrorResponse extends Error; captured raw, Sentry files them
+      // all as one "Non-Error exception captured with keys: …" issue.
+      service.report(apiError(504, 'GET', 'https://api.dasch.swiss/v2/searchextended/count/PREFIX%20knora'));
+
+      expect(captureException).toHaveBeenCalledTimes(1);
+      const [reported, context] = captureException.mock.calls[0];
+      expect(reported).toBeInstanceOf(Error);
+      expect(reported.message).toBe('dsp-api 504 GET /v2/searchextended/count');
+      expect(context.fingerprint).toEqual(['dsp-api', 'GET', '504', '/v2/searchextended/count']);
+      expect(context.tags).toMatchObject({
+        'dsp.status': '504',
+        'dsp.method': 'GET',
+        'dsp.route': '/v2/searchextended/count',
+      });
+    });
+
+    it('reports an HttpErrorResponse, which carries no request method', () => {
+      service.report(new HttpErrorResponse({ status: 500, statusText: 'Server Error', url: '/v2/resources/xyz' }));
+
+      const [reported, context] = captureException.mock.calls[0];
+      expect(reported.message).toBe('dsp-api 500 UNKNOWN /v2/resources');
+      expect(context.fingerprint).toEqual(['dsp-api', 'UNKNOWN', '500', '/v2/resources']);
+    });
+
+    it('keeps the full URL off the tags and on the event, so the tag index stays low-cardinality', () => {
+      const url = 'https://api.dasch.swiss/v2/searchextended/count/PREFIX%20knora-api%3A%3Chttp%3A%2F%2Fexample';
+      service.report(apiError(500, 'GET', url));
+
+      const [, context] = captureException.mock.calls[0];
+      expect(context.extra).toEqual({ 'dsp.url': url });
+      expect(Object.values(context.tags)).not.toContain(url);
+    });
+
+    it('collapses the identifier-bearing tail of a route so one endpoint is one issue', () => {
+      // Two different resource IRIs on the same endpoint must not become two Sentry issues.
+      service.report(apiError(403, 'GET', '/v2/resources/http%3A%2F%2Frdfh.ch%2F0801%2FaaaaaaaaaaaaaaaaaaaaaA'));
+      const first = captureException.mock.calls[0][1].fingerprint;
+
+      now += DEDUP_WINDOW_MS;
+      service.report(apiError(403, 'GET', '/v2/resources/http%3A%2F%2Frdfh.ch%2F0801%2FbbbbbbbbbbbbbbbbbbbbbB'));
+      const second = captureException.mock.calls[1][1].fingerprint;
+
+      expect(first).toEqual(['dsp-api', 'GET', '403', '/v2/resources']);
+      expect(second).toEqual(first);
+    });
+
+    it('attaches caller context as tags so a silently swallowed failure names its call site', () => {
+      service.report(apiError(504, 'GET', '/v2/search/count/gaga'), {
+        component: 'SearchResultComponent',
+        operation: 'fulltextCountQuery',
+      });
+
+      expect(captureException.mock.calls[0][1].tags).toMatchObject({
+        component: 'SearchResultComponent',
+        operation: 'fulltextCountQuery',
+      });
+    });
+  });
+
+  describe('deduplication', () => {
+    it('reports the same failure once within the dedup window', () => {
+      const report = () => service.report(apiError(504, 'GET', '/v2/search/count/gaga'));
+
+      report();
+      now += DEDUP_WINDOW_MS - 1;
+      report();
+
+      // A user hammering retry during a triplestore timeout must not send one event per click.
+      expect(captureException).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports it again once the window has elapsed', () => {
+      service.report(apiError(504, 'GET', '/v2/search/count/gaga'));
+      now += DEDUP_WINDOW_MS;
+      service.report(apiError(504, 'GET', '/v2/search/count/gaga'));
+
+      expect(captureException).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not suppress a different status on the same route', () => {
+      service.report(apiError(504, 'GET', '/v2/search/count/gaga'));
+      service.report(apiError(500, 'GET', '/v2/search/count/gaga'));
+
+      expect(captureException).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('non-API errors', () => {
+    it('passes a JS error through untouched, so Sentry groups it by its own stack as before', () => {
+      const error = new Error('boom');
+
+      service.report(error);
+
+      const [reported, context] = captureException.mock.calls[0];
+      expect(reported).toBe(error);
+      expect(context.fingerprint).toBeUndefined();
+    });
+
+    it('does not deduplicate JS errors', () => {
+      service.report(new Error('boom'));
+      service.report(new Error('boom'));
+
+      expect(captureException).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('transports', () => {
+    it('pushes to Faro alongside Sentry', () => {
+      service.report(apiError(500, 'POST', '/v2/values/xyz'));
+
+      expect(pushError).toHaveBeenCalledTimes(1);
+      const [reported, context] = pushError.mock.calls[0];
+      expect(reported).toBeInstanceOf(Error);
+      expect(context.context).toMatchObject({ 'dsp.status': '500' });
+    });
+
+    it('is a no-op when neither SDK is loaded, which is the normal case locally', () => {
+      delete window.Sentry;
+      delete window.__FARO__;
+
+      expect(() => service.report(apiError(500, 'GET', '/v2/search/count/gaga'))).not.toThrow();
+    });
+
+    it('does not let a failing Sentry transport stop the Faro one', () => {
+      captureException.mockImplementation(() => {
+        throw new Error('Sentry is down');
+      });
+      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      service.report(apiError(500, 'GET', '/v2/search/count/gaga'));
+
+      expect(pushError).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
@@ -58,18 +58,26 @@ describe('ErrorReportingService', () => {
 
   describe('API failures', () => {
     it('reports an ApiResponseError as a real Error, grouped by method, status and route', () => {
-      // Neither ApiResponseError nor HttpErrorResponse extends Error; captured raw, Sentry files them
-      // all as one "Non-Error exception captured with keys: …" issue.
-      service.report(apiError(504, 'GET', 'https://api.dasch.swiss/v2/searchextended/count/PREFIX%20knora'));
+      // The Gravsearch count query dsp-app fires per page: a POST whose query string carries the
+      // project IRI. Neither ApiResponseError nor HttpErrorResponse extends Error, so captured raw
+      // Sentry files them all as one "Non-Error exception captured with keys: …" issue.
+      service.report(
+        apiError(
+          504,
+          'POST',
+          'https://api.dasch.swiss/v2/searchextended/count?limitToProject=http%3A%2F%2Frdfh.ch%2Fprojects%2F0001'
+        )
+      );
 
       expect(captureException).toHaveBeenCalledTimes(1);
       const [reported, context] = captureException.mock.calls[0];
       expect(reported).toBeInstanceOf(Error);
-      expect(reported.message).toBe('dsp-api 504 GET /v2/searchextended/count');
-      expect(context.fingerprint).toEqual(['dsp-api', 'GET', '504', '/v2/searchextended/count']);
+      // The project IRI is dropped with the rest of the query string, so one endpoint stays one issue.
+      expect(reported.message).toBe('dsp-api 504 POST /v2/searchextended/count');
+      expect(context.fingerprint).toEqual(['dsp-api', 'POST', '504', '/v2/searchextended/count']);
       expect(context.tags).toMatchObject({
         'dsp.status': '504',
-        'dsp.method': 'GET',
+        'dsp.method': 'POST',
         'dsp.route': '/v2/searchextended/count',
       });
     });
@@ -83,7 +91,8 @@ describe('ErrorReportingService', () => {
     });
 
     it('keeps the full URL off the tags and on the event, so the tag index stays low-cardinality', () => {
-      const url = 'https://api.dasch.swiss/v2/searchextended/count/PREFIX%20knora-api%3A%3Chttp%3A%2F%2Fexample';
+      // The fulltext count query does put its search term in the path.
+      const url = 'https://api.dasch.swiss/v2/search/count/Wandel%20der%20Zeit?limitToProject=http%3A%2F%2Frdfh.ch';
       service.report(apiError(500, 'GET', url));
 
       const [, context] = captureException.mock.calls[0];

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
@@ -265,6 +265,31 @@ describe('ErrorReportingService', () => {
       expect(context.context).toMatchObject({ 'dsp.status': '500' });
     });
 
+    it('gives Faro every field Sentry gets, extra included', () => {
+      service.report(apiError(400, 'POST', '/v2/values/xyz', { message: 'the label is required' }), {
+        component: 'PropertyValueCreatorComponent',
+      });
+
+      // Faro's context has neither a cardinality penalty nor a length cap, so the tag/extra split that
+      // Sentry's 200-character tag values force has no counterpart here. Passing tags only would leave
+      // Faro without the URL or the server's reason — less than Sentry, which is backwards.
+      expect(pushError.mock.calls[0][1].context).toEqual({
+        'dsp.status': '400',
+        'dsp.method': 'POST',
+        'dsp.route': '/v2/values',
+        'dsp.url': '/v2/values/xyz',
+        'dsp.response': 'the label is required',
+        'dsp.severity': 'warning',
+        component: 'PropertyValueCreatorComponent',
+      });
+    });
+
+    it('does not invent a severity for a JS error, which has no graded status', () => {
+      service.report(new Error('boom'));
+
+      expect(pushError.mock.calls[0][1].context).toEqual({});
+    });
+
     it('is a no-op when neither SDK is loaded, which is the normal case locally', () => {
       delete window.Sentry;
       delete window.__FARO__;

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
@@ -160,6 +160,22 @@ describe('ErrorReportingService', () => {
       expect(captureException.mock.calls[0][1].fingerprint).toEqual(['dsp-api', 'POST', '400', '/v2/values']);
     });
 
+    it('grades a server fault as an error and a rejected request as a warning', () => {
+      service.report(apiError(504, 'POST', '/v2/searchextended/count'));
+      service.report(apiError(403, 'GET', '/v2/resources/xyz'));
+
+      // Same level for both would leave an invalid date firing the same alerts as a triplestore timeout.
+      expect(captureException.mock.calls[0][1].level).toBe('error');
+      expect(captureException.mock.calls[1][1].level).toBe('warning');
+    });
+
+    it('grades a request that never completed as a warning, matching how the app reads it', () => {
+      // AppErrorHandler maps status 0 to the "no internet" message, i.e. the user's own connectivity.
+      service.report(apiError(0, 'GET', '/v2/resources/xyz'));
+
+      expect(captureException.mock.calls[0][1].level).toBe('warning');
+    });
+
     it('attaches caller context as tags so a silently swallowed failure names its call site', () => {
       service.report(apiError(504, 'GET', '/v2/search/count/gaga'), {
         component: 'SearchResultComponent',
@@ -227,6 +243,8 @@ describe('ErrorReportingService', () => {
       const [reported, context] = captureException.mock.calls[0];
       expect(reported).toBe(error);
       expect(context.fingerprint).toBeUndefined();
+      // No level either, so Sentry applies its own default of `error` — a JS error is always a fault.
+      expect(context.level).toBeUndefined();
     });
 
     it('does not deduplicate JS errors', () => {

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
@@ -12,8 +12,8 @@ const DEDUP_WINDOW_MS = 60_000;
  * has a private constructor, so `fromAjaxError` is the only way in — it copies status off the xhr and
  * method/url off the request, which is exactly what the reporting service reads.
  */
-function apiError(status: number, method: string, url: string): ApiResponseError {
-  const xhr = { status, responseType: 'json', response: {} } as unknown as XMLHttpRequest;
+function apiError(status: number, method: string, url: string, response: unknown = {}): ApiResponseError {
+  const xhr = { status, responseType: 'json', response } as unknown as XMLHttpRequest;
   const ajaxError = new AjaxError('Error', xhr, {
     url,
     method,
@@ -113,6 +113,53 @@ describe('ErrorReportingService', () => {
       expect(second).toEqual(first);
     });
 
+    it("keeps dsp-api's reason on the event, since the status alone is not actionable", () => {
+      // The JSON-LD shape. Without this the issue reads "dsp-api 400 POST /v2/values" and nothing
+      // tells you which constraint the API rejected.
+      service.report(
+        apiError(400, 'POST', '/v2/values', {
+          'knora-api:error': 'dsp.errors.BadRequestException: value type is not supported',
+        })
+      );
+
+      expect(captureException.mock.calls[0][1].extra['dsp.response']).toBe(
+        'dsp.errors.BadRequestException: value type is not supported'
+      );
+    });
+
+    it("keeps an HttpErrorResponse's body reason", () => {
+      service.report(
+        new HttpErrorResponse({
+          status: 400,
+          statusText: 'Bad Request',
+          url: '/admin/projects',
+          error: { message: 'shortcode is already taken' },
+        })
+      );
+
+      expect(captureException.mock.calls[0][1].extra['dsp.response']).toBe('shortcode is already taken');
+    });
+
+    it('omits the reason entirely when the body carries none', () => {
+      // Angular's own composed message is not used as a fallback — it restates the status and URL,
+      // both already on the event. So a present dsp.response means the server really said something.
+      service.report(new HttpErrorResponse({ status: 504, statusText: 'Gateway Timeout', url: '/v2/search/count/x' }));
+
+      expect(captureException.mock.calls[0][1].extra).toEqual({ 'dsp.url': '/v2/search/count/x' });
+    });
+
+    it('truncates a long reason', () => {
+      service.report(apiError(500, 'POST', '/v2/values', { message: 'x'.repeat(5000) }));
+
+      expect(captureException.mock.calls[0][1].extra['dsp.response']).toHaveLength(2000);
+    });
+
+    it('keeps the reason out of the fingerprint, so one endpoint stays one issue', () => {
+      service.report(apiError(400, 'POST', '/v2/values', { message: 'the label is required' }));
+
+      expect(captureException.mock.calls[0][1].fingerprint).toEqual(['dsp-api', 'POST', '400', '/v2/values']);
+    });
+
     it('attaches caller context as tags so a silently swallowed failure names its call site', () => {
       service.report(apiError(504, 'GET', '/v2/search/count/gaga'), {
         component: 'SearchResultComponent',
@@ -151,6 +198,23 @@ describe('ErrorReportingService', () => {
       service.report(apiError(500, 'GET', '/v2/search/count/gaga'));
 
       expect(captureException).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not suppress a different reason behind the same fingerprint', () => {
+      // Two distinct rejections of the same endpoint are two distinct failures. Keying dedup on the
+      // fingerprint alone would report the first and silently discard the second reason.
+      service.report(apiError(400, 'POST', '/v2/values', { message: 'the label is required' }));
+      service.report(apiError(400, 'POST', '/v2/values', { message: 'value type is not supported' }));
+
+      expect(captureException).toHaveBeenCalledTimes(2);
+    });
+
+    it('still suppresses a repeat of the same reason', () => {
+      const body = { message: 'the label is required' };
+      service.report(apiError(400, 'POST', '/v2/values', body));
+      service.report(apiError(400, 'POST', '/v2/values', body));
+
+      expect(captureException).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
@@ -21,6 +21,12 @@ const UNKNOWN_ROUTE = 'unknown';
 /** Cap on the server's reason. Generous enough for any dsp-api message, far inside the event limits. */
 const MAX_REASON_LENGTH = 2000;
 
+/**
+ * The Sentry severity levels this service assigns. Declared locally rather than imported from
+ * `@sentry/angular`: the SDK is lazy loaded and reached only through `window`.
+ */
+type ReportLevel = 'error' | 'warning';
+
 /** The request-shaped fields shared by the types a dsp-api failure can arrive as. */
 interface ApiFailure {
   status: number;
@@ -47,6 +53,8 @@ interface ReportPayload {
    * and every URL is unique, so as a tag it would only inflate the tag index.
    */
   extra?: Record<string, string>;
+  /** Left unset for JS errors, which Sentry captures at `error` level by default. */
+  level?: ReportLevel;
 }
 
 /**
@@ -114,6 +122,11 @@ export class ErrorReportingService {
         ...context,
       },
       extra: { 'dsp.url': failure.url, ...(reason ? { 'dsp.response': reason } : {}) },
+      // A 5xx is a fault; a 4xx is the API rejecting what we sent, and a 0 is almost always the user's
+      // own connectivity — the app says as much, mapping it to the "no internet" message. Grading them
+      // alike would make an invalid date indistinguishable from a triplestore timeout in alerting, and
+      // that is how reporting ends up switched off again.
+      level: failure.status >= 500 ? 'error' : 'warning',
     };
   }
 
@@ -231,6 +244,7 @@ export class ErrorReportingService {
           tags: payload.tags,
           extra: payload.extra,
           fingerprint: payload.fingerprint,
+          level: payload.level,
         });
       }
     } catch (sentryError) {

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
@@ -18,6 +18,9 @@ const UNKNOWN_METHOD = 'UNKNOWN';
 
 const UNKNOWN_ROUTE = 'unknown';
 
+/** Cap on the server's reason. Generous enough for any dsp-api message, far inside the event limits. */
+const MAX_REASON_LENGTH = 2000;
+
 /** The request-shaped fields shared by the types a dsp-api failure can arrive as. */
 interface ApiFailure {
   status: number;
@@ -35,10 +38,13 @@ interface ReportPayload {
   faroError: Error | string;
   /** Set for API failures only — see `_buildPayload`. */
   fingerprint?: string[];
+  /** Deliberately outside the fingerprint, but part of the dedup key — see `_isSuppressed`. */
+  reason?: string;
   tags: Record<string, string>;
   /**
-   * Unindexed event detail. The request URL goes here rather than into a tag: a Gravsearch query runs
-   * to thousands of characters, well past Sentry's 200-character tag limit, and every one is unique.
+   * Unindexed event detail. The request URL and the server's reason go here rather than into tags: a
+   * Gravsearch query runs to thousands of characters, well past Sentry's 200-character tag-value cap,
+   * and every URL is unique, so as a tag it would only inflate the tag index.
    */
   extra?: Record<string, string>;
 }
@@ -65,7 +71,7 @@ export class ErrorReportingService {
   report(error: unknown, context?: Record<string, string>): void {
     const payload = this._buildPayload(error, context);
 
-    if (payload.fingerprint && this._isSuppressed(payload.fingerprint)) {
+    if (payload.fingerprint && this._isSuppressed(payload.fingerprint, payload.reason)) {
       return;
     }
 
@@ -86,6 +92,7 @@ export class ErrorReportingService {
 
     const route = ErrorReportingService._routeOf(failure.url);
     const status = `${failure.status}`;
+    const reason = ErrorReportingService._reasonOf(error)?.slice(0, MAX_REASON_LENGTH);
     // Neither ApiResponseError nor HttpErrorResponse extends Error, so Sentry would file every one of
     // them as "Non-Error exception captured with keys: …" and Faro would reject them outright.
     // Re-express the failure as a real Error whose message is the part worth grouping on.
@@ -99,14 +106,54 @@ export class ErrorReportingService {
       // Gravsearch queries in the URL — left alone that is one issue per request. Group on the coarse
       // route instead; the full URL stays on the event.
       fingerprint: ['dsp-api', failure.method, status, route],
+      reason,
       tags: {
         'dsp.status': status,
         'dsp.method': failure.method,
         'dsp.route': route,
         ...context,
       },
-      extra: { 'dsp.url': failure.url },
+      extra: { 'dsp.url': failure.url, ...(reason ? { 'dsp.response': reason } : {}) },
     };
+  }
+
+  /**
+   * The server's own account of the failure. `AppErrorHandler` reads the same fields to build the
+   * snackbar and then drops them, so without this a Sentry issue records that a 400 happened but not
+   * which constraint dsp-api rejected — the only actionable part of it.
+   *
+   * Angular's own `HttpErrorResponse.message` is not used as a fallback: it is composed from the status
+   * and URL, both already on the event. A present `dsp.response` therefore means the server really did
+   * say something.
+   */
+  private static _reasonOf(error: unknown): string | undefined {
+    if (error instanceof ApiResponseError) {
+      return typeof error.error === 'string'
+        ? error.error || undefined
+        : ErrorReportingService._reasonFromBody(error.error.response);
+    }
+
+    if (error instanceof HttpErrorResponse) {
+      return ErrorReportingService._reasonFromBody(error.error);
+    }
+
+    return undefined;
+  }
+
+  /** dsp-api answers with the JSON-LD `knora-api:error`, a `{ message }`, an `{ error }`, or a bare string. */
+  private static _reasonFromBody(body: unknown): string | undefined {
+    if (typeof body === 'string') {
+      return body || undefined;
+    }
+
+    if (!body || typeof body !== 'object') {
+      return undefined;
+    }
+
+    const shape = body as { 'knora-api:error'?: unknown; message?: unknown; error?: unknown };
+    return [shape['knora-api:error'], shape.message, shape.error].find(
+      (candidate): candidate is string => typeof candidate === 'string' && candidate.length > 0
+    );
   }
 
   private static _asApiFailure(error: unknown): ApiFailure | null {
@@ -155,8 +202,13 @@ export class ErrorReportingService {
     return segments.includes('count') && !head.includes('count') ? `${route}/count` : route;
   }
 
-  private _isSuppressed(fingerprint: string[]): boolean {
-    const key = fingerprint.join('|');
+  /**
+   * Keyed on the reason as well as the fingerprint. Two different rejections on one route are two
+   * different failures and both deserve reporting, while a retry loop against the same one still
+   * collapses. Grouping is unaffected — the reason stays out of the fingerprint.
+   */
+  private _isSuppressed(fingerprint: string[], reason?: string): boolean {
+    const key = [...fingerprint, reason ?? ''].join('|');
     const now = Date.now();
     const previous = this._reportedAt.get(key);
 

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
@@ -51,6 +51,8 @@ interface ReportPayload {
    * Unindexed event detail. The request URL and the server's reason go here rather than into tags: a
    * Gravsearch query runs to thousands of characters, well past Sentry's 200-character tag-value cap,
    * and every URL is unique, so as a tag it would only inflate the tag index.
+   *
+   * The split is Sentry's constraint alone — Faro receives tags and extra alike.
    */
   extra?: Record<string, string>;
   /** Left unset for JS errors, which Sentry captures at `error` level by default. */
@@ -252,11 +254,25 @@ export class ErrorReportingService {
     }
   }
 
-  /** Faro is lazy loaded by GrafanaFaroService, and currently disabled in every environment. */
+  /**
+   * Faro is lazy loaded by GrafanaFaroService, and currently disabled in every environment.
+   *
+   * It gets the full context, `extra` included: Faro's context is a flat map with neither a
+   * cardinality penalty nor a length cap, so the split Sentry's tag limits force has no counterpart
+   * here, and withholding `extra` would leave Faro with strictly less than Sentry. The severity is
+   * passed as a field of its own because `pushError` has no level — every Faro error is error-level —
+   * and deriving "was this a server fault" from a numeric status is awkward to express in a query.
+   */
   private _sendToFaro(payload: ReportPayload): void {
     try {
       if (window.__FARO__ && typeof window.__FARO__.api?.pushError === 'function') {
-        window.__FARO__.api.pushError(payload.faroError, { context: payload.tags });
+        window.__FARO__.api.pushError(payload.faroError, {
+          context: {
+            ...payload.tags,
+            ...payload.extra,
+            ...(payload.level ? { 'dsp.severity': payload.level } : {}),
+          },
+        });
       }
     } catch (faroError) {
       console.error('Failed to send error to Faro:', faroError);

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
@@ -1,0 +1,199 @@
+/// <reference types="window" />
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ApiResponseError } from '@dasch-swiss/dsp-js';
+
+/**
+ * How long the same fingerprint stays suppressed after being reported, per browser tab.
+ *
+ * A triplestore timeout (DEV-6864) fails for every user at once, and a user who keeps hitting retry
+ * multiplies that again. Collapsing repeats of an *identical* failure inside a short window keeps one
+ * incident from burning the Sentry quota; every distinct failure still gets through.
+ */
+const DEDUP_WINDOW_MS = 60_000;
+
+/** `HttpErrorResponse` carries no request method, and dsp-js leaves it empty when the xhr had none. */
+const UNKNOWN_METHOD = 'UNKNOWN';
+
+const UNKNOWN_ROUTE = 'unknown';
+
+/** The request-shaped fields shared by the types a dsp-api failure can arrive as. */
+interface ApiFailure {
+  status: number;
+  method: string;
+  url: string;
+}
+
+interface ReportPayload {
+  /**
+   * What Sentry captures. An `Error` wherever one exists, otherwise the raw value, so Sentry keeps
+   * applying its own serialization to whatever was thrown.
+   */
+  sentryError: unknown;
+  /** Faro's `pushError` accepts only `Error | string`. */
+  faroError: Error | string;
+  /** Set for API failures only — see `_buildPayload`. */
+  fingerprint?: string[];
+  tags: Record<string, string>;
+  /**
+   * Unindexed event detail. The request URL goes here rather than into a tag: a Gravsearch query runs
+   * to thousands of characters, well past Sentry's 200-character tag limit, and every one is unique.
+   */
+  extra?: Record<string, string>;
+}
+
+/**
+ * Reports errors to telemetry (Sentry, Faro) **without** notifying the user.
+ *
+ * This is the half of error handling that `AppErrorHandler` used to fuse with the snackbar: anything
+ * that got a snackbar got no telemetry, and vice versa, so no `ApiResponseError` or
+ * `HttpErrorResponse` had ever reached Sentry (DEV-6872). Degraded paths that deliberately stay
+ * silent towards the user — a failed count query next to a rendered result list — call this directly.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorReportingService {
+  private readonly _reportedAt = new Map<string, number>();
+
+  /**
+   * @param error the caught value, in any shape.
+   * @param context low-cardinality key/value pairs attached as Sentry tags — a component and
+   * operation name, so a silent failure can be traced back to the call site that swallowed it.
+   */
+  report(error: unknown, context?: Record<string, string>): void {
+    const payload = this._buildPayload(error, context);
+
+    if (payload.fingerprint && this._isSuppressed(payload.fingerprint)) {
+      return;
+    }
+
+    this._sendToSentry(payload);
+    this._sendToFaro(payload);
+  }
+
+  private _buildPayload(error: unknown, context?: Record<string, string>): ReportPayload {
+    const failure = ErrorReportingService._asApiFailure(error);
+
+    if (!failure) {
+      return {
+        sentryError: error,
+        faroError: error instanceof Error ? error : String(error),
+        tags: { ...context },
+      };
+    }
+
+    const route = ErrorReportingService._routeOf(failure.url);
+    const status = `${failure.status}`;
+    // Neither ApiResponseError nor HttpErrorResponse extends Error, so Sentry would file every one of
+    // them as "Non-Error exception captured with keys: …" and Faro would reject them outright.
+    // Re-express the failure as a real Error whose message is the part worth grouping on.
+    const reported = new Error(`dsp-api ${status} ${failure.method} ${route}`);
+    reported.name = 'DspApiError';
+
+    return {
+      sentryError: reported,
+      faroError: reported,
+      // Without a stack trace Sentry groups by message, and dsp-api puts resource IRIs and whole
+      // Gravsearch queries in the URL — left alone that is one issue per request. Group on the coarse
+      // route instead; the full URL stays on the event.
+      fingerprint: ['dsp-api', failure.method, status, route],
+      tags: {
+        'dsp.status': status,
+        'dsp.method': failure.method,
+        'dsp.route': route,
+        ...context,
+      },
+      extra: { 'dsp.url': failure.url },
+    };
+  }
+
+  private static _asApiFailure(error: unknown): ApiFailure | null {
+    if (error instanceof ApiResponseError) {
+      // ApiResponseError copies status/method/url off the AjaxError it wraps, so its own fields are
+      // enough here; the wrapped error only adds the response body.
+      return {
+        status: error.status,
+        method: error.method || UNKNOWN_METHOD,
+        url: error.url,
+      };
+    }
+
+    if (error instanceof HttpErrorResponse) {
+      return {
+        status: error.status,
+        method: UNKNOWN_METHOD,
+        url: error.url ?? '',
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Collapses a request URL to a coarse route, so that "same endpoint, same status" is one Sentry
+   * issue. Everything past the second path segment is dropped because that is where dsp-api puts
+   * search terms, IRIs and Gravsearch queries. A `/count` segment survives: a failing count query is
+   * a distinct — and far more expensive — operation than the paged query beside it (DEV-6809).
+   */
+  private static _routeOf(url: string): string {
+    if (!url) {
+      return UNKNOWN_ROUTE;
+    }
+
+    const path = url.split('?')[0].replace(/^[a-z][a-z\d+.-]*:\/\/[^/]+/i, '');
+    const segments = path.split('/').filter(Boolean);
+
+    if (segments.length === 0) {
+      return '/';
+    }
+
+    const head = segments.slice(0, 2);
+    const route = `/${head.join('/')}`;
+
+    return segments.includes('count') && !head.includes('count') ? `${route}/count` : route;
+  }
+
+  private _isSuppressed(fingerprint: string[]): boolean {
+    const key = fingerprint.join('|');
+    const now = Date.now();
+    const previous = this._reportedAt.get(key);
+
+    if (previous !== undefined && now - previous < DEDUP_WINDOW_MS) {
+      return true;
+    }
+
+    this._reportedAt.set(key, now);
+    return false;
+  }
+
+  /**
+   * Sentry is lazy loaded by main.ts and only in the environments that are not excluded there, so its
+   * absence is the normal case locally and on the dev servers.
+   */
+  private _sendToSentry(payload: ReportPayload): void {
+    try {
+      if (window.Sentry && typeof window.Sentry.captureException === 'function') {
+        window.Sentry.captureException(payload.sentryError, {
+          tags: payload.tags,
+          extra: payload.extra,
+          fingerprint: payload.fingerprint,
+        });
+      }
+    } catch (sentryError) {
+      console.error('Failed to send error to Sentry:', sentryError);
+    }
+  }
+
+  /** Faro is lazy loaded by GrafanaFaroService, and currently disabled in every environment. */
+  private _sendToFaro(payload: ReportPayload): void {
+    try {
+      if (window.__FARO__ && typeof window.__FARO__.api?.pushError === 'function') {
+        window.__FARO__.api.pushError(payload.faroError, { context: payload.tags });
+      }
+    } catch (faroError) {
+      console.error('Failed to send error to Faro:', faroError);
+    }
+  }
+}

--- a/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ReadProject, ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken, RouteConstants } from '@dasch-swiss/vre/core/config';
+import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
 import { MultipleViewerService } from '@dasch-swiss/vre/pages/data-browser';
 import { DataBrowserPageService, ProjectPageService } from '@dasch-swiss/vre/pages/project/project';
 import { OntologyService, ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
@@ -19,6 +20,7 @@ describe('ResourcesListFetcherComponent', () => {
   let routeParamsSubject: BehaviorSubject<any>;
   let currentProjectSubject: BehaviorSubject<ReadProject>;
   let handleError: jest.Mock;
+  let report: jest.Mock;
 
   const mockResource1 = { id: 'resource-1', label: 'Resource 1' } as ReadResource;
   const mockResource2 = { id: 'resource-2', label: 'Resource 2' } as ReadResource;
@@ -35,6 +37,7 @@ describe('ResourcesListFetcherComponent', () => {
     { provide: MultipleViewerService, useValue: mockMultipleViewerService },
     { provide: DataBrowserPageService, useValue: { onNavigationReload$: of(undefined) } },
     { provide: ErrorHandler, useValue: { handleError } },
+    { provide: ErrorReportingService, useValue: { report } },
   ];
 
   beforeEach(async () => {
@@ -64,6 +67,7 @@ describe('ResourcesListFetcherComponent', () => {
     };
 
     handleError = jest.fn();
+    report = jest.fn();
 
     await TestBed.configureTestingModule({
       imports: [ResourcesListFetcherComponent],
@@ -153,6 +157,24 @@ describe('ResourcesListFetcherComponent', () => {
       // The component provides its own ResourceResultService, so read that instance rather than the
       // module-level mock, which this component never sees.
       expect(fixture.debugElement.injector.get(ResourceResultService).numberOfResults).toBeNull();
+      sub.unsubscribe();
+    });
+
+    it('reports a failed count query to telemetry without notifying the user (DEV-6872)', () => {
+      const error = new Error('count query timed out');
+      mockDspApiConnection.v2.search.doExtendedSearch.mockReturnValue(of({ resources: [mockResource1] }));
+      mockDspApiConnection.v2.search.doExtendedSearchCountQuery.mockReturnValue(throwError(() => error));
+
+      component.ngOnChanges();
+      const { sub } = collectData();
+
+      // The failure used to be swallowed outright, leaving no signal of a count-query timeout anywhere.
+      expect(report).toHaveBeenCalledWith(error, {
+        component: 'ResourcesListFetcherComponent',
+        operation: 'gravsearchCountQuery',
+      });
+      // Still deliberately silent towards the user: the resource list rendered fine.
+      expect(handleError).not.toHaveBeenCalled();
       sub.unsubscribe();
     });
 

--- a/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.ts
+++ b/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.ts
@@ -3,6 +3,7 @@ import { Component, ErrorHandler, Inject, Input, OnChanges, signal } from '@angu
 import { ActivatedRoute, Router } from '@angular/router';
 import { KnoraApiConnection, ReadProject, ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken, RouteConstants } from '@dasch-swiss/vre/core/config';
+import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
 import { MultipleViewerService, ResourcesListComponent } from '@dasch-swiss/vre/pages/data-browser';
 import { OntologyService, ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
@@ -89,11 +90,16 @@ export class ResourcesListFetcherComponent implements OnChanges {
       )
       .pipe(
         map(response => response.numberOfResults),
-        // Swallowed without a snackbar on purpose: the resources rendered fine and an error toast over
-        // a working list is noise. Nothing is reported anywhere either, because no production channel
-        // exists — AppErrorHandler sends only non-HTTP errors to Sentry/Faro, so no ApiResponseError
-        // has ever reached telemetry (DEV-6872).
-        catchError(() => of(null))
+        // Reported, not surfaced: the resources rendered fine and an error toast over a working list is
+        // noise, but the cost of this query is exactly what DEV-6809 and DEV-6864 are about, so it must
+        // not stay invisible.
+        catchError((error: unknown) => {
+          this._errorReporting.report(error, {
+            component: 'ResourcesListFetcherComponent',
+            operation: 'gravsearchCountQuery',
+          });
+          return of(null);
+        })
       );
 
   constructor(
@@ -103,6 +109,7 @@ export class ResourcesListFetcherComponent implements OnChanges {
     private readonly _ontologyService: OntologyService,
     private readonly _resourceResult: ResourceResultService,
     private readonly _errorHandler: ErrorHandler,
+    private readonly _errorReporting: ErrorReportingService,
     protected route: ActivatedRoute,
     protected router: Router,
     public projectPageService: ProjectPageService

--- a/libs/vre/pages/search/advanced-search/src/lib/advanced-search-results.component.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/advanced-search-results.component.ts
@@ -12,6 +12,7 @@ import {
 import { Title } from '@angular/platform-browser';
 import { KnoraApiConnection } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
+import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
 import { ResourceBrowserComponent } from '@dasch-swiss/vre/pages/data-browser';
 import { ProjectPageService } from '@dasch-swiss/vre/pages/project/project';
 import { filterNull } from '@dasch-swiss/vre/shared/app-common';
@@ -68,6 +69,7 @@ export class AdvancedSearchResultsComponent implements OnChanges {
   private readonly _logger = inject(SearchFlowLogger);
   private readonly _projectPageService = inject(ProjectPageService);
   private readonly _errorHandler = inject(ErrorHandler);
+  private readonly _errorReporting = inject(ErrorReportingService);
 
   private readonly querySubject = new BehaviorSubject<string | null>(null);
 
@@ -154,11 +156,15 @@ export class AdvancedSearchResultsComponent implements OnChanges {
       .doExtendedSearchCountQuery(`${this._getQuery(query_)}OFFSET 0`, this._projectPageService.currentProject.id)
       .pipe(
         catchError((err: unknown) => {
-          // Dev-console only — SearchFlowLogger is isDevMode()-gated. There is no production channel
-          // for this: AppErrorHandler sends only non-HTTP errors to Sentry/Faro, so no ApiResponseError
-          // has ever reached telemetry (DEV-6872). Deliberately not a snackbar: the results rendered
-          // fine, and an error toast over a working result list is noise.
+          // Deliberately not a snackbar: the results rendered fine, and an error toast over a working
+          // result list is noise. It is reported nonetheless — the cost of this query is exactly what
+          // DEV-6809 and DEV-6864 are about. The logger stays for the dev console, being
+          // isDevMode()-gated and therefore absent in production.
           this._logger.searchError(err);
+          this._errorReporting.report(err, {
+            component: 'AdvancedSearchResultsComponent',
+            operation: 'gravsearchCountQuery',
+          });
           return of(null);
         })
       );

--- a/libs/vre/pages/search/advanced-search/src/lib/spec/advanced-search-results.component.spec.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/spec/advanced-search-results.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
 import { ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
+import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
 import { ProjectPageService } from '@dasch-swiss/vre/pages/project/project';
 import { ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { TranslateModule } from '@ngx-translate/core';
@@ -18,11 +19,13 @@ describe('AdvancedSearchResultsComponent', () => {
   let doExtendedSearch: jest.Mock;
   let doExtendedSearchCountQuery: jest.Mock;
   let handleError: jest.Mock;
+  let report: jest.Mock;
 
   beforeEach(() => {
     doExtendedSearch = jest.fn().mockReturnValue(of({ resources: [] }));
     doExtendedSearchCountQuery = jest.fn().mockReturnValue(of({ numberOfResults: 0 }));
     handleError = jest.fn();
+    report = jest.fn();
 
     TestBed.configureTestingModule({
       imports: [AdvancedSearchResultsComponent, TranslateModule.forRoot()],
@@ -38,6 +41,7 @@ describe('AdvancedSearchResultsComponent', () => {
         },
         { provide: Title, useValue: { setTitle: jest.fn() } },
         { provide: ErrorHandler, useValue: { handleError } },
+        { provide: ErrorReportingService, useValue: { report } },
       ],
     });
     TestBed.overrideComponent(AdvancedSearchResultsComponent, { set: { template: '', imports: [] } });
@@ -124,6 +128,25 @@ describe('AdvancedSearchResultsComponent', () => {
       // Null, not the page length: substituting a wrong total would have the UI assert it as fact.
       // Read the component's own instance — it declares providers: [ResourceResultService].
       expect(fixture.debugElement.injector.get(ResourceResultService).numberOfResults).toBeNull();
+      sub.unsubscribe();
+    });
+
+    it('reports a failed count query to telemetry without notifying the user (DEV-6872)', () => {
+      const error = new Error('count query timed out');
+      doExtendedSearch.mockReturnValue(of({ resources: [resource] }));
+      doExtendedSearchCountQuery.mockReturnValue(throwError(() => error));
+      const component = renderComponent();
+
+      const sub = component.resources$.subscribe();
+
+      // Previously this only reached the isDevMode()-gated SearchFlowLogger, so in production the
+      // failure left no trace at all.
+      expect(report).toHaveBeenCalledWith(error, {
+        component: 'AdvancedSearchResultsComponent',
+        operation: 'gravsearchCountQuery',
+      });
+      // Still deliberately silent towards the user: the result list rendered fine.
+      expect(handleError).not.toHaveBeenCalled();
       sub.unsubscribe();
     });
 

--- a/libs/vre/pages/search/search/src/lib/search-result.component.spec.ts
+++ b/libs/vre/pages/search/search/src/lib/search-result.component.spec.ts
@@ -2,6 +2,7 @@ import { ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
+import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
 import { ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { TranslateModule } from '@ngx-translate/core';
 import { of, throwError } from 'rxjs';
@@ -18,6 +19,7 @@ describe('SearchResultComponent — search failure handling (DEV-6866)', () => {
   let doFulltextSearch: jest.Mock;
   let doFulltextSearchCountQuery: jest.Mock;
   let handleError: jest.Mock;
+  let report: jest.Mock;
 
   const renderComponent = (query = 'der') => {
     const fixture = TestBed.createComponent(SearchResultComponent);
@@ -31,6 +33,7 @@ describe('SearchResultComponent — search failure handling (DEV-6866)', () => {
     doFulltextSearch = jest.fn().mockReturnValue(of({ resources: [resource] }));
     doFulltextSearchCountQuery = jest.fn().mockReturnValue(of({ numberOfResults: 1 }));
     handleError = jest.fn();
+    report = jest.fn();
 
     TestBed.configureTestingModule({
       imports: [SearchResultComponent, TranslateModule.forRoot()],
@@ -40,6 +43,7 @@ describe('SearchResultComponent — search failure handling (DEV-6866)', () => {
           useValue: { v2: { search: { doFulltextSearch, doFulltextSearchCountQuery } } },
         },
         { provide: ErrorHandler, useValue: { handleError } },
+        { provide: ErrorReportingService, useValue: { report } },
       ],
     });
     TestBed.overrideComponent(SearchResultComponent, { set: { template: '', imports: [] } });
@@ -82,6 +86,24 @@ describe('SearchResultComponent — search failure handling (DEV-6866)', () => {
     expect(component.loading()).toBe(false);
     // Null, not the page length: substituting a wrong total would have the UI assert it as fact.
     expect(resourceResult.numberOfResults).toBeNull();
+    sub.unsubscribe();
+  });
+
+  it('reports a failed count query to telemetry without notifying the user (DEV-6872)', () => {
+    const error = new Error('count query timed out');
+    doFulltextSearchCountQuery.mockReturnValue(throwError(() => error));
+    const { component } = renderComponent();
+
+    const sub = component.resources$.subscribe();
+
+    // The failure used to be swallowed outright, which is what left the DEV-6809 count-query cost and
+    // the DEV-6864 timeouts with no production signal at all.
+    expect(report).toHaveBeenCalledWith(error, {
+      component: 'SearchResultComponent',
+      operation: 'fulltextCountQuery',
+    });
+    // Still deliberately silent towards the user: the result list rendered fine.
+    expect(handleError).not.toHaveBeenCalled();
     sub.unsubscribe();
   });
 

--- a/libs/vre/pages/search/search/src/lib/search-result.component.ts
+++ b/libs/vre/pages/search/search/src/lib/search-result.component.ts
@@ -2,6 +2,7 @@ import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ErrorHandler, Inject, Input, OnChanges, signal } from '@angular/core';
 import { IFulltextSearchParams, KnoraApiConnection, ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
+import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
 import { ResourceBrowserComponent } from '@dasch-swiss/vre/pages/data-browser';
 import { ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
@@ -70,7 +71,8 @@ export class SearchResultComponent implements OnChanges {
     @Inject(DspApiConnectionToken)
     private readonly _dspApiConnection: KnoraApiConnection,
     private readonly _resourceResultService: ResourceResultService,
-    private readonly _errorHandler: ErrorHandler
+    private readonly _errorHandler: ErrorHandler,
+    private readonly _errorReporting: ErrorReportingService
   ) {}
 
   ngOnChanges() {
@@ -138,12 +140,14 @@ export class SearchResultComponent implements OnChanges {
    */
   private _numberOfAllResults$ = (query: string) =>
     this._dspApiConnection.v2.search.doFulltextSearchCountQuery(query, 0, this.searchInProjectParam).pipe(
-      catchError(() => {
-        // Swallowed without a snackbar on purpose: the results rendered fine and an error toast over a
-        // working result list is noise. Nothing is reported anywhere either, because no production
-        // channel exists — AppErrorHandler sends only non-HTTP errors to Sentry/Faro, so no
-        // ApiResponseError has ever reached telemetry (DEV-6872). Advanced search additionally has a
-        // dev-only SearchFlowLogger; this lib has none.
+      catchError((error: unknown) => {
+        // Reported, not surfaced: the results rendered fine and an error toast over a working result
+        // list is noise, but the cost of this query is exactly what DEV-6809 and DEV-6864 are about,
+        // so it must not stay invisible.
+        this._errorReporting.report(error, {
+          component: 'SearchResultComponent',
+          operation: 'fulltextCountQuery',
+        });
         return of(null);
       })
     );

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -8,7 +8,7 @@
  * Sentry is lazy-loaded in production environments
  */
 interface SentrySDK {
-  captureException(error: any): void;
+  captureException(error: any, captureContext?: any): void;
   captureMessage(message: string): void;
   init(options: any): void;
   browserTracingIntegration(): any;


### PR DESCRIPTION
[DEV-6872](https://linear.app/dasch/issue/DEV-6872)

## Summary

- `AppErrorHandler.handleError` reported from its final `else` only — and to **neither** channel from the other three, since `_sendErrorToSentry` and `_sendErrorToFaro` were both confined to that branch. Every dsp-api failure (a triplestore timeout, a 500, a 403) was invisible in production once the snackbar auto-dismissed after five seconds.
- Reporting is split out into `ErrorReportingService`, which reports to telemetry **without** notifying the user, so a degraded path can record a failure it deliberately does not surface.
- The three count queries that absorb their own failure to keep a working result list on screen now report. That is the production signal DEV-6809 (count-query cost) and DEV-6864 (HTTP 500s) had none of.

Both transports are fed on every branch, so this is the prerequisite for **either** channel carrying API errors — turning Faro on without it would still deliver nothing, because in three of four branches there was no reporting call to deliver from.

## Why a plain `captureException` would not have worked

Neither `ApiResponseError` (it extends `ApiResponse`, a plain object) nor Angular's `HttpErrorResponse` extends `Error`. Captured raw, Sentry files all of them as one *"Non-Error exception captured with keys: error, method, status, url"* issue, and Faro's `pushError` rejects them outright. The service re-expresses them as a real `Error`.

Since there is no stack trace, Sentry groups by message — and dsp-api puts search terms, resource IRIs and the project IRI in the URL, so left alone that is one issue per request. Grouping is therefore pinned to `['dsp-api', method, status, route]`, where `route` keeps the first two path segments plus a `/count` marker.

## What lands on an event

| Field | Sentry | Faro |
|---|---|---|
| `status`, `method`, `route` | tags | context |
| full request URL | `extra` | context |
| server's reason (`knora-api:error` / `message` / `error`, truncated at 2000 chars) | `extra` | context |
| severity | `level` | `dsp.severity` field |
| grouping key | `fingerprint` | n/a — Faro groups by message and stack |

The tag/`extra` split is Sentry's constraint alone: it caps tag values at 200 characters and indexes them, so a unique Gravsearch URL belongs in `extra`. Faro's context has neither limit, so it receives everything — withholding `extra` there would leave Faro with strictly less than Sentry. The severity is a plain field for Faro because `pushError` has no level of its own.

The server's reason matters because the status alone is not actionable: it says a request was rejected, not *which constraint* rejected it. `AppErrorHandler` already reads those fields to build the snackbar and then drops them. `HttpErrorResponse.message` is deliberately **not** used as a fallback — it is composed from the status and URL, both already on the event — so a present reason means the server really did say something.

## Volume and severity

Three independent controls, because grouping, deduplication and alerting want different granularity:

- **Grouping** is coarse: `['dsp-api', method, status, route]`. The reason is *not* in the fingerprint, so one endpoint stays one Sentry issue.
- **Deduplication** is finer: the same fingerprint *and* the same reason is suppressed for 60s per tab. A user hammering retry through a triplestore timeout sends one event, not one per click — but two *different* rejections of one endpoint are two different failures and both get through, because keying on the fingerprint alone would silently discard the second reason. The trade is deliberate: a burst of distinct 4xx on one route is no longer collapsed to a single event.
- **Severity** carries the rest: a 5xx is captured at `error`, everything else at `warning`. Status 0 counts as a warning — the app already maps it to the "no internet" message, reading it as the user's own connectivity rather than a fault of ours.

JS errors are unchanged throughout: passed to Sentry as-is, no fingerprint, no level (so Sentry's default `error` applies), no severity field, and never deduplicated.

**Decision worth noting:** 400s are reported, including the ones that are really rejected user input. The alternative was filtering to 5xx/network only, which would also have dropped the frontend/API contract bugs that show up as 400s. The severity split is what keeps that affordable — an invalid date does not fire the same alerts as a triplestore timeout.

**Widening worth noting:** response bodies can echo submitted values, so slightly more user data reaches telemetry. It is incremental rather than a new class — full URLs already go, carrying search terms and resource IRIs.

## Follow-up: enabling Faro

The issue asked whether Faro should be switched on or removed as dead configuration. **Decided: it stays, as the intended source of truth.** Enabling it is out of scope here because it is not a config flip — `instrumentation.faro.collectorUrl` is `http://localhost:12345/collect` in **all five** environments including `prod`, and `tracingCorsUrls` is empty everywhere except `dev-server`. It needs real collector endpoints provisioned per environment plus a ~300KB lazy-loaded bundle turned on in production. This PR makes sure that, once enabled, Faro actually receives API errors.

The 60s dedup window is also tuned to Sentry's per-event cost. If Faro becomes primary, suppressing less (or suppressing per transport) is worth revisiting — a knob, not a defect.

## Changes

**`libs/vre/core/error-handler`**
- New `ErrorReportingService` with `report(error, context?)` — normalization, fingerprinting, reason extraction, per-reason dedup, severity grading, both transports at parity.
- `AppErrorHandler` reports before branching and delegates its two private `_sendErrorTo*` methods. Snackbar messages and the non-prod `console.error` are unchanged.

**Call sites** — `SearchResultComponent`, `AdvancedSearchResultsComponent`, `ResourcesListFetcherComponent` report their swallowed count-query failure with component/operation context. The comments claiming no production channel exists are corrected.

**`types/window.d.ts`** — `captureException` accepts the `captureContext` argument.

## Test Plan

- `nx run vre-core-error-handler:test` — 34 pass. Covers a report call on each of the four `handleError` branches (the fix-confirmation tests: all three snackbar branches reported nothing before), plus normalization against the real dsp-api URL shapes, reason extraction from both error shapes and its absence when the body carries none, truncation, the reason being excluded from the fingerprint but included in the dedup key, the dedup window and its expiry, severity grading per status class, Faro receiving every field Sentry gets, context tags, the absent-SDK no-op, and one failing transport not stopping the other.
- `nx run-many --target=test --projects=vre-pages-search-search,vre-pages-search-advanced-search,vre-pages-project-project` — pass, each with a new test asserting the count failure is reported *and* still shows no snackbar.
- `nx run-many --target=lint` on all four projects — clean.
- `nx run dsp-app:build` — succeeds, covering the global `window.d.ts` change.

Sentry contract verified against the installed `@sentry/core` v10 rather than from memory: `{ tags, extra, fingerprint, level }` is discriminated as a `CaptureContext` (all four keys are in `captureContextKeys`), and `applyFingerprintToEvent` concatenates onto an otherwise-empty `event.fingerprint`, so the array is the whole grouping key. Nothing else in dsp-app calls `setFingerprint`.

## Screenshots

No UI change — all three call sites are deliberately invisible to the user.