### PR TITLE
chore(ci): roll the review prompt back to baseline and patch it against false flags

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,24 +49,52 @@ jobs:
             - Security concerns
             - Test coverage (only for modified code)
 
-            Focus your review **only on files and lines changed in this PR**.
-            Do **not** review unrelated parts of the repository.
+            Report issues **only in lines this PR changed** — but read whatever you need to
+            decide whether an issue is real: the changed files in full (diff hunks alone give
+            too little context), their callers, their tests, and neighbouring implementations
+            of the same pattern. Reading widely is fine; reporting widely is not.
             Do **not** make any code changes, run commands, or push code; only provide analysis and suggestions.
 
+            Before reporting an issue, name the concrete input or state that triggers it and
+            the wrong output, crash, or regression that results. Drop any issue where you
+            cannot; where the justification is only "more robust" or "best practice"; or where
+            a code comment explains it as a deliberate decision (read the comments before
+            flagging). If you checked a concern and could not prove it but still believe it
+            matters, report it as Suspected rather than dropping it or inflating its severity.
+            A few defensible issues beat many speculative ones, and reporting no issues at all
+            is a valid and useful outcome.
+
+            Do not assert how a library behaves from memory. When an issue depends on a
+            dependency's API or semantics, confirm it against the version this repo installs
+            (`package.json` and the lock file) or the library's own documentation via web
+            search — or grade the issue Suspected.
+
             Structure your review as follows:
-            1. Summary of PR changes
-            2. Identified issues (prioritize Critical issues, including bugs, security vulnerabilities, or regressions):
-              - Grade each issue as Critical, Major, or Minor.
-              - Only Critical issues should prevent the PR from being ready to merge.
-              - Minor or style issues should be noted but do not affect merge readiness.
-            3. Recommendations for improvement (aligned with the issue severity)
-            4. Clear statement whether the PR is ready to merge (based **only** on Critical issues)
+            1. Summary of PR changes (one paragraph)
+            2. Identified issues, most severe first. For each: `file:line`, the failure
+               scenario, and a suggested fix. Grade each as Critical, Major, Minor, or Suspected:
+              - Critical: a bug, security vulnerability, or regression that reaches users.
+                Only Critical issues prevent the PR from being ready to merge.
+              - Major / Minor: worth fixing / worth noting, but do not affect merge readiness.
+              - Suspected: a concern you could not prove — state what would confirm or refute
+                it. Never blocks merge.
+            3. Clear statement whether the PR is ready to merge (based **only** on Critical issues)
 
             Be constructive, precise, and concise. Avoid verbose explanations unless necessary for clarity.
