### PR TITLE
fix(search): show the server's reason in the search failure panel

### DIFF
--- a/libs/vre/core/error-handler/src/index.ts
+++ b/libs/vre/core/error-handler/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/api-error-reason';
 export * from './lib/app-error-handler';
 export * from './lib/app-error-handler.providers';
 export * from './lib/app-error';

--- a/libs/vre/core/error-handler/src/lib/api-error-reason.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/api-error-reason.spec.ts
@@ -1,0 +1,83 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ApiResponseError } from '@dasch-swiss/dsp-js';
+import { AjaxError } from 'rxjs/ajax';
+import { reasonFromApiError, reasonFromErrorBody, userFacingReason } from './api-error-reason';
+
+const makeApiResponseError = (status: number, response: unknown): ApiResponseError => {
+  const ajax = Object.create(AjaxError.prototype) as AjaxError;
+  Object.assign(ajax, { status, response, message: `ajax error ${status}`, name: 'AjaxError' });
+  const error = Object.create(ApiResponseError.prototype) as ApiResponseError;
+  Object.assign(error, { status, error: ajax, url: '/v2/search/x', method: 'GET' });
+  return error;
+};
+
+describe('reasonFromErrorBody', () => {
+  it.each([
+    ['a bare string body', 'plain failure', 'plain failure'],
+    ['an empty string body', '', undefined],
+    ['a JSON-LD knora-api:error', { 'knora-api:error': 'jsonld reason' }, 'jsonld reason'],
+    ['an OpenAPI { message }', { message: 'openapi reason' }, 'openapi reason'],
+    ['an { error } body', { error: 'error-field reason' }, 'error-field reason'],
+    ['a body with no reason', { unrelated: 1 }, undefined],
+    ['a null body', null, undefined],
+  ])('reads %s', (_label, body, expected) => {
+    expect(reasonFromErrorBody(body)).toBe(expected);
+  });
+});
+
+describe('reasonFromApiError', () => {
+  it('reads through an ApiResponseError to the wrapped AjaxError body', () => {
+    expect(reasonFromApiError(makeApiResponseError(400, { message: 'wrapped reason' }))).toBe('wrapped reason');
+  });
+
+  it('reads an HttpErrorResponse body', () => {
+    const error = new HttpErrorResponse({ status: 409, error: { message: 'conflict reason' } });
+    expect(reasonFromApiError(error)).toBe('conflict reason');
+  });
+
+  it('returns undefined for anything that is not an API failure', () => {
+    expect(reasonFromApiError(new Error('boom'))).toBeUndefined();
+  });
+});
+
+describe('userFacingReason', () => {
+  it('surfaces the reason dsp-api gives for a rejected query (DEV-6866)', () => {
+    // The real body from GET /v2/search/de* — the case that was reported as an eternal spinner.
+    const error = makeApiResponseError(400, {
+      message:
+        'A wildcard search term must contain at least 3 characters besides the wildcard, but the following do not: de*.',
+    });
+
+    expect(userFacingReason(error)).toBe(
+      'A wildcard search term must contain at least 3 characters besides the wildcard, but the following do not: de*.'
+    );
+  });
+
+  it('strips the dsp exception class the older v2 shape prefixes', () => {
+    const error = makeApiResponseError(400, {
+      'knora-api:error': 'dsp.errors.BadRequestException: the query is malformed',
+    });
+
+    expect(userFacingReason(error)).toBe('the query is malformed');
+  });
+
+  it('surfaces a 409 conflict reason', () => {
+    const error = new HttpErrorResponse({ status: 409, error: { message: 'shortname already taken' } });
+
+    expect(userFacingReason(error)).toBe('shortname already taken');
+  });
+
+  it.each([500, 502, 504, 403, 404])(
+    'withholds the body of a %i, which carries internals rather than an explanation',
+    status => {
+      const error = makeApiResponseError(status, { message: 'NullPointerException at internal.Service:42' });
+
+      // Callers fall back to their own curated wording, matching what the snackbar shows.
+      expect(userFacingReason(error)).toBeUndefined();
+    }
+  );
+
+  it('returns undefined when a reason-bearing status carries no reason', () => {
+    expect(userFacingReason(makeApiResponseError(400, {}))).toBeUndefined();
+  });
+});

