### PR TITLE
fix(ci): gate the Claude Code workflow to repo members (DEV-6884)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,10 +17,21 @@ concurrency:
 
 jobs:
   # Job 1: Dedicated code review with predefined prompt which triggers on commands: '@claude review' posted in the comments of a PR
+  #
+  # Both jobs gate on author_association (DEV-6884): comment-triggered workflows always run
+  # from the default branch with secrets available, and the repo setting "Require approval
+  # for all external contributors" gates only fork pull_request events — not comment events,
+  # so without this gate any GitHub account that can comment could spend the org's API key.
+  # CONTRIBUTOR is deliberately outside the allowlist; a member can trigger on an outside
+  # contributor's behalf. A blocked trigger skips silently, like a non-matching comment.
   claude-code-review:
     if: |
       (github.event.issue.pull_request || github.event.pull_request) &&
-      (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review'))
+      (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review')) &&
+      (
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      )
     runs-on: ubuntu-latest
     # 30, not 15: the action writes its result only at the end, so a killed run yields no
     # review at all — and measured review runs have peaked within a few minutes of 15.
@@ -170,10 +181,23 @@ jobs:
 
   # Job 2: General Claude assistant (flexible) available on this repository PRs, issues etc. triggered by "@claude <PROMPT>"
   claude-general:
+    # The allowlist check sits inside each trigger arm instead of being AND-ed once across
+    # all three: issue_comment payloads also carry issue.author_association, so a single
+    # OR-ed check would let a stranger's comment pass on any issue or PR a member opened.
     if: |
-      (contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
-      (contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
[DEV-6884](https://linear.app/dasch/issue/DEV-6884)

## Summary
- Neither job in `claude.yml` checked who triggered it; on a public repo, comment-triggered workflows always run from the default branch with secrets available, so any GitHub account able to comment could fire either job and spend the org's `ANTHROPIC_API_KEY`.
- Both jobs now require the triggering author's association to be `OWNER`, `MEMBER` or `COLLABORATOR`. Everything else (`CONTRIBUTOR` included, per the decision in the issue) skips silently, exactly like a non-matching comment.

## Changes
- `claude-code-review`: the issue's condition verbatim — comment/review objects never coexist in one event, so a single OR over both associations is safe.
- `claude-general`: the allowlist check sits **inside each trigger arm** instead of being AND-ed once across all three. Deviation from the issue's literal "same plus `issue.author_association`" wording: `issue_comment` payloads also carry `issue.author_association` (the issue/PR author's), so a single OR-ed check would let a stranger's `@claude <anything>` pass on any issue or PR a member opened — the exact hole this PR closes.

## Org-wide sweep (per the issue's "check the other DaSCH repos")

All repos using `anthropics/claude-code-action` were enumerated; every one had the same ungated quickstart-derived condition. Fixed in sibling PRs, all on branch `feature/dev-6884-gate-claude-workflow-to-org-members`:

| Repo | Visibility | Note | PR |
|---|---|---|---|
| dsp-api | public | `claude-general` runs with `contents: write` | dasch-swiss/dsp-api#4253 |
| dsp-repository | public | same two-job shape as dsp-app | dasch-swiss/dsp-repository#320 |
| sipi | public | job runs with `contents: write` | dasch-swiss/sipi#780 |
| ark-resolver | public | `workflow_dispatch` arm stays ungated (needs write access) | dasch-swiss/ark-resolver#182 |
| dasch-claude-plugins | private | theoretical today; gated for consistency | dasch-swiss/dasch-claude-plugins#107 |

## Test Plan
- YAML parse validated locally; the `contains(fromJSON('[...]'), ...author_association)` pattern is the documented GitHub Actions idiom.
- The live trigger check ("one real `@claude review` from a member still works") can only happen **after merge**: comment-event workflows run the workflow file from the default branch, so this PR's version is not exercised by commenting on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)