### PR TITLE
fix(advanced-search): anchor ?mainRes for class-less non-fulltext searches (DEV-6894)

### DIFF
--- a/libs/vre/pages/search/advanced-search/src/lib/service/gravsearch.service.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/service/gravsearch.service.ts
@@ -56,13 +56,17 @@ export class GravsearchService {
       '?mainRes knora-api:isMainResource true .\n' +
       `${constructStatements}\n` +
       '} WHERE {\n' +
-      // NB: no generic `?mainRes a knora-api:Resource .` anchor. Measured against the dev DB it is the
-      // dominant cost — it defeats matchFulltext's index anchoring and forces a full project-wide
-      // resource scan (60-80s for some terms). `?mainRes` is always typed by something else: the class
-      // restriction, matchFulltext (its first arg is resource-typed), or a property statement (its
-      // subject's domain). The one shape with none of those (no class, no fulltext, no filter) is not
-      // generated (gravsearchQuery$ returns null). Verified: parity with /v2/search and 14-20x faster.
-      `${this._restrictToResourceClassStatement(resourceClassIri)}\n` +
+      // `?mainRes` must be typed by *something* in the WHERE clause — dsp-api's Gravsearch type
+      // inspection (SearchResponderV2 → GravsearchTypeInspectionRunner over the WHERE clause) fails a
+      // query outright ("Types could not be determined for one or more entities: ?mainRes") when it
+      // cannot infer a type for it. A selected class (`?mainRes a <class>`) or a matchFulltext term (its
+      // first arg is resource-typed) both type it — and in the fulltext case the generic anchor is a
+      // measured perf pessimization (it defeats matchFulltext's index anchoring), so we omit it there.
+      // But `rdfs:label` does NOT type `?mainRes`, so a class-less label-only search (e.g. "Resource
+      // label is like X" with no class and no fulltext) has nothing to anchor it → 400 (DEV-6889).
+      // Restore the generic `?mainRes a knora-api:Resource .` anchor for exactly that gap: no class AND
+      // no fulltext. (No per-class UNION — the removed optimization stays removed.)
+      `${this._restrictToResourceClassStatement(resourceClassIri, trimmedTerm)}\n` +
       '?mainRes rdfs:label ?label .\n' +
       `${fulltextTriple}` +
       `${whereClause}\n` +
@@ -72,11 +76,19 @@ export class GravsearchService {
     );
   }
 