-            Use the repository's CLAUDE.md for guidance on style, conventions, and repository-specific best practices.
+            Read `REVIEW.md` at the repository root if it exists; its rules override the
+            defaults above. Otherwise use the repository's CLAUDE.md for style, conventions,
+            and repository-specific best practices.
             Use `gh pr comment` to leave your review as a comment on the PR.
 
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Reading files is already in the action's base tool set; search and web lookup are
+          # not, and the prompt above depends on both — Grep/Glob to check a suspicion against
+          # the rest of the repo instead of guessing, WebSearch/WebFetch to check a dependency's
+          # real API instead of recalling it. Bash stays confined to read-only gh commands.
+          #
+          # --model: pinned to Opus. In the 2026-08 prompt benchmark the model choice dominated
+          # the prompt choice: Opus caught 6/6 planted bugs with zero blocking false positives;
+          # Sonnet caught 1/6 and produced the only merge-blocking false positives.
+          claude_args: '--model claude-opus-5 --allowed-tools "Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,10 @@ jobs:
       (github.event.issue.pull_request || github.event.pull_request) &&
       (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review'))
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30, not 15: the action writes its result only at the end, so a killed run yields no
+    # review at all — and measured review runs have peaked within a few minutes of 15.
+    # A generous ceiling costs nothing on the runs that finish early.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -96,12 +99,15 @@ jobs:
           # Sonnet caught 1/6 and produced the only merge-blocking false positives.
           claude_args: '--model claude-opus-5 --allowed-tools "Grep,Glob,WebSearch,WebFetch,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
+      # cancelled() as well as failure(): a `timeout-minutes` kill marks the job cancelled,
+      # not failed, so `if: failure()` alone lets a timed-out review pass silently with no
+      # comment on the PR.
       - name: Notify on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
           if [ -n "$PR_NUMBER" ]; then
-            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code Review failed. Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+            gh issue comment "$PR_NUMBER" --body "⚠️ Claude Code Review did not complete (failed, timed out, or was cancelled). Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,86 +42,31 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
 
-            Review this pull request for correctness, security, performance, and test coverage.
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage (only for modified code)
 
-            ## Scope
+            Focus your review **only on files and lines changed in this PR**.
+            Do **not** review unrelated parts of the repository.
+            Do **not** make any code changes, run commands, or push code; only provide analysis and suggestions.
 
-            Report issues **only in lines this PR changed**. But READ WHATEVER YOU NEED to decide
-            whether an issue is real: open the changed files in full (the diff hunks alone give too
-            little surrounding context), plus their callers, their tests, neighbouring
-            implementations of the same pattern, and read-only git history. Reading widely is
-            required; reporting widely is not.
+            Structure your review as follows:
+            1. Summary of PR changes
+            2. Identified issues (prioritize Critical issues, including bugs, security vulnerabilities, or regressions):
+              - Grade each issue as Critical, Major, or Minor.
+              - Only Critical issues should prevent the PR from being ready to merge.
+              - Minor or style issues should be noted but do not affect merge readiness.
+            3. Recommendations for improvement (aligned with the issue severity)
+            4. Clear statement whether the PR is ready to merge (based **only** on Critical issues)
 
-            ## Every finding must survive this test
-
-            Name the concrete input or state that triggers it, and the wrong output, crash, or
-            regression that results.
-
-            DELETE — do not downgrade — any finding where:
-            - you cannot name a specific input and a specific wrong outcome;
-            - the justification is "more robust", "best practice", or "could break if X" where X
-              does not occur in this codebase;
-            - the code is already correct under TypeScript, RxJS, or Angular semantics;
-            - it is a deliberate decision explained in a comment (read the comment before flagging).
-
-            Three defensible findings beat twelve speculative ones. Reporting no findings is a
-            valid and useful outcome.
-
-            ## Verify every Critical or Major finding before reporting it
-
-            Spawn a separate agent per finding to attack it. Give that agent the finding, the file
-            and the surrounding code — but NOT the reasoning that led you to suspect it, so its
-            judgement is not shaped by yours. Instruct it to argue the finding is WRONG, to check
-            the claim against the source, and to default to "refuted" where the evidence is
-            ambiguous. Drop every finding its verifier refutes.
-
-            If you cannot spawn agents at all, do NOT check the findings yourself and do NOT post a
-            review. Post only a short error stating that subagents were unavailable and what
-            happened when you tried. A review that reads as verified but was not is worse than no
-            review, and quietly falling back to self-checking restores the exact anchoring this
-            section exists to remove.
-
-            If an individual spawn fails, retry it once; if it fails again keep that finding but
-            label it `unverified` and carry on. One flaky spawn should not sink a whole review.
-
-            Apply the deletion test to Minor findings without a verifier.
-
-            Work inside the job's time budget: verify in descending order of severity, and if you
-            run short, report the remaining findings explicitly marked as unverified rather than
-            letting the run time out. A partial review is useful; a timed-out one is not.
-
-            ## Checking claims about libraries
-
-            Do not assert an API contract from memory. When a finding depends on how a dependency
-            behaves — a method signature, an option shape, a documented limit — confirm it against
-            the version installed in this repo (`node_modules`, lock file) or against the library's
-            own documentation via web search. An unverified claim about a dependency is a finding
-            to delete, not to report.
-
-            ## Test coverage
-
-            For a bug fix, check that a test exists which would FAIL without the change — name it,
-            or state that none exists. Do not ask for tests that only restate an implementation
-            line or assert a config value.
-
-            ## Output
-
-            1. One-paragraph summary of what the PR does.
-            2. Findings, most severe first. For each: `file:line`, the failure scenario, and the
-               fix. Grade Critical / Major / Minor, where Critical means a bug, security hole, or
-               regression that reaches users.
-            3. Ready to merge: yes or no, based **only** on Critical findings.
-
-            Be precise and concise. Read REVIEW.md at the repository root if it exists; its rules
-            override these defaults. Do **not** change code, push, or run commands.
+            Be constructive, precise, and concise. Avoid verbose explanations unless necessary for clarity.
+            Use the repository's CLAUDE.md for guidance on style, conventions, and repository-specific best practices.
             Use `gh pr comment` to leave your review as a comment on the PR.
 
-          # Reading files is already in the action's base tool set; search, web lookup and Task are
-          # not, and the prompt above depends on all three — Grep/Glob to confirm a suspicion across
-          # the repo, WebSearch/WebFetch to check a dependency's real API instead of recalling it,
-          # and Task to verify findings in an agent that has not seen the reasoning behind them.
-          # Bash stays confined to read-only gh commands, so no path to secrets is opened.
-          claude_args: '--allowed-tools "Grep,Glob,WebSearch,WebFetch,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Context

The CI review-prompt experimentation (P1/P2/P3 × 3 models benchmark) is paused. This PR puts a pragmatic interim in place: roll back to the simple pre-#3300 baseline prompt ("P1"), then apply a small set of targeted patches that fix its two known weaknesses — over-flagging and poor output structure — **without** reintroducing the expensive verifier/two-pass machinery of the current prompt.

## How to review

Three commits, on purpose:

1. **Rollback** — restores the pre-#3300 workflow file verbatim.
2. **Prompt patches** — the actual prompt changes to review. Look at this commit's diff alone to see exactly what changed relative to the old baseline prompt.
3. **Infra** — review-job timeout 15 → 30 and notify on `cancelled()` (a `timeout-minutes` kill is "cancelled", not "failed"), mirroring what dsp-api already carries. Separate so it doesn't pollute the prompt diff; can be dropped independently if unwanted.

## The patches (commit 2)

- **Scope split**: report only changed lines, but *read* whatever is needed to verify a suspicion (the old "do not review unrelated parts" is what made suspicions unverifiable and over-flagged).
- **Deletion test**: findings must name a concrete trigger + wrong outcome; "best practice" speculation and documented-deliberate decisions get dropped.
- **`Suspected` severity**: non-blocking grade for unproven concerns, so they surface without blocking merge.
- **Library claims**: checked against `package.json`/lock file or upstream docs, never from memory (Grep/Glob/WebSearch/WebFetch added; no Task/subagents).
- **Output**: tightened to `file:line` + failure scenario + fix, most severe first; merge verdict on Critical only.
- **Model pinned to Opus**: the benchmark showed model choice dominates prompt choice (Opus 6/6 planted bugs, 0 blocking false positives; Sonnet 1/6, both blocking false positives).

Twin PR on dsp-api: dasch-swiss/dsp-api#4248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)