### PR TITLE
fix(advanced-search): order by ?label when sorting on rdfs:label (DEV-6889 follow-up)

### DIFF
--- a/libs/vre/pages/search/advanced-search/src/lib/service/gravsearch.service.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/service/gravsearch.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { LABEL_VARIABLE, RESOURCE_PLACEHOLDER } from '../constants';
+import { LABEL_VARIABLE, RDFS_LABEL, RESOURCE_PLACEHOLDER } from '../constants';
 import { escapeSparqlStringLiteral, OrderByItem, StatementElement } from '../model';
 import { GravsearchWriter } from './gravsearch-writer';
 import { OntologyDataService } from './ontology-data.service';
@@ -95,8 +95,13 @@ export class GravsearchService {
     const orderByProps: string[] = orderBy
       .filter(o => o.orderBy)
       .map(o => {
-        const index = statements.findIndex(stm => stm.selectedPredicate?.iri === o.id);
-        const variable = `${RESOURCE_PLACEHOLDER}${index}`;
+        // A ResourceLabel statement filters on the assembly's shared `?label` variable and no longer
+        // binds a `?resN` object variable, so sort on `?label` for it; other statements sort on the
+        // `?resN` bound by their object projection, indexed by statement position.
+        const variable =
+          o.id === RDFS_LABEL
+            ? LABEL_VARIABLE
+            : `${RESOURCE_PLACEHOLDER}${statements.findIndex(stm => stm.selectedPredicate?.iri === o.id)}`;
         const fn = o.direction === 'desc' ? 'DESC' : 'ASC';
         return `${fn}(${variable})`;
       });

--- a/libs/vre/pages/search/advanced-search/src/lib/service/spec/gravsearch.service.spec.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/service/spec/gravsearch.service.spec.ts
@@ -4,6 +4,7 @@ import { LocalizationService } from '@dasch-swiss/vre/shared/app-helper-services
 import { createMockLocalizationService } from '@dasch-swiss/vre/shared/app-helper-services/testing';
 import { TranslateLoader } from '@ngx-translate/core';
 import { of } from 'rxjs';
+import { RDFS_LABEL } from '../../constants';
 import { IriLabelPair, NodeValue, OrderByItem, Predicate, StatementElement, StringValue } from '../../model';
 import { Operator } from '../../operators.config';
 import { englishLabels, makeIriLabelPair } from '../../testing/test-data-builders';
@@ -332,6 +333,43 @@ OFFSET 0`;
     // Runtime wire string inside the FILTER literal: say \\\"hi\\\" \\\\*
     // (3 backslashes per quote, 4 backslashes per user backslash)
     expect(query).toContain('FILTER regex(?label, "say \\\\\\"hi\\\\\\" \\\\\\\\*", "i")');
+  });
+
+  it('sorts on the shared ?label variable when ordering by rdfs:label (not the unbound ?resN)', () => {
+    // A ResourceLabel statement filters on the assembly's `?label` and does not bind a `?resN` object
+    // variable, so an active sort on rdfs:label must ORDER BY on `?label` — ordering on `?resN` would
+    // reference an out-of-scope variable and make the query invalid.
+    const labelSnapshot = {
+      selectedOntology: { iri: webernOntologyIri, label: 'webern-onto' },
+      selectedResourceClass: { iri: '', label: 'All resource classes' },
+      statementElements: [
+        {
+          id: 'label-stmt',
+          statementLevel: 0,
+          _selectedPredicate: {
+            iri: RDFS_LABEL,
+            label: 'Resource Label',
+            objectValueType: 'http://api.knora.org/ontology/knora-api/v2#ResourceLabel',
+            isLinkProperty: false,
+          },
+          _selectedOperator: 'is like',
+          _selectedObjectNode: { statementId: 'label-stmt', _value: 'foo' },
+        },
+      ],
+      orderBy: [],
+    };
+    setupTestFromJson(searchStateService, JSON.stringify(labelSnapshot), makeIriLabelPair('', 'All resource classes'));
+
+    const activeOrderBy = [new OrderByItem(RDFS_LABEL, [], false, true)];
+    const query = gravsearchService.generateGravSearchQuery(
+      searchStateService.validStatementElements,
+      undefined,
+      '',
+      activeOrderBy
+    );
+
+    expect(query).toContain('ORDER BY ASC(?label)');
+    expect(query).not.toContain('?res0');
   });
 });
 


### PR DESCRIPTION
Follow-up to #3309, addressing a Copilot review comment.

## Problem

#3309 made a "Resource label" filter reuse the query assembly's shared `?label` variable and stop binding its own `?resN` object variable. But `_getOrderByString` still maps an active sort to `?res{index}` by statement position, so **sorting by Resource Label** emitted:

```sparql
ORDER BY ASC(?res0)
```

where `?res0` is not bound anywhere in the WHERE clause. dsp-api rejects this with **HTTP 400**:

> Variable ?res0 is used in ORDER by, but is not bound at the top level of the WHERE clause

## Fix

In `_getOrderByString`, when the sort target is `rdfs:label` (`o.id === RDFS_LABEL`), order on the shared `?label` variable (`LABEL_VARIABLE`); other predicates keep the indexed `?resN` bound by their object projection.

## Verification (live, api.dev — BIZ 0828)

- `ORDER BY ASC(?label)` (fixed) → **200**
- `ORDER BY ASC(?res0)` (old) → **400** (`Variable ?res0 ... not bound`)

Added a unit test asserting a label sort emits `ORDER BY ASC(?label)` and no `?res0`. Full advanced-search lib suite green (239 tests), lint clean.

Refs DEV-6889.

🤖 Generated with [Claude Code](https://claude.com/claude-code)