### PR TITLE
fix(error-handler): bind the ErrorHandler token without a stale deps list (DEV-6872)

### DIFF
--- a/apps/dsp-app/src/app/app.config.ts
+++ b/apps/dsp-app/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
-import { ApplicationConfig, ErrorHandler, inject, NgZone, provideAppInitializer } from '@angular/core';
+import { ApplicationConfig, inject, provideAppInitializer } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withComponentInputBinding, withRouterConfig } from '@angular/router';
 import { GrafanaFaroService } from '@dasch-swiss/vre/3rd-party-services/analytics';
@@ -12,11 +12,10 @@ import {
   DspAppConfigToken,
   DspInstrumentationToken,
 } from '@dasch-swiss/vre/core/config';
-import { AppErrorHandler } from '@dasch-swiss/vre/core/error-handler';
+import { provideAppErrorHandler } from '@dasch-swiss/vre/core/error-handler';
 import { apiConnectionTokenProvider } from '@dasch-swiss/vre/pages/user-settings/user';
 import { LocalizationService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { provideCalendarDateAdapter } from '@dasch-swiss/vre/ui/date-picker';
-import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
 import { TRANSLATE_HTTP_LOADER_CONFIG } from '@ngx-translate/http-loader';
 import { routes } from './app.routes';
@@ -75,11 +74,7 @@ export const appConfig: ApplicationConfig = {
       useFactory: (configService: AppConfigService) => configService.dspApiConfig.apiUrl,
       deps: [AppConfigService],
     },
-    {
-      provide: ErrorHandler,
-      useClass: AppErrorHandler,
-      deps: [NotificationService, AppConfigService, NgZone],
-    },
+    ...provideAppErrorHandler(),
     LocalizationService,
     ...provideCalendarDateAdapter(),
   ],

--- a/libs/vre/core/error-handler/src/index.ts
+++ b/libs/vre/core/error-handler/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/app-error-handler';
+export * from './lib/app-error-handler.providers';
 export * from './lib/app-error';
 export * from './lib/error-reporting.service';
 export * from './lib/user-feedback-error';

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.providers.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.providers.spec.ts
@@ -1,0 +1,46 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ErrorHandler } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { AppConfigService } from '@dasch-swiss/vre/core/config';
+import { NotificationService } from '@dasch-swiss/vre/ui/notification';
+import { TranslateService } from '@ngx-translate/core';
+import { provideAppErrorHandler } from './app-error-handler.providers';
+import { ErrorReportingService } from './error-reporting.service';
+
+/**
+ * Resolves the handler through the `ErrorHandler` token, the way the running app does — not through
+ * the class token, the way `app-error-handler.spec.ts` does.
+ *
+ * The distinction is the whole point of this file: the QA-bounced build wired the token with a
+ * hand-written `deps` list that had fallen one entry behind the constructor, so the instance behind
+ * the token was missing its `ErrorReportingService` and threw on every single error, while every
+ * class-token test kept passing (DEV-6872).
+ */
+describe('provideAppErrorHandler', () => {
+  let openSnackBar: jest.Mock;
+  let report: jest.Mock;
+
+  beforeEach(() => {
+    openSnackBar = jest.fn();
+    report = jest.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...provideAppErrorHandler(),
+        { provide: NotificationService, useValue: { openSnackBar } },
+        { provide: TranslateService, useValue: { instant: (key: string) => key } },
+        { provide: AppConfigService, useValue: { dspInstrumentationConfig: { environment: 'prod' } } },
+        { provide: ErrorReportingService, useValue: { report } },
+      ],
+    });
+  });
+
+  it('resolves a fully constructed handler that both reports and notifies', () => {
+    const error = new HttpErrorResponse({ status: 500, url: 'http://api/v2/search/count/foo' });
+
+    TestBed.inject(ErrorHandler).handleError(error);
+
+    expect(report).toHaveBeenCalledWith(error);
+    expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.contactSupport', 'error');
+  });
+});

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.providers.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.providers.ts
@@ -1,0 +1,17 @@
+import { ErrorHandler, Provider } from '@angular/core';
+import { AppErrorHandler } from './app-error-handler';
+
+/**
+ * Binds Angular's `ErrorHandler` token to {@link AppErrorHandler}.
+ *
+ * Deliberately carries no `deps` array. Angular's `providerToFactory` bypasses a class's own factory
+ * whenever a `useClass` provider declares `deps`, and constructs it from that list instead — so a
+ * hand-written list silently passes `undefined` for every constructor parameter added after it was
+ * last edited. That is what happened when `ErrorReportingService` joined the constructor: the handler
+ * threw on its own first line, so no error reached a snackbar or telemetry at all (DEV-6872 QA bounce).
+ * Unit tests could not see it, because they resolve the class token directly rather than through this
+ * binding. `useExisting` also keeps a single instance shared with the `providedIn: 'root'` one.
+ */
+export function provideAppErrorHandler(): Provider[] {
+  return [{ provide: ErrorHandler, useExisting: AppErrorHandler }];
+}

