### PR TITLE
fix(error-handler): test the IIIF failure before the generic one (DEV-6946)

### DIFF
--- a/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.spec.ts
@@ -335,5 +335,24 @@ describe('AppErrorHandler', () => {
 
       expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.serverUnreachable', 'error');
     });
+
+    /**
+     * A Sipi failure is a status-0 failure too — Angular writes the status into the message, so the
+     * `0` in `knora.json: 0 Unknown Error` is that same status. Testing the generic case first left
+     * the IIIF message with no reachable input; it is now tried before the fallback (DEV-6946).
+     */
+    it('names Sipi rather than the server when the failed request was for knora.json (DEV-6946)', () => {
+      // The shape Angular produces when the request `RepresentationService.getFileInfo` issues fails
+      // at the network layer: `message` is composed from the url, status and statusText.
+      handler.handleError(
+        new HttpErrorResponse({
+          status: 0,
+          statusText: 'Unknown Error',
+          url: 'https://iiif.dasch.swiss/0801/aB1cD2eF3gH-image.jp2/knora.json',
+        })
+      );
+
+      expect(openSnackBar).toHaveBeenCalledWith('core.errorHandler.iiifServerError', 'error');
+    });
   });
 });

--- a/libs/vre/core/error-handler/src/lib/app-error-handler.ts
+++ b/libs/vre/core/error-handler/src/lib/app-error-handler.ts
@@ -120,7 +120,19 @@ export class AppErrorHandler implements ErrorHandler {
   private handleGenericError(error: HttpErrorResponse | AjaxError, url: string | null): void {
     let message: string;
 
-    if (error.status === 0) {
+    if (error.message.includes('knora.json: 0 Unknown Error')) {
+      // Tested before `status === 0`, not after it. Angular composes `message` as
+      // `…: ${status} ${statusText}`, so the `0` in the literal above *is* the status: every input
+      // that can match this test also satisfies the generic one, and ordering the generic test first
+      // left this branch with no reachable input at all (DEV-6946). Specific before generic — the
+      // status-0 branch below is the fallback, so it has to be tried last.
+      //
+      // Reachable here, but still without a producer: `RepresentationService.getFileInfo` is the only
+      // caller that requests `knora.json`, and all four of its subscribers take the failure with
+      // `catchError` and render an inline failed-to-load state instead of rethrowing, so nothing
+      // hands a Sipi failure to this handler today. Left in place for whoever wires one up.
+      message = this._translateService.instant('core.errorHandler.iiifServerError');
+    } else if (error.status === 0) {
       // `status: 0` is what the browser reports for every failure it cannot attribute to a response —
       // a CORS rejection, DNS, TLS, an aborted request, a blocking extension — and for a genuine loss
       // of connectivity. It used to be read as proof the user was offline, which sent them to check
@@ -128,13 +140,6 @@ export class AppErrorHandler implements ErrorHandler {
       // away by the shared ingress before routing, with no CORS headers, so the browser exposes
       // nothing (DEV-6935). The message names only what is known — the server was not reached.
       message = this._translateService.instant('core.errorHandler.serverUnreachable');
-    } else if (error.message.includes('knora.json: 0 Unknown Error')) {
-      // Unreachable, and not by design: Angular composes `message` as `…: ${status} ${statusText}`,
-      // so the `0` in the literal above is the status and the branch before this one has already
-      // taken every input that could match. A Sipi failure therefore shows the generic message
-      // rather than this one. Pre-dates DEV-6935 and is left alone by it — fixing it means putting
-      // this test first, which changes what the user sees and needs its own test (DEV-6946).
-      message = this._translateService.instant('core.errorHandler.iiifServerError');
     } else if (error.status === 400) {
       // A 400 carries an actionable reason. Support both response shapes: the older JSON-LD
       // `knora-api:error` ("dsp.errors.BadRequestException: <msg>") and the newer `{ message }`.


### PR DESCRIPTION
[DEV-6946](https://linear.app/dasch/issue/DEV-6946)

## Summary

- `handleGenericError` tested `status === 0` before the IIIF failure, and the IIIF test can only match when the status *is* `0` — Angular composes the message as `…: ${status} ${statusText}`, so the `0` in the matched literal `knora.json: 0 Unknown Error` is that status. The generic branch took every input that could have reached the specific one, leaving `core.errorHandler.iiifServerError` unreachable in all four languages.
- Specific before generic: the `knora.json` test now runs first, the status-0 branch stays as the fallback it is.
- A test covers both messages and fails against the previous order.

## Changes

**`app-error-handler.ts`** — the two branches swapped, and the comment rewritten: it previously documented the branch as dead and pointed here, which this makes false.

**`app-error-handler.spec.ts`** — one test for the `knora.json` shape. The existing `status: 0` tests (DEV-6935) are the guard for the other half of the acceptance criteria: a status-0 failure that is not a `knora.json` request still reports the server as unreachable.

## Known limitation — the branch still has no producer

Fixing the order makes the branch reachable *in the handler*, but nothing routes a Sipi failure into `AppErrorHandler` today, so this changes nothing a user currently sees.

`RepresentationService.getFileInfo` is the only caller that requests `knora.json`, and all four of its subscribers take the failure themselves rather than rethrowing:

| Caller | Handling |
|---|---|
| `file-representation.component.ts:65` | `catchError` → `failedToLoad = true`, `EMPTY` |
| `pdf-document.component.ts:177` | `catchError` → `failedToLoad = true`, `EMPTY` |
| `video.component.ts:99` | `catchError` → `console.error`, `EMPTY` |
| `audio.component.ts:98` | `catchError` → `failedToLoad = true`, `EMPTY` |

Neither HTTP interceptor reports errors either, so Angular's global `ErrorHandler` is never invoked for this request. The established UX for a failed `knora.json` is the inline failed-to-load state, not a snackbar — so surfacing the snackbar as well is a UX decision of its own and deliberately out of scope here. Recorded in the code comment and noted on the Linear issue.

## Test Plan

- `nx run vre-core-error-handler:test` — 79 passed.
- Verified the new test fails against the previous branch order: `Expected: "core.errorHandler.iiifServerError"` / `Received: "core.errorHandler.serverUnreachable"`.
- `nx run vre-core-error-handler:lint` — clean.

## Screenshots

No UI change (see the limitation above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)