--- a/libs/vre/core/error-handler/src/lib/api-error-reason.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/api-error-reason.spec.ts
@@ -61,6 +61,36 @@ describe('userFacingReason', () => {
     expect(userFacingReason(error)).toBe('the query is malformed');
   });
 
+  it.each([
+    ['dsp.errors.ConflictException: shortname already taken', 'shortname already taken'],
+    ['dsp.errors.NotFoundException: no such resource', 'no such resource'],
+  ])('strips any dsp exception class, not only BadRequestException (%s)', (body, expected) => {
+    expect(userFacingReason(makeApiResponseError(400, { 'knora-api:error': body }))).toBe(expected);
+  });
+
+  it('withholds a triplestore exception forwarded verbatim', () => {
+    // The real body from searching `"unbalanced` or `AND`: dsp-api passes Jena's parse failure straight
+    // through, and a Java class name on screen is worse than the generic wording it would replace.
+    const error = makeApiResponseError(400, {
+      message:
+        "org.apache.jena.query.text.TextIndexParseException: Text search parse error:\nCannot parse '\"unbalanced': Lexical error",
+    });
+
+    expect(userFacingReason(error)).toBeUndefined();
+  });
+
+  it('withholds a bare java.lang failure too', () => {
+    const error = makeApiResponseError(400, { message: 'java.lang.IllegalArgumentException: bad input' });
+
+    expect(userFacingReason(error)).toBeUndefined();
+  });
+
+  it('keeps a plain sentence that merely mentions the word exception', () => {
+    const error = makeApiResponseError(400, { message: 'This value is an exception to the rule.' });
+
+    expect(userFacingReason(error)).toBe('This value is an exception to the rule.');
+  });
+
   it('surfaces a 409 conflict reason', () => {
     const error = new HttpErrorResponse({ status: 409, error: { message: 'shortname already taken' } });
 

--- a/libs/vre/core/error-handler/src/lib/api-error-reason.ts
+++ b/libs/vre/core/error-handler/src/lib/api-error-reason.ts
@@ -1,3 +1,6 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ApiResponseError } from '@dasch-swiss/dsp-js';
+
 /**
  * The server's own account of a failure, read out of whichever field carries it.
  *
@@ -22,4 +25,49 @@ export function reasonFromErrorBody(body: unknown): string | undefined {
   return [shape['knora-api:error'], shape.message, shape.error].find(
     (candidate): candidate is string => typeof candidate === 'string' && candidate.length > 0
   );
+}
+
+/** The same reason, read off a whole error rather than a body already dug out of it. */
+export function reasonFromApiError(error: unknown): string | undefined {
+  if (error instanceof ApiResponseError) {
+    // `error` is the wrapped `AjaxError` for a JS-LIB failure and a plain string otherwise.
+    return reasonFromErrorBody(typeof error.error === 'string' ? error.error : error.error?.response);
+  }
+
+  if (error instanceof HttpErrorResponse) {
+    return reasonFromErrorBody(error.error);
+  }
+
+  return undefined;
+}
+
+/**
+ * Statuses whose body explains something the user can act on. A 400 names the constraint they broke
+ * ("a wildcard search term must contain at least 3 characters"); a 409 names the conflict. Everything
+ * else is deliberately excluded: 403/404/504 already have curated messages, and a 500 body carries
+ * server internals that do not belong on screen — which is why `AppErrorHandler` answers those with
+ * "contact support" rather than the raw text.
+ */
+const REASON_BEARING_STATUSES = new Set([400, 409]);
+
+/** dsp-api prefixes some 400s with its exception class; the user only wants what follows it. */
+const DSP_BAD_REQUEST_PREFIX = /dsp\.errors\.BadRequestException:(.*)$/;
+
+/**
+ * The server's explanation, when it is fit to show the user directly.
+ *
+ * Returns `undefined` when the failure has no actionable text, so callers can fall back to their own
+ * generic wording. Used to give a persistent failure panel the same sentence the snackbar shows —
+ * before this, a rejected query explained itself for five seconds and then left the user looking at
+ * "something went wrong, please try again", advice that cannot work for a malformed query (DEV-6866).
+ */
+export function userFacingReason(error: unknown): string | undefined {
+  const status = error instanceof ApiResponseError || error instanceof HttpErrorResponse ? error.status : undefined;
+
+  if (status === undefined || !REASON_BEARING_STATUSES.has(status)) {
+    return undefined;
+  }
+
+  const reason = reasonFromApiError(error);
+  return reason?.match(DSP_BAD_REQUEST_PREFIX)?.[1].trim() ?? reason;
 }

--- a/libs/vre/core/error-handler/src/lib/api-error-reason.ts
+++ b/libs/vre/core/error-handler/src/lib/api-error-reason.ts
@@ -50,8 +50,17 @@ export function reasonFromApiError(error: unknown): string | undefined {
  */
 const REASON_BEARING_STATUSES = new Set([400, 409]);
 
-/** dsp-api prefixes some 400s with its exception class; the user only wants what follows it. */
-const DSP_BAD_REQUEST_PREFIX = /dsp\.errors\.BadRequestException:(.*)$/;
+/** dsp-api prefixes its own exceptions with their class; the user only wants what follows it. */
+const DSP_EXCEPTION_PREFIX = /^dsp\.errors\.\w+:\s*([\s\S]*)$/;
+
+/**
+ * A package-qualified exception class still leading the text once dsp's own prefix is gone — dsp-api
+ * forwards some failures verbatim from the triplestore, so a malformed Lucene term comes back as
+ * `org.apache.jena.query.text.TextIndexParseException: Text search parse error: Cannot parse …`.
+ * That names internals rather than anything the user can act on, so it is withheld even though the
+ * status says the request was bad, and the caller falls back to its own wording.
+ */
+const FOREIGN_EXCEPTION = /^[a-z][\w$]*(\.[\w$]+)*\.[A-Z][\w$]*(Exception|Error)\b/;
 
 /**
  * The server's explanation, when it is fit to show the user directly.
@@ -69,5 +78,10 @@ export function userFacingReason(error: unknown): string | undefined {
   }
 
   const reason = reasonFromApiError(error);
-  return reason?.match(DSP_BAD_REQUEST_PREFIX)?.[1].trim() ?? reason;
+  if (!reason) {
+    return undefined;
+  }
+
+  const withoutDspPrefix = reason.match(DSP_EXCEPTION_PREFIX)?.[1].trim() ?? reason;
+  return FOREIGN_EXCEPTION.test(withoutDspPrefix) ? undefined : withoutDspPrefix;
 }

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
@@ -3,7 +3,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ApiResponseError } from '@dasch-swiss/dsp-js';
-import { reasonFromErrorBody } from './api-error-reason';
+import { reasonFromApiError } from './api-error-reason';
 
 /**
  * How long the same fingerprint stays suppressed after being reported, per browser tab.
@@ -143,17 +143,7 @@ export class ErrorReportingService {
    * say something.
    */
   private static _reasonOf(error: unknown): string | undefined {
-    if (error instanceof ApiResponseError) {
-      // `error` is the wrapped `AjaxError` for a JS-LIB failure and a plain string otherwise, where it
-      // defaults to empty. The reader takes either and maps an empty one to undefined.
-      return reasonFromErrorBody(typeof error.error === 'string' ? error.error : error.error.response);
-    }
-
-    if (error instanceof HttpErrorResponse) {
-      return reasonFromErrorBody(error.error);
-    }
-
-    return undefined;
+    return reasonFromApiError(error);
   }
 
   private static _asApiFailure(error: unknown): ApiFailure | null {

--- a/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.ts
+++ b/libs/vre/pages/project/project/src/lib/sidenav/resource-class-sidenav/resources-list-fetcher.component.ts
@@ -3,7 +3,7 @@ import { Component, ErrorHandler, Inject, Input, OnChanges, signal } from '@angu
 import { ActivatedRoute, Router } from '@angular/router';
 import { KnoraApiConnection, ReadProject, ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken, RouteConstants } from '@dasch-swiss/vre/core/config';
-import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
+import { ErrorReportingService, userFacingReason } from '@dasch-swiss/vre/core/error-handler';
 import { MultipleViewerService, ResourcesListComponent } from '@dasch-swiss/vre/pages/data-browser';
 import { OntologyService, ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
@@ -31,7 +31,7 @@ import { ProjectPageService } from '../../project-page.service';
     @let data = data$ | async;
     @if (failed()) {
       <app-centered-box>
-        <app-search-failed (retry)="onRetry()" />
+        <app-search-failed [reason]="failureReason()" (retry)="onRetry()" />
       </app-centered-box>
     } @else if (data) {
       @if (userCanViewResources) {
@@ -67,6 +67,8 @@ export class ResourcesListFetcherComponent implements OnChanges {
   userCanViewResources = true;
 
   readonly failed = signal(false);
+  /** dsp-api's own account of the failure, when it gave one fit to show. */
+  readonly failureReason = signal<string | undefined>(undefined);
 
   /** Re-triggers the load after a failure. Replays on subscribe so the initial load runs too. */
   private readonly _retrySubject = new BehaviorSubject<void>(undefined);
@@ -118,6 +120,7 @@ export class ResourcesListFetcherComponent implements OnChanges {
   ngOnChanges() {
     this._resourceResult.updatePageIndex(0);
     this.failed.set(false);
+    this.failureReason.set(undefined);
 
     this.data$ = this._retrySubject.pipe(switchMap(() => this._data$()));
   }
@@ -182,6 +185,9 @@ export class ResourcesListFetcherComponent implements OnChanges {
         // that are no longer on screen, and leaving it would break the service's "null means genuinely
         // unknown" contract for as long as the failure state lasts.
         this._resourceResult.numberOfResults = null;
+        // A rejected request explains itself; the panel says so instead of "try again", which cannot
+        // work for a request the server will keep rejecting (DEV-6866).
+        this.failureReason.set(userFacingReason(error));
         this.failed.set(true);
         // Last, so the failure state is committed before the global handler runs and a throw there
         // cannot bring the eternal spinner back (DEV-6872). It would still error this stream and

--- a/libs/vre/pages/search/advanced-search/src/lib/advanced-search-results.component.ts
+++ b/libs/vre/pages/search/advanced-search/src/lib/advanced-search-results.component.ts
@@ -12,7 +12,7 @@ import {
 import { Title } from '@angular/platform-browser';
 import { KnoraApiConnection } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
-import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
+import { ErrorReportingService, userFacingReason } from '@dasch-swiss/vre/core/error-handler';
 import { ResourceBrowserComponent } from '@dasch-swiss/vre/pages/data-browser';
 import { ProjectPageService } from '@dasch-swiss/vre/pages/project/project';
 import { filterNull } from '@dasch-swiss/vre/shared/app-common';
@@ -38,7 +38,7 @@ import { SearchFlowLogger } from './service/search-flow-logger.service';
     @let resources = resources$ | async;
     @if (failed()) {
       <app-centered-box>
-        <app-search-failed (retry)="onRetry()" />
+        <app-search-failed [reason]="failureReason()" (retry)="onRetry()" />
       </app-centered-box>
     } @else if (!resources && queryIsExecuting()) {
       <app-centered-box>
@@ -75,12 +75,15 @@ export class AdvancedSearchResultsComponent implements OnChanges {
 
   readonly queryIsExecuting = signal(false);
   readonly failed = signal(false);
+  /** dsp-api's own account of the failure, when it gave one fit to show. */
+  readonly failureReason = signal<string | undefined>(undefined);
 
   readonly resources$ = this.querySubject.pipe(
     filterNull(),
     switchMap(query => {
       this.queryIsExecuting.set(true);
       this.failed.set(false);
+      this.failureReason.set(undefined);
       return combineLatest([
         this._resourceResultService.pageIndex$.pipe(
           switchMap(pageNumber => this._performGravSearch$(query, pageNumber))
@@ -105,6 +108,9 @@ export class AdvancedSearchResultsComponent implements OnChanges {
           // that are no longer on screen, and leaving it would break the service's "null means genuinely
           // unknown" contract for as long as the failure state lasts.
           this._resourceResultService.numberOfResults = null;
+          // A rejected query explains itself; the panel says so instead of "try again", which cannot
+          // work for a query the server will keep rejecting (DEV-6866).
+          this.failureReason.set(userFacingReason(err));
           this.queryIsExecuting.set(false);
           this.failed.set(true);
           // Last, so the failure state is committed before the global handler runs and a throw there

--- a/libs/vre/pages/search/search/src/lib/search-result.component.spec.ts
+++ b/libs/vre/pages/search/search/src/lib/search-result.component.spec.ts
@@ -1,11 +1,12 @@
 import { ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ReadResource } from '@dasch-swiss/dsp-js';
+import { ApiResponseError, ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
 import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
 import { ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { TranslateModule } from '@ngx-translate/core';
 import { of, throwError } from 'rxjs';
+import { AjaxError } from 'rxjs/ajax';
 import { SearchResultComponent } from './search-result.component';
 
 /**
@@ -104,6 +105,42 @@ describe('SearchResultComponent — search failure handling (DEV-6866)', () => {
     });
     // Still deliberately silent towards the user: the result list rendered fine.
     expect(handleError).not.toHaveBeenCalled();
+    sub.unsubscribe();
+  });
+
+  it('shows the reason dsp-api gave for rejecting the query (DEV-6866)', () => {
+    // The real body from GET /v2/search/de*, reported as an eternal spinner and then as an unhelpful
+    // "please try again" — advice that cannot work for a query the server will keep rejecting.
+    const ajax = Object.create(AjaxError.prototype) as AjaxError;
+    Object.assign(ajax, {
+      status: 400,
+      message: 'ajax error 400',
+      name: 'AjaxError',
+      response: { message: 'A wildcard search term must contain at least 3 characters besides the wildcard.' },
+    });
+    const rejected = Object.create(ApiResponseError.prototype) as ApiResponseError;
+    Object.assign(rejected, { status: 400, error: ajax, url: '/v2/search/de*', method: 'GET' });
+    doFulltextSearch.mockReturnValue(throwError(() => rejected));
+
+    const { component } = renderComponent('de*');
+    const sub = component.resources$.subscribe();
+
+    expect(component.loading()).toBe(false);
+    expect(component.failed()).toBe(true);
+    expect(component.failureReason()).toBe(
+      'A wildcard search term must contain at least 3 characters besides the wildcard.'
+    );
+    sub.unsubscribe();
+  });
+
+  it('falls back to the generic wording when the failure carries no usable reason', () => {
+    doFulltextSearch.mockReturnValue(throwError(() => new Error('socket hang up')));
+
+    const { component } = renderComponent();
+    const sub = component.resources$.subscribe();
+
+    expect(component.failed()).toBe(true);
+    expect(component.failureReason()).toBeUndefined();
     sub.unsubscribe();
   });
 

--- a/libs/vre/pages/search/search/src/lib/search-result.component.ts
+++ b/libs/vre/pages/search/search/src/lib/search-result.component.ts
@@ -2,7 +2,7 @@ import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ErrorHandler, Inject, Input, OnChanges, signal } from '@angular/core';
 import { IFulltextSearchParams, KnoraApiConnection, ReadResource } from '@dasch-swiss/dsp-js';
 import { DspApiConnectionToken } from '@dasch-swiss/vre/core/config';
-import { ErrorReportingService } from '@dasch-swiss/vre/core/error-handler';
+import { ErrorReportingService, userFacingReason } from '@dasch-swiss/vre/core/error-handler';
 import { ResourceBrowserComponent } from '@dasch-swiss/vre/pages/data-browser';
 import { ResourceResultService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
@@ -23,7 +23,7 @@ import { BehaviorSubject, catchError, combineLatest, map, Observable, of, switch
     @let resources = resources$ | async;
     @if (failed()) {
       <app-centered-box>
-        <app-search-failed (retry)="onRetry()" />
+        <app-search-failed [reason]="failureReason()" (retry)="onRetry()" />
       </app-centered-box>
     } @else if (!resources && loading()) {
       <app-progress-indicator />
@@ -51,6 +51,8 @@ export class SearchResultComponent implements OnChanges {
 
   readonly loading = signal(true);
   readonly failed = signal(false);
+  /** dsp-api's own account of the failure, when it gave one fit to show. */
+  readonly failureReason = signal<string | undefined>(undefined);
 
   resources$!: Observable<ReadResource[] | null>;
 
@@ -104,6 +106,7 @@ export class SearchResultComponent implements OnChanges {
         tap(() => {
           this.loading.set(true);
           this.failed.set(false);
+          this.failureReason.set(undefined);
         }),
         switchMap(pageNumber =>
           this._dspApiConnection.v2.search.doFulltextSearch(this.query, pageNumber, this.searchInProjectParam)
@@ -124,6 +127,9 @@ export class SearchResultComponent implements OnChanges {
         // that are no longer on screen, and leaving it would break the service's "null means genuinely
         // unknown" contract for as long as the failure state lasts.
         this._resourceResultService.numberOfResults = null;
+        // A rejected query explains itself; the panel says so instead of "try again", which cannot
+        // work for a query the server will keep rejecting (DEV-6866).
+        this.failureReason.set(userFacingReason(error));
         this.loading.set(false);
         this.failed.set(true);
         // Last, so the failure state is committed before the global handler runs and a throw there

--- a/libs/vre/ui/ui/src/lib/search-failed.component.ts
+++ b/libs/vre/ui/ui/src/lib/search-failed.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslatePipe } from '@ngx-translate/core';
 import { CenteredMessageComponent } from './centered-message.component';
@@ -16,7 +16,7 @@ import { CenteredMessageComponent } from './centered-message.component';
     <app-centered-message
       [icon]="'error_outline'"
       [title]="'pages.search.searchFailed.title' | translate"
-      [message]="'pages.search.searchFailed.message' | translate" />
+      [message]="reason ?? ('pages.search.searchFailed.message' | translate)" />
     <button mat-stroked-button data-cy="search-failed-retry" (click)="retry.emit()">
       {{ 'ui.common.actions.retry' | translate }}
     </button>
@@ -33,5 +33,12 @@ import { CenteredMessageComponent } from './centered-message.component';
   imports: [CenteredMessageComponent, MatButtonModule, TranslatePipe],
 })
 export class SearchFailedComponent {
+  /**
+   * The server's own explanation, when it gave one worth showing (a rejected query says why it was
+   * rejected). Falls back to the generic wording. Not translated — it is dsp-api's text, and the
+   * snackbar has always shown it in the same language.
+   */
+  @Input() reason?: string;
+
   @Output() retry = new EventEmitter<void>();
 }

--- a/libs/vre/ui/ui/src/lib/search-failed.stories.ts
+++ b/libs/vre/ui/ui/src/lib/search-failed.stories.ts
@@ -9,6 +9,11 @@ const meta: Meta<SearchFailedComponent> = {
   title: 'UI / Search Failed',
   component: SearchFailedComponent,
   argTypes: {
+    reason: {
+      description: "The server's own explanation, shown in place of the generic message when present.",
+      control: 'text',
+      table: { type: { summary: 'string' }, category: 'Content' },
+    },
     retry: {
       description: 'Emitted when the user clicks the Retry button.',
       table: { type: { summary: 'EventEmitter<void>' }, category: 'Events' },
@@ -40,6 +45,24 @@ export const Default: Story = {
     await step('Clicking Retry emits the retry output', async () => {
       await userEvent.click(canvas.getByRole('button', { name: /Retry/i }));
       await expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+  },
+};
+
+export const WithServerReason: Story = {
+  name: "Shows the server's own explanation instead of the generic message",
+  args: {
+    reason: 'A wildcard search term must contain at least 3 characters besides the wildcard.',
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('The rejected query explains itself', async () => {
+      await expect(canvas.getByText(/at least 3 characters/i)).toBeInTheDocument();
+    });
+    await step('The unhelpful generic advice is not shown alongside it', async () => {
+      // "Please try again" cannot work for a query the server will keep rejecting (DEV-6866).
+      await expect(canvas.queryByText(/Please try again/i)).toBeNull();
     });
   },
 };


### PR DESCRIPTION
[DEV-6866](https://linear.app/dasch/issue/DEV-6866)

Follows the reopen: *"Searching for `de*` gives a 400 immediately, but the spinner goes forever."*

## What actually caused the reported spinner — and why it is already gone

Not a missing error path. **`AppErrorHandler` was throwing**, so the `catchError` that stops the spinner never finished.

My PR #3298 added a 4th constructor dependency to `AppErrorHandler` (`ErrorReportingService`), while `app.config.ts` still declared three:

```ts
{ provide: ErrorHandler, useClass: AppErrorHandler, deps: [NotificationService, AppConfigService, NgZone] }
```

`useClass` **plus an explicit `deps` list** constructs positionally, so `_errorReporting` was `undefined` and `handleError` threw a `TypeError`. At that time the search `catchError` called `handleError` first, so `loading.set(false)` and `failed.set(true)` never ran — for **every** error, which is why the report says "other errors weren't handled" rather than naming a single class.

That was fixed by **#3314** (`provideAppErrorHandler()`, no hand-written deps) — shipped in **v13.12.2**, merged four hours after the report — and hardened by **#3315**, which reorders the failure handlers so the state is committed before the global handler runs. Verified by driving the real `de*` 400 through the real `AppErrorHandler`: the spinner stops, the panel appears, the snackbar carries the reason, and the stream stays alive so Retry works.

**Please retest on an environment running ≥ v13.12.2.**

## What this PR changes

The remaining defect the reopen exposes, which no version fixes: for `de*` the panel says *"Something went wrong… Please try again"*. Retrying is useless — the server will reject that query every time — and the sentence that would let the user fix it (*"a wildcard search term must contain at least 3 characters besides the wildcard"*) only existed in the 5-second snackbar.

- **`userFacingReason(error)`** (`vre/core/error-handler`) returns dsp-api's explanation only for the statuses whose body is meant for the user — **400** (names the broken constraint) and **409** (names the conflict). 403/404/504 already have curated messages; 500 is excluded because its body carries server internals. It also strips the `dsp.errors.BadRequestException:` prefix the older v2 shape adds.
- **`reasonFromApiError(error)`** reads the reason off a whole `ApiResponseError`/`HttpErrorResponse`; `ErrorReportingService` was duplicating that shape and now delegates.
- **`SearchFailedComponent`** takes an optional `reason` and shows it instead of the generic message. Wired into all three failure paths (fulltext search, advanced search, sidenav resource list).

The panel now carries the same sentence as the snackbar, and falls back to the generic wording when the failure has nothing actionable to say.

## Test Plan

- New `api-error-reason.spec.ts`: body-shape precedence, whole-error reading, the real `de*` body, the `dsp.errors.BadRequestException:` strip, the 409 case, and that 500/502/504/403/404 bodies are withheld.
- `search-result.component.spec.ts`: a 400 carrying the real wildcard message surfaces it; a failure with no usable reason falls back to `undefined`.
- New `WithServerReason` story asserting the explanation replaces the generic advice.
- `nx affected` across **16 projects**: lint and test green. `dsp-app:build` clean. Storybook interaction tests pass in chromium.

## How this class of mistake gets avoided

Three separate things had to line up, and each is worth a different guard:

1. **`useClass` + `deps` is a silent trap.** The list is positional and TypeScript cannot check it against the constructor, so adding a dependency compiles fine and breaks DI at runtime. Dropping `deps` and letting Angular read the class's own metadata — what `provideAppErrorHandler()` now does — makes the desync structurally impossible. A lint rule banning `deps:` next to `useClass:` would enforce it repo-wide; happy to add it if wanted.
2. **Nothing tested the app's real DI wiring.** The break lived in `app.config.ts`, which no spec exercises — my whole DEV-6866 suite stayed green while the app was broken. A smoke test that resolves the real provider set would have caught it in CI.
3. **A failure handler must not depend on a side-effecting call succeeding.** Putting `handleError` first meant one throw defeated the entire fix. Commit local state first, notify outward last — now done in all three components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)