### PR TITLE
fix(error-handler): show the reason of a 400 whose body is knora-api:error

### DIFF
--- a/libs/vre/core/error-handler/src/lib/api-error-reason.ts
+++ b/libs/vre/core/error-handler/src/lib/api-error-reason.ts
@@ -27,6 +27,22 @@ export function reasonFromErrorBody(body: unknown): string | undefined {
   );
 }
 
+/**
+ * The `{ message }` of an exception declared in the OpenAPI spec, when the body carries one.
+ *
+ * Lives next to `reasonFromErrorBody` so that knowledge of the response shapes stays in one module: a
+ * caller that tidies up raw exception text before showing it needs to know whether the reason it was
+ * handed is that text or a sentence dsp-api already wrote for the user.
+ */
+export function declaredMessageOf(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') {
+    return undefined;
+  }
+
+  const message = (body as { message?: unknown }).message;
+  return typeof message === 'string' && message.length > 0 ? message : undefined;
+}
+
 /** The same reason, read off a whole error rather than a body already dug out of it. */
 export function reasonFromApiError(error: unknown): string | undefined {
   if (error instanceof ApiResponseError) {

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
@@ -182,6 +182,16 @@ describe('AppErrorHandler', () => {
       );
     });
 
+    it('says nothing when the body is a page rather than a message', () => {
+      // Angular assigns the raw text when an error body does not parse as JSON, so a 400 from a proxy
+      // ahead of the API arrives as a whole HTML page. MatSnackBar would show all of it, escaped.
+      handler.handleError(
+        badRequest('<html>\r\n<head><title>400 Request Header Or Cookie Too Large</title></head>\r\n</html>\r\n')
+      );
+
+      expect(openSnackBar).not.toHaveBeenCalled();
+    });
+
     it('does not throw on a 400 with an empty body', () => {
       // Angular leaves `error` null when a 400 arrives with no body, as a gateway or proxy answers.
       // There is nothing to tell the user, but throwing here costs them the snackbar for every

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
@@ -98,12 +98,96 @@ describe('AppErrorHandler', () => {
       expect(instant).toHaveBeenCalledWith('core.errorHandler.contactSupport');
       expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.contactSupport', 'error');
     });
+  });
 
-    it('does not throw on a 400 with an empty body (ApiServices path)', () => {
+  /**
+   * The `HttpErrorResponse` path used to test the body against three shapes in turn, so the JSON-LD
+   * `{ 'knora-api:error': … }` of the hand-written v2 services matched none of them and the branch
+   * returned having notified nobody: the user caused a 400 and saw nothing (DEV-6922). All four shapes
+   * now go through the precedence `reasonFromErrorBody` already shares with telemetry.
+   */
+  describe('400 error body (ApiServices path via handleHttpErrorResponse)', () => {
+    const badRequest = (body: unknown) =>
+      new HttpErrorResponse({ status: 400, statusText: 'Bad Request', error: body });
+
+    it('surfaces the knora-api:error of the hand-written JSON-LD v2 services (DEV-6922)', () => {
+      handler.handleError(badRequest({ 'knora-api:error': 'dsp.errors.BadRequestException: the label is required' }));
+
+      // Everything after the colon, verbatim: the capture group is not trimmed, exactly as the
+      // `{ error }` shape beside it has always shown it.
+      expect(openSnackBar).toHaveBeenCalledWith(' the label is required', 'error');
+    });
+
+    it('surfaces a knora-api:error that carries no exception class verbatim', () => {
+      handler.handleError(badRequest({ 'knora-api:error': 'the resource is already deleted' }));
+
+      expect(openSnackBar).toHaveBeenCalledWith('the resource is already deleted', 'error');
+    });
+
+    it('prefers the knora-api:error over a { message } beside it, as telemetry and the JS-LIB path do', () => {
+      handler.handleError(
+        badRequest({ 'knora-api:error': 'dsp.errors.BadRequestException: precise reason', message: 'generic message' })
+      );
+
+      expect(openSnackBar).toHaveBeenCalledWith(' precise reason', 'error');
+    });
+
+    it.each([
+      [
+        'an { error } carrying a dsp exception',
+        { error: 'dsp.errors.BadRequestException: the label is required' },
+        ' the label is required',
+      ],
+      [
+        'the parenthesised detail of an invalid request',
+        { error: 'Invalid request (the label must not be empty)' },
+        'the label must not be empty',
+      ],
+      [
+        'the detail rather than the message it follows',
+        { error: 'dsp.errors.BadRequestException: invalid (must be an integer)' },
+        'must be an integer',
+      ],
+      [
+        'the detail out of a bare string body',
+        'Invalid request (the label must not be empty)',
+        'the label must not be empty',
+      ],
+      ['a declared { message } whole', { message: 'value type is not supported' }, 'value type is not supported'],
+    ])('keeps showing %s', (_label, body, expected) => {
+      handler.handleError(badRequest(body));
+
+      expect(openSnackBar).toHaveBeenCalledWith(expected, 'error');
+    });
+
+    it('shows a declared { message } whole even when it ends in a parenthesis', () => {
+      // The parenthesis extraction belongs to dsp-api's raw exception text. A `{ message }` is a
+      // sentence written for the user, so extracting from it would drop everything before the clause.
+      handler.handleError(badRequest({ message: 'The value is invalid (an integer was expected)' }));
+
+      expect(openSnackBar).toHaveBeenCalledWith('The value is invalid (an integer was expected)', 'error');
+    });
+
+    it('shows one snackbar for a body that matches both extractions', () => {
+      // Both used to fire, and MatSnackBar.open replaces the bar already showing — so the detail was
+      // what the user ended up reading, after a frame of the message it follows.
+      handler.handleError(badRequest({ error: 'dsp.errors.BadRequestException: invalid (must be an integer)' }));
+
+      expect(openSnackBar).toHaveBeenCalledTimes(1);
+      expect(openSnackBar).toHaveBeenCalledWith('must be an integer', 'error');
+    });
+
+    it('does not throw on a 400 with an empty body', () => {
       // Angular leaves `error` null when a 400 arrives with no body, as a gateway or proxy answers.
       // There is nothing to tell the user, but throwing here costs them the snackbar for every
-      // error and kills the calling component's stream.
+      // error and kills the calling component's stream (DEV-6872).
       expect(() => handler.handleError(new HttpErrorResponse({ status: 400 }))).not.toThrow();
+      expect(openSnackBar).not.toHaveBeenCalled();
+    });
+
+    it('says nothing when a 400 body carries no reason at all', () => {
+      handler.handleError(badRequest({ unrelated: 'metadata' }));
+
       expect(openSnackBar).not.toHaveBeenCalled();
     });
   });

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
@@ -144,11 +144,6 @@ describe('AppErrorHandler', () => {
         'the label must not be empty',
       ],
       [
-        'the detail rather than the message it follows',
-        { error: 'dsp.errors.BadRequestException: invalid (must be an integer)' },
-        'must be an integer',
-      ],
-      [
         'the detail out of a bare string body',
         'Invalid request (the label must not be empty)',
         'the label must not be empty',
@@ -168,13 +163,23 @@ describe('AppErrorHandler', () => {
       expect(openSnackBar).toHaveBeenCalledWith('The value is invalid (an integer was expected)', 'error');
     });
 
-    it('shows one snackbar for a body that matches both extractions', () => {
-      // Both used to fire, and MatSnackBar.open replaces the bar already showing — so the detail was
-      // what the user ended up reading, after a frame of the message it follows.
-      handler.handleError(badRequest({ error: 'dsp.errors.BadRequestException: invalid (must be an integer)' }));
+    it('keeps the sentence behind the exception class rather than the parenthesis it ends with', () => {
+      // A real dsp-api 400 (SearchResponderV2): the parenthesis holds Lucene's parse failure, the text
+      // before it names what the user got wrong. Taking the parenthesis first — which is what the two
+      // extractions used to add up to, the later call replacing the earlier bar — left the user holding
+      // internals that `userFacingReason` withholds from the failure panel outright (DEV-6866).
+      handler.handleError(
+        badRequest({
+          'knora-api:error':
+            "dsp.errors.BadRequestException: Invalid search string: 'de*' (org.apache.lucene.queryparser.classic.ParseException: Cannot parse 'de*')",
+        })
+      );
 
       expect(openSnackBar).toHaveBeenCalledTimes(1);
-      expect(openSnackBar).toHaveBeenCalledWith('must be an integer', 'error');
+      expect(openSnackBar).toHaveBeenCalledWith(
+        " Invalid search string: 'de*' (org.apache.lucene.queryparser.classic.ParseException: Cannot parse 'de*')",
+        'error'
+      );
     });
 
     it('does not throw on a 400 with an empty body', () => {

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.ts
@@ -5,7 +5,7 @@ import { AppConfigService } from '@dasch-swiss/vre/core/config';
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { TranslateService } from '@ngx-translate/core';
 import { AjaxError } from 'rxjs/ajax';
-import { reasonFromErrorBody } from './api-error-reason';
+import { declaredMessageOf, reasonFromErrorBody } from './api-error-reason';
 import { ErrorReportingService } from './error-reporting.service';
 import { UserFeedbackError } from './user-feedback-error';
 
@@ -23,6 +23,9 @@ export class AppErrorHandler implements ErrorHandler {
   ) {}
 
   badRequestRegexMatch = /dsp\.errors\.BadRequestException:(.*)$/;
+
+  /** dsp-api appends what was actually wrong with an invalid request in a trailing parenthesis. */
+  invalidRequestDetailMatch = /\((.*)\)$/;
 
   handleError(error: any): void {
     // Reported before branching, so every branch reaches telemetry rather than only the last one.
@@ -54,26 +57,51 @@ export class AppErrorHandler implements ErrorHandler {
 
   private handleHttpErrorResponse(error: HttpErrorResponse) {
     if (error.status === 400) {
-      if (error.error?.error) {
-        const badRequestRegexMatch = error.error.error.match(this.badRequestRegexMatch);
-
-        if (badRequestRegexMatch) {
-          this.displayNotification(badRequestRegexMatch[1]);
-        }
-
-        this.testInvalidRequest(error.error.error);
-      } else if (typeof error.error === 'string') {
-        this.testInvalidRequest(error.error);
-      } else if (error.error?.message) {
-        // Null-safe: Angular leaves `error` null for a 400 with an empty body — a gateway or proxy
-        // answers that way — and reading through it threw inside the handler, which costs the user
-        // the snackbar and kills the stream of whichever component called it (DEV-6872).
-        this.displayNotification(error.error.message);
-      }
+      this.handleBadRequest(error.error);
       return;
     }
 
     this.handleGenericError(error, error.url);
+  }
+
+  /**
+   * A 400 names the constraint the user broke, so the body is the message. It is read through the
+   * shared precedence (`knora-api:error` → `message` → `error` → bare string) rather than a branch per
+   * shape: branching that way recognised three of dsp-api's four and silently dropped the JSON-LD
+   * `{ 'knora-api:error': … }` the hand-written v2 services answer with, so that failure reached
+   * Sentry while the user saw no snackbar at all (DEV-6922).
+   *
+   * Nothing is shown when the body carries no reason — Angular leaves `error` null for a 400 with an
+   * empty body, as a gateway or proxy answers (DEV-6872) — and there is deliberately no generic
+   * fallback: a 400 with nothing in it can say nothing the failed action has not already said.
+   */
+  private handleBadRequest(body: unknown): void {
+    const reason = reasonFromErrorBody(body);
+
+    if (reason === undefined) {
+      return;
+    }
+
+    // A declared `{ message }` is dsp-api's own sentence for the user and is shown whole; tidying it
+    // would swap a full explanation for whatever its last clause happens to be. The other fields
+    // carry raw exception text, which is worth tidying.
+    const isDeclaredMessage = declaredMessageOf(body) === reason;
+    this.displayNotification(isDeclaredMessage ? reason : this.readableExceptionText(reason));
+  }
+
+  /**
+   * The part of dsp-api's exception text worth putting on screen: the detail it appends in a trailing
+   * parenthesis, else whatever follows the exception class, else the text as it stands.
+   *
+   * The order matters and preserves what the user used to end up seeing. Both extractions ran, one
+   * after the other, and `MatSnackBar.open` replaces the bar already showing — so the parenthesised
+   * detail won whenever there was one, and the message following the class name is only reached
+   * without it.
+   *
+   * TODO ask the backend to uniformize their response, so that none of this is needed.
+   */
+  private readableExceptionText(reason: string): string {
+    return reason.match(this.invalidRequestDetailMatch)?.[1] ?? reason.match(this.badRequestRegexMatch)?.[1] ?? reason;
   }
 
   private handleGenericError(error: HttpErrorResponse | AjaxError, url: string | null): void {
@@ -122,13 +150,5 @@ export class AppErrorHandler implements ErrorHandler {
     this._ngZone.run(() => {
       this._notification.openSnackBar(message, 'error');
     });
-  }
-
-  // TODO ask the backend to uniformize their response, so that this method is only called once.
-  private testInvalidRequest(error: string) {
-    const invalidRequestRegexMatch = error.match(/\((.*)\)$/);
-    if (invalidRequestRegexMatch) {
-      this.displayNotification(invalidRequestRegexMatch[1]);
-    }
   }
 }

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.ts
@@ -78,7 +78,7 @@ export class AppErrorHandler implements ErrorHandler {
   private handleBadRequest(body: unknown): void {
     const reason = reasonFromErrorBody(body);
 
-    if (reason === undefined) {
+    if (reason === undefined || this.looksLikeMarkup(reason)) {
       return;
     }
 
@@ -87,6 +87,17 @@ export class AppErrorHandler implements ErrorHandler {
     // carry raw exception text, which is worth tidying.
     const isDeclaredMessage = declaredMessageOf(body) === reason;
     this.displayNotification(isDeclaredMessage ? reason : this.readableExceptionText(reason));
+  }
+
+  /**
+   * A 400 body is only shown when dsp-api wrote it. Angular hands the raw text through when the body
+   * does not parse as JSON — for an error status it does not wrap it, it assigns it (`HttpXhrBackend`
+   * keeps `body = originalBody`, `FetchBackend` returns the text) — so a 400 from a proxy ahead of the
+   * API arrives here as a whole HTML page, which `MatSnackBar` would put on screen escaped and
+   * untruncated. There is nothing in it for the user, so it is dropped as an unreadable body.
+   */
+  private looksLikeMarkup(reason: string): boolean {
+    return /^\s*</.test(reason);
   }
 
   /**

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.ts
@@ -90,18 +90,20 @@ export class AppErrorHandler implements ErrorHandler {
   }
 
   /**
-   * The part of dsp-api's exception text worth putting on screen: the detail it appends in a trailing
-   * parenthesis, else whatever follows the exception class, else the text as it stands.
+   * The part of dsp-api's exception text worth putting on screen: what follows the exception class,
+   * else the detail it appends in a trailing parenthesis, else the text as it stands.
    *
-   * The order matters and preserves what the user used to end up seeing. Both extractions ran, one
-   * after the other, and `MatSnackBar.open` replaces the bar already showing — so the parenthesised
-   * detail won whenever there was one, and the message following the class name is only reached
-   * without it.
+   * The class prefix is stripped first because the sentence behind it is the actionable half and the
+   * parenthesis it ends with need not be. `Invalid search string: 'de*' (org.apache.lucene…
+   * ParseException: Cannot parse 'de*')` is a real dsp-api 400 (`SearchResponderV2`): taking the
+   * parenthesis first leaves the user holding Lucene's internals — the very text `userFacingReason`
+   * withholds from the failure panel (DEV-6866) — with the half naming their mistake dropped. The
+   * parenthesis extraction is what remains for the `Invalid request (…)` shape, which carries no class.
    *
    * TODO ask the backend to uniformize their response, so that none of this is needed.
    */
   private readableExceptionText(reason: string): string {
-    return reason.match(this.invalidRequestDetailMatch)?.[1] ?? reason.match(this.badRequestRegexMatch)?.[1] ?? reason;
+    return reason.match(this.badRequestRegexMatch)?.[1] ?? reason.match(this.invalidRequestDetailMatch)?.[1] ?? reason;
   }
 
   private handleGenericError(error: HttpErrorResponse | AjaxError, url: string | null): void {


### PR DESCRIPTION
[DEV-6922](https://linear.app/dasch/issue/DEV-6922)

## Summary

- A 400 arriving as an `HttpErrorResponse` with a `{ "knora-api:error": … }` body showed **no snackbar at all**. The branch tested three shapes in turn and returned, so the shape the hand-written JSON-LD v2 services answer with (`ResourceLegalV2ApiService` and friends) matched nothing — the failure reached Sentry and the user, who had caused the 400, was told nothing.
- All four shapes now read through `reasonFromErrorBody`, the precedence already shared with telemetry and the search failure panel. This path now agrees with the JS-LIB one on which field wins when a body carries several.
- One snackbar per 400 instead of one replacing another, and the half of dsp-api's exception text that names the user's mistake is the half that survives.

## Changes

**`app-error-handler.ts`** — the 400 branch becomes `handleBadRequest`, which reads the reason once and shows it. The two extractions dsp-api's raw exception text needs move into `readableExceptionText`: the exception class prefix is stripped first, and the trailing parenthesised detail is what remains for the `Invalid request (…)` shape, which carries no class. `testInvalidRequest` is gone, folded into that method. A body that opens as markup is dropped rather than shown.

**`api-error-reason.ts`** — adds `declaredMessageOf`, the guard on the tidying. A declared `{ message }` is a sentence dsp-api wrote for the user, so extracting a trailing parenthesis out of it would swap the whole explanation for its last clause. Shape knowledge stays in the module that owns it.

### Behaviour deltas

| 400 body | before | after |
|---|---|---|
| `{ 'knora-api:error': … }` | *nothing* | the reason |
| `{ error: 'dsp…: msg' }` | ` msg` | unchanged |
| `{ error: 'dsp…: msg (detail)' }` | `msg (detail)` then `detail` | ` msg (detail)`, one bar |
| `'bare string (detail)'` | `detail` | unchanged |
| `{ message: 'x' }` | `x` | unchanged |
| `{ message: 'x (y)' }` | `x (y)` | unchanged — the guard |
| `{ error: 'no class here' }` | *nothing* | `no class here` |
| `'bare string, no parens'` | *nothing* | the string |
| `'<html>…400 from a proxy…'` | *nothing* | unchanged — dropped as markup |
| empty / no reason | *nothing* | unchanged |

Row 3 is the one place where "keep today's visible text" and "show the useful half" disagree, and it is decided by a real message: `SearchResponderV2` answers a malformed search with `BadRequestException(s"Invalid search string: '$searchValue' ($err)")`, where `$err` is Lucene's parse failure. Taking the parenthesis first showed `org.apache.lucene…ParseException: Cannot parse 'de*'` and dropped the half naming the mistake — the same text `userFacingReason` withholds from the failure panel outright (DEV-6866), and the opposite of what `handleGenericError` shows for that body.

The reason is otherwise shown verbatim, matching what the JS-LIB 400 path has always done. There is still deliberately no generic fallback here: a 400 with an empty body has nothing to say that the failed action has not already said.

## Test Plan

`nx run vre-core-error-handler:test` — 76 passed, lint and prettier clean.

New `describe` for the `HttpErrorResponse` 400 path covering all four shapes, the precedence when a body carries both fields, the `{ message }` guard, the extraction order against the real Lucene message, the single-bar property, the markup body and the silent cases. Verified against the unfixed handler: **4 of them fail** (the three `knora-api:error` cases and the bar count), the rest pass on both — so the regression guards really are guards.