-  private _restrictToResourceClassStatement(resourceClassIri: string): string {
-    // A selected class → a plain type restriction (also the type anchor for `?mainRes`). No class →
-    // no restriction at all: matchFulltext or a property statement types `?mainRes`, and project scope
-    // (limitToProject, passed by the results component) constrains the result set. No per-class UNION.
-    return resourceClassIri ? `?mainRes a <${resourceClassIri}> .` : '';
+  private _restrictToResourceClassStatement(resourceClassIri: string, fulltextTerm: string): string {
+    // Selected class → a plain type restriction (also the type anchor for `?mainRes`).
+    if (resourceClassIri) {
+      return `?mainRes a <${resourceClassIri}> .`;
+    }
+    // No class, but a fulltext term → matchFulltext types `?mainRes`; adding the generic anchor here
+    // would only pessimize the backend (see WHERE-clause note), so emit nothing.
+    if (fulltextTerm) {
+      return '';
+    }
+    // No class and no fulltext → nothing else types `?mainRes`; emit the generic anchor so the query is
+    // valid (project scope via limitToProject still constrains the result set).
+    return '?mainRes a knora-api:Resource .';
   }
 
   private _getOrderByString(statements: StatementElement[], orderBy: OrderByItem[]): string {

--- a/libs/vre/pages/search/advanced-search/src/lib/service/spec/gravsearch.service.spec.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/service/spec/gravsearch.service.spec.ts
@@ -251,6 +251,7 @@ CONSTRUCT {
 ?mainRes knora-api:isMainResource true .
 
 } WHERE {
+?mainRes a knora-api:Resource .
 ?mainRes rdfs:label ?label .
 ?mainRes <http://www.w3.org/2000/01/rdf-schema#label> ?res0 .
 
@@ -443,6 +444,7 @@ CONSTRUCT {
 ?mainRes <http://api.stage.dasch.swiss/ontology/0806/webern-onto/v2#hasPlacePublisher> ?res0 .
 
 } WHERE {
+?mainRes a knora-api:Resource .
 ?mainRes rdfs:label ?label .
 ?mainRes <http://api.stage.dasch.swiss/ontology/0806/webern-onto/v2#hasPlacePublisher> ?res0 .
 ?res0 <http://api.knora.org/ontology/knora-api/v2#valueAsString> ?res0val .
@@ -964,6 +966,80 @@ OFFSET 0`;
 
     // Only check the operator-specific FILTER clause
     expect(query).toContain('FILTER (?res0val <= "1"^^<http://www.w3.org/2001/XMLSchema#integer> )');
+  });
+});
+
+describe('GravsearchService — main-resource type anchor (DEV-6889)', () => {
+  // `?mainRes` must be typed by *something* in the WHERE clause, or dsp-api's Gravsearch type
+  // inspection rejects the query with HTTP 400 ("Types could not be determined for … ?mainRes").
+  // A selected class or a matchFulltext term type it; `rdfs:label` and (in general) property
+  // statements do not guarantee it. So the generator must emit the generic `?mainRes a
+  // knora-api:Resource .` anchor exactly when there is no class AND no fulltext term.
+  let gravsearchService: GravsearchService;
+  let ontologyDataService: OntologyDataService;
+
+  const ontologyIri = 'http://api.stage.dasch.swiss/ontology/0806/webern-onto/v2';
+  const labelPredicate = 'http://www.w3.org/2000/01/rdf-schema#label';
+
+  function labelStatement(operator: Operator, value = 'foo'): StatementElement[] {
+    const stm = new StatementElement();
+    (stm as any).id = 'label-stmt';
+    (stm as any).statementLevel = 0;
+    (stm as any)._selectedPredicate = new Predicate(
+      labelPredicate,
+      englishLabels('Resource Label'),
+      'http://api.knora.org/ontology/knora-api/v2#ResourceLabel',
+      false
+    );
+    (stm as any)._selectedOperator = operator;
+    (stm as any)._selectedObjectNode = new StringValue('label-stmt', value);
+    return [stm];
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        GravsearchService,
+        OntologyDataService,
+        { provide: DspApiConnectionToken, useValue: {} },
+        { provide: LocalizationService, useValue: mockLocalizationService },
+        { provide: TranslateLoader, useValue: mockTranslateLoader },
+      ],
+    });
+    gravsearchService = TestBed.inject(GravsearchService);
+    ontologyDataService = TestBed.inject(OntologyDataService);
+    jest
+      .spyOn(ontologyDataService, 'selectedOntology', 'get')
+      .mockReturnValue({ iri: ontologyIri, label: 'webern-onto' });
+    jest.spyOn(ontologyDataService, 'classIris', 'get').mockReturnValue([`${ontologyIri}#Person`]);
+  });
+
+  it('emits the generic type anchor for a class-less, fulltext-less label "is like" search (the DEV-6889 400 case)', () => {
+    const query = gravsearchService.generateGravSearchQuery(labelStatement(Operator.IsLike));
+    expect(query).toContain('?mainRes a knora-api:Resource .');
+  });
+
+  it('emits the generic type anchor for a class-less label "equals" search', () => {
+    const query = gravsearchService.generateGravSearchQuery(labelStatement(Operator.Equals));
+    expect(query).toContain('?mainRes a knora-api:Resource .');
+  });
+
+  it('emits the generic type anchor for an empty class-less, fulltext-less search', () => {
+    const query = gravsearchService.generateGravSearchQuery([]);
+    expect(query).toContain('?mainRes a knora-api:Resource .');
+  });
+
+  it('uses the class restriction as the anchor and omits the generic one when a class is selected', () => {
+    const classIri = `${ontologyIri}#Person`;
+    const query = gravsearchService.generateGravSearchQuery(labelStatement(Operator.IsLike), undefined, classIri);
+    expect(query).toContain(`?mainRes a <${classIri}> .`);
+    expect(query).not.toContain('?mainRes a knora-api:Resource .');
+  });
+
+  it('omits the generic anchor when a fulltext term is present (matchFulltext types ?mainRes; anchor pessimizes the backend)', () => {
+    const query = gravsearchService.generateGravSearchQuery([], 'hello');
+    expect(query).toContain('FILTER knora-api:matchFulltext(?mainRes, "hello")');
+    expect(query).not.toContain('a knora-api:Resource');
   });
 });
 


### PR DESCRIPTION
## Problem

In Advanced Search, a search with **no resource class** ("All resources") filtering only on **Resource label** — *is like* / *equals* / *does not equal* — fails with **HTTP 400**:

```
Types could not be determined for one or more entities: ?mainRes
```

The generated Gravsearch has nothing typing `?mainRes`:

```sparql
WHERE {
?mainRes rdfs:label ?label .
?mainRes rdfs:label ?res0 .
FILTER regex(?res0, "Einstieg", "i") .
}
```

dsp-api's type inspection (`SearchResponderV2` → `GravsearchTypeInspectionRunner`, over the WHERE clause) requires a type for every entity, including `?mainRes`. A class restriction or a `matchFulltext` term types it — **`rdfs:label` does not**.

Introduced by the advanced-search refactor **#3236**, which removed the generic `?mainRes a knora-api:Resource .` anchor. That removal is a genuine perf optimization for the fulltext path (the anchor defeats matchFulltext index anchoring), but it broke the class-less label-only case.

## Fix

Re-introduce `?mainRes a knora-api:Resource .` **only when no class is selected AND no fulltext term is present** — the exact gap where nothing else types `?mainRes`. The per-class `UNION` is **not** reintroduced.

`_restrictToResourceClassStatement`:
- class selected → `?mainRes a <class> .`
- no class + fulltext → `''` (matchFulltext types `?mainRes`)
- no class + no fulltext → `?mainRes a knora-api:Resource .`

## Verification (live, api.dev — BIZ project 0828)

| Scenario | Before | After |
|---|---|---|
| class-less label _is like_ "Einstieg" | **400** | **200, 2 results** |
| class-less label _equals_ | **400** | **200, 1 result** |
| class-less **fulltext** | 200 (anchor-free) | 200 (still anchor-free — perf preserved) |
| class selected | 200 | 200 (class is the anchor) |

## Tests

- Corrected 2 pre-existing tests that encoded the buggy anchor-less output.
- Added 5 tests covering the three-way anchor branch.
- Full advanced-search lib suite green (218 tests), lint clean.

## Scope

Fixes the HTTP-400 class of bugs from the DEV-6889 analysis. The multi-valued "does not equal" leak (DEV-6889 proper) and the duplicate `rdfs:label` binding are tracked separately.

Closes DEV-6894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)