--- a/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.ts
+++ b/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.ts
@@ -178,12 +178,14 @@ export class ResourcesListFetcherComponent implements OnChanges {
         return { resources: currResources!, selectFirstResource };
       }),
       catchError((error: unknown) => {
-        this._errorHandler.handleError(error);
         // Drop any previously known total: after a failed page change the old count describes results
         // that are no longer on screen, and leaving it would break the service's "null means genuinely
         // unknown" contract for as long as the failure state lasts.
         this._resourceResult.numberOfResults = null;
         this.failed.set(true);
+        // Last, so that the failure state stands on its own: a throw inside the global handler must
+        // not be able to take the retry panel down with it and restore the eternal spinner (DEV-6872).
+        this._errorHandler.handleError(error);
         return of(null);
       })
     );

--- a/libs/vre/pages/search/advanced-search/src/lib/advanced-search-results.component.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/advanced-search-results.component.ts
@@ -101,13 +101,15 @@ export class AdvancedSearchResultsComponent implements OnChanges {
         // `of(null)` keeps the stream alive for retry while the `failed` signal drives the real state.
         catchError((err: unknown) => {
           this._logger.searchError(err);
-          this._errorHandler.handleError(err);
           // Drop any previously known total: after a failed page change the old count describes results
           // that are no longer on screen, and leaving it would break the service's "null means genuinely
           // unknown" contract for as long as the failure state lasts.
           this._resourceResultService.numberOfResults = null;
           this.queryIsExecuting.set(false);
           this.failed.set(true);
+          // Last, so that the failure state stands on its own: a throw inside the global handler must
+          // not be able to take the retry panel down with it and restore the eternal spinner (DEV-6872).
+          this._errorHandler.handleError(err);
           return of(null);
         }),
         startWith(null)

--- a/libs/vre/pages/search/search/src/lib/search-result.component.ts
+++ b/libs/vre/pages/search/search/src/lib/search-result.component.ts
@@ -120,13 +120,15 @@ export class SearchResultComponent implements OnChanges {
         return resourceResponse.resources;
       }),
       catchError((error: unknown) => {
-        this._errorHandler.handleError(error);
         // Drop any previously known total: after a failed page change the old count describes results
         // that are no longer on screen, and leaving it would break the service's "null means genuinely
         // unknown" contract for as long as the failure state lasts.
         this._resourceResultService.numberOfResults = null;
         this.loading.set(false);
         this.failed.set(true);
+        // Last, so that the failure state stands on its own: a throw inside the global handler must
+        // not be able to take the retry panel down with it and restore the eternal spinner (DEV-6872).
+        this._errorHandler.handleError(error);
         return of(null);
       })
     );


### PR DESCRIPTION
Fixes the [DEV-6872](https://linear.app/dasch/issue/DEV-6872) QA bounce: `AppErrorHandler.handleError` threw `TypeError: Cannot read properties of undefined (reading 'report')` on every handled error in the running app (Sentry [DSP-APP-28Q](https://dasch.sentry.io/issues/DSP-APP-28Q)), so no error produced a snackbar, and the handler path reported nothing to telemetry.

## Root cause

`app.config.ts` bound the `ErrorHandler` token with a hand-written dependency list:

```ts
{ provide: ErrorHandler, useClass: AppErrorHandler, deps: [NotificationService, AppConfigService, NgZone] }
```

Angular's `providerToFactory` bypasses a class's own factory whenever a `useClass` provider declares `deps`, and constructs it from that list instead. #3298 added `ErrorReportingService` as the fourth constructor parameter without extending the list, so the instance behind the token received `undefined` for it — and `handleError` reports before branching, so it threw on its own first line.

Not a build or Angular 21 interaction: it reproduces in plain Jest as soon as the handler is resolved through the `ErrorHandler` token with a `deps` list.

## Changes

- **`provideAppErrorHandler()`** in the error-handler lib, following the `provideCalendarDateAdapter()` precedent, with no `deps` — the constructor becomes the single source of truth, and this class of drift cannot recur. `useExisting` also avoids a second instance next to the `providedIn: 'root'` one.
- **Regression test** resolving the handler through the `ErrorHandler` token, the way the app does. The pre-existing specs resolve the class token, which uses the class factory — which is why the whole suite stayed green through the bounce.
- **Call-site ordering** in the three degraded paths (`search-result`, `advanced-search-results`, `resources-list-fetcher`): the failure state is now set before `handleError` is called. Previously a throw in the global handler also defeated the DEV-6866 / DEV-6871 failure states and restored the eternal spinner.

## Verification

Putting the stale `deps` list back into the provider function makes the new spec fail with the production stack, `at AppErrorHandler.handleError (app-error-handler.ts:30:26)`; removing it passes.

Tests and lint green for `vre-core-error-handler`, `vre-pages-search-search`, `vre-pages-search-advanced-search`, `vre-pages-project-project`, `dsp-app`; `nx run dsp-app:build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)