### PR TITLE
fix(i18n): pick data-side labels via a fixed fallback chain (DEV-6875)

### DIFF
--- a/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.spec.ts
+++ b/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.spec.ts
@@ -9,15 +9,15 @@ describe('pickPreferredLanguageString', () => {
     expect(pickPreferredLanguageString(labels, 'en')).toBe('Documentation');
   });
 
-  it('returns the first non-empty value when preferred language is missing', () => {
+  it('falls back through the fixed chain (en first) when preferred language is missing', () => {
     const labels = [
       { language: 'de', value: 'Dokumentation' },
       { language: 'en', value: 'Documentation' },
     ];
-    expect(pickPreferredLanguageString(labels, 'fr')).toBe('Dokumentation');
+    expect(pickPreferredLanguageString(labels, 'fr')).toBe('Documentation');
   });
 
-  it('returns the first non-empty value when preferred value is empty', () => {
+  it('falls back through the chain when preferred value is empty', () => {
     const labels = [
       { language: 'en', value: '' },
       { language: 'de', value: 'Dokumentation' },
@@ -25,7 +25,7 @@ describe('pickPreferredLanguageString', () => {
     expect(pickPreferredLanguageString(labels, 'en')).toBe('Dokumentation');
   });
 
-  it('returns the first non-empty value when preferred value is whitespace-only', () => {
+  it('falls back through the chain when preferred value is whitespace-only', () => {
     const labels = [
       { language: 'en', value: '   ' },
       { language: 'de', value: 'Dokumentation' },
@@ -37,5 +37,71 @@ describe('pickPreferredLanguageString', () => {
     expect(pickPreferredLanguageString(null, 'en')).toBe('');
     expect(pickPreferredLanguageString(undefined, 'en')).toBe('');
     expect(pickPreferredLanguageString([], 'en')).toBe('');
+  });
+
+  describe('deterministic fallback chain (en > de > fr > it > rm)', () => {
+    it('falls back to en before any other language when preferred is missing', () => {
+      const labels = [
+        { language: 'it', value: 'Italiano' },
+        { language: 'fr', value: 'Français' },
+        { language: 'en', value: 'English' },
+        { language: 'de', value: 'Deutsch' },
+      ];
+      expect(pickPreferredLanguageString(labels, 'rm')).toBe('English');
+    });
+
+    it('falls back to de when preferred is missing and en is absent', () => {
+      const labels = [
+        { language: 'it', value: 'Italiano' },
+        { language: 'fr', value: 'Français' },
+        { language: 'de', value: 'Deutsch' },
+      ];
+      expect(pickPreferredLanguageString(labels, 'rm')).toBe('Deutsch');
+    });
+
+    it('falls back to fr when preferred is missing and en/de are absent', () => {
+      const labels = [
+        { language: 'it', value: 'Italiano' },
+        { language: 'fr', value: 'Français' },
+      ];
+      expect(pickPreferredLanguageString(labels, 'rm')).toBe('Français');
+    });
+
+    it('falls back to it when only it and rm are present', () => {
+      const labels = [
+        { language: 'rm', value: 'Rumantsch' },
+        { language: 'it', value: 'Italiano' },
+      ];
+      expect(pickPreferredLanguageString(labels, 'en')).toBe('Italiano');
+    });
+
+    it('falls back to rm when it is the only available language', () => {
+      const labels = [{ language: 'rm', value: 'Rumantsch' }];
+      expect(pickPreferredLanguageString(labels, 'en')).toBe('Rumantsch');
+    });
+
+    it('resolves the same string regardless of input array order', () => {
+      const orderA = [
+        { language: 'it', value: 'Italiano' },
+        { language: 'fr', value: 'Français' },
+        { language: 'en', value: 'English' },
+        { language: 'de', value: 'Deutsch' },
+      ];
+      const orderB = [
+        { language: 'de', value: 'Deutsch' },
+        { language: 'en', value: 'English' },
+        { language: 'fr', value: 'Français' },
+        { language: 'it', value: 'Italiano' },
+      ];
+      expect(pickPreferredLanguageString(orderA, 'rm')).toBe(pickPreferredLanguageString(orderB, 'rm'));
+    });
+
+    it('skips whitespace-only chain entries and continues down the fallback order', () => {
+      const labels = [
+        { language: 'en', value: '   ' },
+        { language: 'de', value: 'Deutsch' },
+      ];
+      expect(pickPreferredLanguageString(labels, 'rm')).toBe('Deutsch');
+    });
   });
 });

--- a/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.spec.ts
+++ b/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.spec.ts
@@ -103,5 +103,20 @@ describe('pickPreferredLanguageString', () => {
       ];
       expect(pickPreferredLanguageString(labels, 'rm')).toBe('Deutsch');
     });
+
+    it('falls back to untagged labels (language: "") when the chain misses', () => {
+      // `search-by-label` results, ListNodeV2, and other endpoints that expose a
+      // single label with no language tag rely on this safety net.
+      const labels = [{ language: '', value: 'Book' }];
+      expect(pickPreferredLanguageString(labels, 'en')).toBe('Book');
+    });
+
+    it('prefers a chain-language label over an untagged one', () => {
+      const labels = [
+        { language: '', value: 'Untagged' },
+        { language: 'de', value: 'Deutsch' },
+      ];
+      expect(pickPreferredLanguageString(labels, 'rm')).toBe('Deutsch');
+    });
   });
 });

--- a/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.ts
+++ b/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.ts
@@ -3,9 +3,23 @@ import { LanguageStringDto } from '@dasch-swiss/vre/3rd-party-services/open-api'
 import { AvailableLanguage } from '@dasch-swiss/vre/core/config';
 
 /**
+ * Deterministic fallback order for data-side labels when the preferred
+ * language is absent. Independent of the current UI language so the same
+ * label resolves to the same string across endpoints and users.
+ * See DEV-6875.
+ */
+const DATA_LANGUAGE_FALLBACK_ORDER: readonly AvailableLanguage[] = ['en', 'de', 'fr', 'it', 'rm'];
+
+/**
  * Pick the displayable label for the preferred language with fallback.
- * Returns the label in `language` if non-empty; otherwise the first
- * non-empty label in any language; otherwise an empty string.
+ * Returns the label in `language` if non-empty; otherwise walks the fixed
+ * fallback chain (`en > de > fr > it > rm`) and returns the first non-empty
+ * label found; otherwise an empty string.
+ *
+ * The fixed chain guarantees the same label wins across API endpoints
+ * regardless of the order they return language variants in. The chain
+ * covers every language the dsp-api model exposes — no other tags reach
+ * this function.
  *
  * Shared between `StringifyStringLiteralPipe` (display) and any
  * call site that needs the same string for sort-key consistency.
@@ -15,8 +29,9 @@ export function pickPreferredLanguageString(
   language: AvailableLanguage
 ): string {
   if (!value || value.length === 0) return '';
-  const byLanguage = value.find(l => l.language === language)?.value;
-  if (byLanguage && byLanguage.trim() !== '') return byLanguage;
-  const firstNonEmpty = value.find(l => l.value && l.value.trim() !== '')?.value;
-  return firstNonEmpty ?? '';
+  for (const lang of [language, ...DATA_LANGUAGE_FALLBACK_ORDER]) {
+    const v = value.find(l => l.language === lang)?.value;
+    if (v && v.trim() !== '') return v;
+  }
+  return '';
 }

--- a/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.ts
+++ b/libs/vre/shared/app-helper-services/src/lib/pick-preferred-language-string.ts
@@ -14,12 +14,13 @@ const DATA_LANGUAGE_FALLBACK_ORDER: readonly AvailableLanguage[] = ['en', 'de', 
  * Pick the displayable label for the preferred language with fallback.
  * Returns the label in `language` if non-empty; otherwise walks the fixed
  * fallback chain (`en > de > fr > it > rm`) and returns the first non-empty
- * label found; otherwise an empty string.
+ * label found; otherwise the first non-empty label in any language
+ * (safety net for untagged labels the app constructs for endpoints that
+ * return no language tag — e.g. `search-by-label`, `ListNodeV2`);
+ * otherwise an empty string.
  *
  * The fixed chain guarantees the same label wins across API endpoints
- * regardless of the order they return language variants in. The chain
- * covers every language the dsp-api model exposes — no other tags reach
- * this function.
+ * regardless of the order they return language variants in.
  *
  * Shared between `StringifyStringLiteralPipe` (display) and any
  * call site that needs the same string for sort-key consistency.
@@ -33,5 +34,5 @@ export function pickPreferredLanguageString(
     const v = value.find(l => l.language === lang)?.value;
     if (v && v.trim() !== '') return v;
   }
-  return '';
+  return value.find(l => l.value && l.value.trim() !== '')?.value ?? '';
 }

--- a/libs/vre/ui/string-literal/src/lib/stringify-string-literal.pipe.spec.ts
+++ b/libs/vre/ui/string-literal/src/lib/stringify-string-literal.pipe.spec.ts
@@ -19,14 +19,14 @@ describe('StringifyStringLiteralPipe', () => {
     expect(pipe.transform(labels)).toBe('Documentation');
   });
 
-  it('falls back to the first non-empty value when the current language is missing', () => {
+  it('falls back through the fixed chain (en > de > fr > it > rm) when the current language is missing', () => {
     localization.currentLanguage = 'fr';
     const labels = [
       { language: 'de', value: 'Dokumentation' },
       { language: 'en', value: 'Documentation' },
     ];
-    // No hardcoded English preference — first non-empty wins.
-    expect(pipe.transform(labels)).toBe('Dokumentation');
+    // Deterministic fallback order — en wins regardless of input array order. See DEV-6875.
+    expect(pipe.transform(labels)).toBe('Documentation');
   });
 
   it('falls back to the only available label regardless of language', () => {
@@ -37,7 +37,7 @@ describe('StringifyStringLiteralPipe', () => {
 
   it('never consults the browser language (regression for DEV-6319 / DEV-6535)', () => {
     // Even when current lang is missing AND English is missing, browser language
-    // must not be used — only the first non-empty value.
+    // must not be used — only the fixed data-language fallback chain (it before rm).
     localization.currentLanguage = 'fr';
     const labels = [
       { language: 'it', value: 'Tomba' },


### PR DESCRIPTION
## Summary

- `pickPreferredLanguageString` now walks a deterministic `en > de > fr > it > rm` fallback chain when the preferred UI language is missing (or its value is empty/whitespace-only), instead of returning "first non-empty in whatever order the API returned".
- The chain is independent of the current UI language, so the same data resolves to the same label across API endpoints and across users. Displayed labels and sort keys (`SortingHelper.sortByLocalizedString`, `StringifyStringLiteralPipe`) stay in sync automatically.
- Extended specs to cover the fallback order, order-independence across input arrays, and whitespace-only skipping mid-chain.

## Why

Reported in DEV-6875: with `rm` selected as UI language a single project surfaced labels in three different languages depending on the component:
- `ResourceClassSidenavComponent` → Italian (v3 endpoint returned `it, fr, en, de`)
- `DataClassPanelComponent` → German (v2 endpoint returned `de, en, fr, it`)
- `ResourceHeaderComponent` → German

Root cause was the picker's `value.find(l => l.value && ...)` — literally "first in array". Fixing it in one central function repairs every consumer of the pipe *and* the sorter.

## Behavior change to be aware of

- Any list sorted via `sortByLocalizedString` may reorder for users whose current language isn't present in the data — that's the intended win (stable ordering across users), but reviewers/QA should expect visible diffs in the ontology sidenav, list-page, resource-class chips, property pickers, etc.
- Anywhere the code still reads `labels[0]` / `comments[0]` directly bypasses this picker and will keep showing whatever the API returned first — worth a follow-up sweep but out of scope for this PR.

## Test plan

- [ ] `nx run app-helper-services:test` — 37/37 pass locally
- [ ] `nx run vre-library-app-string-literal:test` — 14/14 pass locally
- [ ] Manual: switch UI to `rm` on stage, open a project — confirm the resource class labels in sidenav, panel, and header all show the same string (English) for the same resource class.
- [ ] Manual: confirm ontology list sorting under `rm` UI matches what a `de` user sees for data with no `rm` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)