### PR TITLE
fix(error-handler): stop claiming the user is offline on any status 0 (DEV-6935)

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -971,7 +971,7 @@
   },
   "core": {
     "errorHandler": {
-      "noInternet": "Es scheint, dass Sie nicht mit dem Internet verbunden sind.",
+      "serverUnreachable": "Der Server konnte nicht erreicht werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
       "iiifServerError": "IIIF-Serverfehler: Das Bild konnte nicht geladen werden. Bitte versuchen Sie es später erneut.",
       "noPermission": "Sie haben keine Berechtigung, eine oder mehrere Ressourcen zu sehen.",
       "notFound": "Die angeforderte Ressource wurde nicht gefunden.",

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -971,7 +971,7 @@
   },
   "core": {
     "errorHandler": {
-      "noInternet": "It seems that you are not connected to internet.",
+      "serverUnreachable": "Could not reach the server. Please check your connection and try again.",
       "iiifServerError": "IIIF server error: The image could not be loaded. Please try again later.",
       "noPermission": "You do not have permission to see one or more resources.",
       "notFound": "The requested resource was not found.",

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -971,7 +971,7 @@
   },
   "core": {
     "errorHandler": {
-      "noInternet": "Il semble que vous ne soyez pas connecté à Internet.",
+      "serverUnreachable": "Le serveur n'a pas pu être joint. Veuillez vérifier votre connexion et réessayer.",
       "iiifServerError": "Erreur du serveur IIIF : L'image n'a pas pu être chargée. Veuillez réessayer plus tard.",
       "noPermission": "Vous n'avez pas la permission de voir une ou plusieurs ressources.",
       "notFound": "La ressource demandée n'a pas été trouvée.",

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -971,7 +971,7 @@
   },
   "core": {
     "errorHandler": {
-      "noInternet": "Sembra che tu non sia connesso a Internet.",
+      "serverUnreachable": "Non è stato possibile raggiungere il server. Controlla la connessione e riprova.",
       "iiifServerError": "Errore del server IIIF: L'immagine non è stata caricata. Riprova più tardi.",
       "noPermission": "Non hai il permesso di vedere una o più risorse.",
       "notFound": "La risorsa richiesta non è stata trovata.",

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
@@ -328,7 +328,6 @@ describe('AppErrorHandler', () => {
       );
 
       expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.serverUnreachable', 'error');
-      expect(instant).not.toHaveBeenCalledWith('core.errorHandler.noInternet');
     });
 
     it('reads the same on the JS-LIB path', () => {

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
@@ -308,4 +308,33 @@ describe('AppErrorHandler', () => {
       expect(openSnackBar).toHaveBeenCalledWith('duplicate value', 'error');
     });
   });
+
+  /**
+   * `status: 0` was read as proof the user was offline. It is what the browser reports for any failure
+   * it cannot attribute to a response — including a rejection by our own ingress, which is how a search
+   * for `\*bc` produced it with the connection perfectly fine (DEV-6935).
+   */
+  describe('status 0 (no response the browser can attribute)', () => {
+    it('does not claim the user is offline for a CORS-less rejection (DEV-6935)', () => {
+      // The shape the browser hands to Angular when the response carries no CORS headers: nothing of
+      // the response is exposed, so status collapses to 0 — what the ingress returns for a path
+      // containing %5C.
+      handler.handleError(
+        new HttpErrorResponse({
+          status: 0,
+          statusText: 'Unknown Error',
+          url: 'https://api.dev.dasch.swiss/v2/search/%5C*bc',
+        })
+      );
+
+      expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.serverUnreachable', 'error');
+      expect(instant).not.toHaveBeenCalledWith('core.errorHandler.noInternet');
+    });
+
+    it('reads the same on the JS-LIB path', () => {
+      handler.handleError(jsLibError(0, undefined));
+
+      expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.serverUnreachable', 'error');
+    });
+  });
 });

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.ts
@@ -121,7 +121,13 @@ export class AppErrorHandler implements ErrorHandler {
     let message: string;
 
     if (error.status === 0) {
-      message = this._translateService.instant('core.errorHandler.noInternet');
+      // `status: 0` is what the browser reports for every failure it cannot attribute to a response —
+      // a CORS rejection, DNS, TLS, an aborted request, a blocking extension — and for a genuine loss
+      // of connectivity. It used to be read as proof the user was offline, which sent them to check
+      // their wifi when the request had been rejected by our own ingress: searching `\*bc` is turned
+      // away by the shared ingress before routing, with no CORS headers, so the browser exposes
+      // nothing (DEV-6935). The message names only what is known — the server was not reached.
+      message = this._translateService.instant('core.errorHandler.serverUnreachable');
     } else if (error.message.includes('knora.json: 0 Unknown Error')) {
       message = this._translateService.instant('core.errorHandler.iiifServerError');
     } else if (error.status === 400) {

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.ts
@@ -129,6 +129,11 @@ export class AppErrorHandler implements ErrorHandler {
       // nothing (DEV-6935). The message names only what is known — the server was not reached.
       message = this._translateService.instant('core.errorHandler.serverUnreachable');
     } else if (error.message.includes('knora.json: 0 Unknown Error')) {
+      // Unreachable, and not by design: Angular composes `message` as `…: ${status} ${statusText}`,
+      // so the `0` in the literal above is the status and the branch before this one has already
+      // taken every input that could match. A Sipi failure therefore shows the generic message
+      // rather than this one. Pre-dates DEV-6935 and is left alone by it — fixing it means putting
+      // this test first, which changes what the user sees and needs its own test (DEV-6946).
       message = this._translateService.instant('core.errorHandler.iiifServerError');
     } else if (error.status === 400) {
       // A 400 carries an actionable reason. Support both response shapes: the older JSON-LD

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.spec.ts
@@ -170,7 +170,8 @@ describe('ErrorReportingService', () => {
     });
 
     it('grades a request that never completed as a warning, matching how the app reads it', () => {
-      // AppErrorHandler maps status 0 to the "no internet" message, i.e. the user's own connectivity.
+      // A 0 is a request the browser could not attribute to a response — not proof of the user's own
+      // connectivity, which is why the app no longer says so either (DEV-6935).
       service.report(apiError(0, 'GET', '/v2/resources/xyz'));
 
       expect(captureException.mock.calls[0][1].level).toBe('warning');

--- a/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
+++ b/libs/vre/core/error-handler/src/lib/error-reporting.service.ts
@@ -125,10 +125,11 @@ export class ErrorReportingService {
         ...context,
       },
       extra: { 'dsp.url': failure.url, ...(reason ? { 'dsp.response': reason } : {}) },
-      // A 5xx is a fault; a 4xx is the API rejecting what we sent, and a 0 is almost always the user's
-      // own connectivity — the app says as much, mapping it to the "no internet" message. Grading them
-      // alike would make an invalid date indistinguishable from a triplestore timeout in alerting, and
-      // that is how reporting ends up switched off again.
+      // A 5xx is a fault; a 4xx is the API rejecting what we sent, and a 0 is a request the browser
+      // could not attribute to any response at all — which is not evidence of the user's own
+      // connectivity, and is as likely to be our own ingress refusing the request (DEV-6935). Grading
+      // them alike would make an invalid date indistinguishable from a triplestore timeout in
+      // alerting, and that is how reporting ends up switched off again.
       level: failure.status >= 500 ? 'error' : 'warning',
     };
   }


### PR DESCRIPTION
[DEV-6935](https://linear.app/dasch/issue/DEV-6935)

## Summary

- `AppErrorHandler` treated an HTTP `status: 0` as proof the user is offline — *"It seems that you are not connected to internet."* But `status: 0` is what the browser reports for **every** failure it cannot attribute to a response: a CORS rejection, DNS, TLS, an aborted request, a blocking extension, and a genuine loss of connectivity.
- Found by searching `\*bc` on dev with the connection perfectly fine: the shared ingress rejects any path containing `%5C` before routing, with no CORS headers at all, so the browser exposes nothing of the response and the status collapses to `0`. The app then sent the user to check their wifi for a request our own infrastructure had refused.
- The message now names only what is known — the server was not reached — while keeping the same actionable advice.

## Changes

**Message** — `libs/vre/core/error-handler/src/lib/app-error-handler.ts:123` resolves `core.errorHandler.serverUnreachable` instead of `noInternet`, with a comment recording why a `0` cannot be read as "offline".

**i18n** — the key is renamed rather than reworded in place, so it stops asserting a cause too. All four languages; no `rm.json` exists, Romansh is bound to English by the runtime fallback loader (DEV-6629). Key sets verified identical across `en`/`de`/`fr`/`it`.

**Telemetry comments** — `error-reporting.service.ts` justified grading a `0` as a warning by asserting it is "almost always the user's own connectivity — the app says as much, mapping it to the 'no internet' message". Neither half survives this fix, and left standing the comment hands the next reader back the exact premise the fix removes. The grading itself is unchanged: whether a `0` should now be an `error` rather than a `warning` is an alerting decision, not a comment fix.

**Not included** — no `navigator.onLine === false` branch. The single message carries the same advice the offline wording gave, so the branch would buy slightly nicer phrasing in a case already covered, at the cost of a conditional, a retained key in four languages, and a test.

## Test Plan

- `nx run vre-core-error-handler:test` — 78 passed, 5 suites.
- The two new cases in `app-error-handler.spec.ts` were **verified to fail against the unfixed code** (2 failed / 76 passed with the message key reverted) rather than assumed to. They cover the `HttpErrorResponse` ingress-rejection shape and the JS-LIB path.
- `nx run vre-core-error-handler:lint`, prettier, and `tsc -p apps/dsp-app/tsconfig.app.json --noEmit` all clean.
- Repo-wide grep for both `noInternet` and the prose "no internet" returns nothing.

## Found while reviewing, filed separately

[DEV-6946](https://linear.app/dasch/issue/DEV-6946) — the IIIF branch immediately below this one is **unreachable**, so `core.errorHandler.iiifServerError` is dead in all four languages. Angular composes `message` as `` `…: ${status} ${statusText}` `` ([`_module-chunk.mjs:682`](https://github.com/angular/angular/blob/main/packages/common/http/src/response.ts)), so the `0` in the matched literal `knora.json: 0 Unknown Error` *is* the status — every input that could satisfy it has already been taken by `status === 0`. The ordering predates this PR and is present on `main`; it is a separate user-visible behaviour change needing its own test, so this PR was kept to DEV-6935's stated scope.

## Screenshots

Snackbar text only; no layout change.