### PR TITLE
fix: add UTF-8 BOM and file extension to CSV downloads

### DIFF
--- a/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.spec.ts
@@ -13,6 +13,16 @@ import { provideTranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 import { DownloadDialogResourcesTabComponent } from './download-dialog-resources-tab.component';
 
+// jsdom's Blob implements neither arrayBuffer() nor text(), so FileReader is the only way to get
+// at the raw bytes of a Blob under test.
+const readBlobBytes = (blob: Blob): Promise<Uint8Array> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+
 describe('DownloadDialogResourcesTabComponent', () => {
   let component: DownloadDialogResourcesTabComponent;
   let fixture: ComponentFixture<DownloadDialogResourcesTabComponent>;
@@ -297,7 +307,26 @@ describe('DownloadDialogResourcesTabComponent', () => {
 
         expect(createObjectURLSpy).toHaveBeenCalled();
         const blobArg = createObjectURLSpy.mock.calls[0][0] as Blob;
-        expect(blobArg.type).toBe('text/csv');
+        expect(blobArg.type).toBe('text/csv;charset=utf-8');
+      });
+
+      // DEV-6987: without the BOM, Excel/Numbers on macOS decode the file as Mac OS Roman and
+      // render "für" as "f√ºr". The BOM is the only thing that tells them the file is UTF-8.
+      it('prefixes the CSV with a UTF-8 BOM so spreadsheet apps decode non-ASCII correctly', async () => {
+        const nonAsciiBody = 'label,description\nMuseum für Kommunikation,Genève — Moritz Mähr\n';
+
+        component.downloadCsv();
+        events$.next(new HttpResponse({ body: nonAsciiBody, status: 200 }));
+        events$.complete();
+
+        const blobArg = createObjectURLSpy.mock.calls[0][0] as Blob;
+        const bytes = await readBlobBytes(blobArg);
+
+        // Asserted at byte level, not as a decoded string: UTF-8 decoding strips a leading BOM, so
+        // a string-level assertion would pass against the unfixed code too.
+        expect([...bytes.slice(0, 3)]).toEqual([0xef, 0xbb, 0xbf]);
+        // "für" must still be the precomposed two-byte c3 bc — the BOM is the only change.
+        expect(new TextDecoder('utf-8').decode(bytes.slice(3))).toBe(nonAsciiBody);
       });
 
       it('creates and clicks a download anchor', () => {

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.ts
@@ -21,6 +21,9 @@ import { DownloadPropertyListComponent } from './download-property-list.componen
 // than in download-dialog.component.ts so the dialog can reuse it without a circular import.
 export const CSV_EXPORT_LARGE_THRESHOLD = 1_000;
 
+// U+FEFF, encoded by Blob as the three-byte UTF-8 BOM (ef bb bf).
+const UTF8_BOM = '\uFEFF';
+
 @Component({
   selector: 'app-download-dialog-properties-tab',
   standalone: true,
@@ -249,7 +252,9 @@ export class DownloadDialogResourcesTabComponent {
   }
 
   private _createBlob(csvText: string) {
-    const blob = new Blob([csvText], { type: 'text/csv' });
+    // Excel and Numbers on macOS do not auto-detect UTF-8 without a byte-order mark and fall back
+    // to Mac OS Roman, rendering "für" as "f√ºr". The BOM is what tells them how to read the file.
+    const blob = new Blob([UTF8_BOM + csvText], { type: 'text/csv;charset=utf-8' });
     const filename = `resources_export_${new Date().toISOString().split('T')[0]}.csv`;
 
     const link = document.createElement('a');

--- a/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.ts
+++ b/libs/vre/pages/project/project/src/lib/download/download-dialog-resources-tab.component.ts
@@ -8,7 +8,7 @@ import { MatDialogActions } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { BASE_PATH, ExportRequest } from '@dasch-swiss/vre/3rd-party-services/open-api';
-import { PropertyInfoValues } from '@dasch-swiss/vre/shared/app-common';
+import { PropertyInfoValues, triggerBlobDownload } from '@dasch-swiss/vre/shared/app-common';
 import { LocalizationService } from '@dasch-swiss/vre/shared/app-helper-services';
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -257,12 +257,6 @@ export class DownloadDialogResourcesTabComponent {
     const blob = new Blob([UTF8_BOM + csvText], { type: 'text/csv;charset=utf-8' });
     const filename = `resources_export_${new Date().toISOString().split('T')[0]}.csv`;
 
-    const link = document.createElement('a');
-    link.href = window.URL.createObjectURL(blob);
-    link.download = filename;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    window.URL.revokeObjectURL(link.href);
+    triggerBlobDownload(blob, filename);
   }
 }

--- a/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.spec.ts
@@ -1,0 +1,88 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { APIV2ApiService } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { AccessTokenService } from '@dasch-swiss/vre/core/session';
+import { provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { ProjectPageService } from '../../project-page.service';
+import { ResourceMetadataComponent } from './resource-metadata.component';
+
+// jsdom's Blob implements neither arrayBuffer() nor text(), so FileReader is the only way to get at
+// the raw bytes of a Blob under test.
+const readBlobBytes = (blob: Blob): Promise<Uint8Array> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+
+describe('ResourceMetadataComponent', () => {
+  let component: ResourceMetadataComponent;
+  let fixture: ComponentFixture<ResourceMetadataComponent>;
+  let mockV2ApiService: jest.Mocked<Pick<APIV2ApiService, 'getV2MetadataProjectsProjectshortcodeResources'>>;
+  let createObjectURLSpy: jest.SpyInstance;
+
+  const shortcode = '0810';
+  const csvText = 'label,description\nMuseum für Kommunikation,Genève — Moritz Mähr\n';
+
+  // The component defers the download by 1s so the success snackbar is visible first.
+  const runDownload = () => {
+    component.exportMetadata();
+    jest.advanceTimersByTime(1000);
+  };
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+
+    mockV2ApiService = {
+      getV2MetadataProjectsProjectshortcodeResources: jest.fn().mockReturnValue(of(csvText)),
+    } as any;
+
+    if (!window.URL.createObjectURL) window.URL.createObjectURL = jest.fn();
+    if (!window.URL.revokeObjectURL) window.URL.revokeObjectURL = jest.fn();
+    createObjectURLSpy = jest.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    jest.spyOn(window.URL, 'revokeObjectURL').mockImplementation();
+
+    await TestBed.configureTestingModule({
+      imports: [ResourceMetadataComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: APIV2ApiService, useValue: mockV2ApiService },
+        { provide: AccessTokenService, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: jest.fn() } },
+        { provide: ProjectPageService, useValue: { currentProject$: of({ shortcode }) } },
+        provideTranslateService(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ResourceMetadataComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe('exportMetadata', () => {
+    // DEV-6987: without the BOM, Excel/Numbers on macOS decode the file as Mac OS Roman and render
+    // "für" as "f√ºr". The BOM is the only thing that tells them the file is UTF-8.
+    it('prefixes the CSV with a UTF-8 BOM so spreadsheet apps decode non-ASCII correctly', async () => {
+      runDownload();
+
+      const blobArg = createObjectURLSpy.mock.calls[0][0] as Blob;
+      // Real timers are needed for FileReader, which is asynchronous.
+      jest.useRealTimers();
+      const bytes = await readBlobBytes(blobArg);
+
+      // Asserted at byte level, not as a decoded string: UTF-8 decoding strips a leading BOM, so a
+      // string-level assertion would pass against the unfixed code too.
+      expect([...bytes.slice(0, 3)]).toEqual([0xef, 0xbb, 0xbf]);
+      // "für" must still be the precomposed two-byte c3 bc — the BOM is the only change.
+      expect(new TextDecoder('utf-8').decode(bytes.slice(3))).toBe(csvText);
+      expect(blobArg.type).toBe('text/csv;charset=utf-8');
+    });
+  });
+});

--- a/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.spec.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.spec.ts
@@ -22,6 +22,7 @@ describe('ResourceMetadataComponent', () => {
   let component: ResourceMetadataComponent;
   let fixture: ComponentFixture<ResourceMetadataComponent>;
   let mockV2ApiService: jest.Mocked<Pick<APIV2ApiService, 'getV2MetadataProjectsProjectshortcodeResources'>>;
+  let createElementSpy: jest.SpyInstance;
   let createObjectURLSpy: jest.SpyInstance;
 
   const shortcode = '0810';
@@ -33,12 +34,20 @@ describe('ResourceMetadataComponent', () => {
     jest.advanceTimersByTime(1000);
   };
 
+  const lastAnchor = () =>
+    createElementSpy.mock.results
+      .map(result => result.value as HTMLElement)
+      .filter((element): element is HTMLAnchorElement => element instanceof HTMLAnchorElement)
+      .pop()!;
+
   beforeEach(async () => {
     jest.useFakeTimers();
 
     mockV2ApiService = {
       getV2MetadataProjectsProjectshortcodeResources: jest.fn().mockReturnValue(of(csvText)),
     } as any;
+
+    createElementSpy = jest.spyOn(document, 'createElement');
 
     if (!window.URL.createObjectURL) window.URL.createObjectURL = jest.fn();
     if (!window.URL.revokeObjectURL) window.URL.revokeObjectURL = jest.fn();
@@ -67,6 +76,14 @@ describe('ResourceMetadataComponent', () => {
   });
 
   describe('exportMetadata', () => {
+    // DEV-6987: the filename was built without any extension, so the download did not open as a
+    // spreadsheet at all.
+    it('names the downloaded file with a .csv extension', () => {
+      runDownload();
+
+      expect(lastAnchor().download).toBe(`project_${shortcode}_metadata.csv`);
+    });
+
     // DEV-6987: without the BOM, Excel/Numbers on macOS decode the file as Mac OS Roman and render
     // "für" as "f√ºr". The BOM is the only thing that tells them the file is UTF-8.
     it('prefixes the CSV with a UTF-8 BOM so spreadsheet apps decode non-ASCII correctly', async () => {

--- a/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
@@ -94,7 +94,7 @@ export class ResourceMetadataComponent implements OnDestroy {
     const isJson = format.toLowerCase() === 'json';
     const body = isJson ? response : UTF8_BOM + response;
     const blob = new Blob([body], { type: this._getMimeType(format) });
-    const filename = `project_${shortcode}_metadata`;
+    const filename = `project_${shortcode}_metadata.${this._getFileExtension(format)}`;
 
     const link = document.createElement('a');
     link.href = window.URL.createObjectURL(blob);
@@ -115,6 +115,19 @@ export class ResourceMetadataComponent implements OnDestroy {
         return 'application/json';
       default:
         return 'text/plain;charset=utf-8';
+    }
+  }
+
+  private _getFileExtension(format: string): string {
+    switch (format.toLowerCase()) {
+      case 'csv':
+        return 'csv';
+      case 'tsv':
+        return 'tsv';
+      case 'json':
+        return 'json';
+      default:
+        return 'txt';
     }
   }
 

--- a/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
@@ -9,6 +9,9 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, finalize, Subject, switchMap, takeUntil } from 'rxjs';
 import { ProjectPageService } from '../../project-page.service';
 
+// U+FEFF, encoded by Blob as the three-byte UTF-8 BOM (ef bb bf).
+const UTF8_BOM = '\uFEFF';
+
 @Component({
   selector: 'app-resource-metadata',
   templateUrl: './resource-metadata.component.html',
@@ -52,7 +55,6 @@ export class ResourceMetadataComponent implements OnDestroy {
   private _getResourceMetadata(shortcode: string, format: ExportFormat) {
     this.isDownloadingFile = true;
 
-    const mimeType = this._getMimeType(format);
     const classIris: string[] | undefined = undefined;
 
     this._v2ApiService
@@ -72,7 +74,7 @@ export class ResourceMetadataComponent implements OnDestroy {
             this._translateService.instant('pages.project.resourceMetadata.downloadSuccess', { shortcode })
           );
           setTimeout(() => {
-            this._handleDownload(response, shortcode, mimeType);
+            this._handleDownload(response, shortcode, format);
           }, 1000);
         },
         error => {
@@ -86,8 +88,12 @@ export class ResourceMetadataComponent implements OnDestroy {
       );
   }
 
-  private _handleDownload(response: string, shortcode: string, mimeType: string): void {
-    const blob = new Blob([response], { type: mimeType });
+  private _handleDownload(response: string, shortcode: string, format: ExportFormat): void {
+    // Excel and Numbers on macOS do not auto-detect UTF-8 without a byte-order mark and fall back
+    // to Mac OS Roman, rendering "für" as "f√ºr". JSON is excluded: a BOM breaks strict parsers.
+    const isJson = format.toLowerCase() === 'json';
+    const body = isJson ? response : UTF8_BOM + response;
+    const blob = new Blob([body], { type: this._getMimeType(format) });
     const filename = `project_${shortcode}_metadata`;
 
     const link = document.createElement('a');
@@ -102,13 +108,13 @@ export class ResourceMetadataComponent implements OnDestroy {
   private _getMimeType(format: string): string {
     switch (format.toLowerCase()) {
       case 'csv':
-        return 'text/csv';
+        return 'text/csv;charset=utf-8';
       case 'tsv':
-        return 'text/tab-separated-values';
+        return 'text/tab-separated-values;charset=utf-8';
       case 'json':
         return 'application/json';
       default:
-        return 'text/plain';
+        return 'text/plain;charset=utf-8';
     }
   }
 

--- a/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
@@ -4,6 +4,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { APIV2ApiService, ExportFormat } from '@dasch-swiss/vre/3rd-party-services/open-api';
 import { AppError } from '@dasch-swiss/vre/core/error-handler';
 import { AccessTokenService } from '@dasch-swiss/vre/core/session';
+import { triggerBlobDownload } from '@dasch-swiss/vre/shared/app-common';
 import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, finalize, Subject, switchMap, takeUntil } from 'rxjs';
@@ -96,13 +97,7 @@ export class ResourceMetadataComponent implements OnDestroy {
     const blob = new Blob([body], { type: this._getMimeType(format) });
     const filename = `project_${shortcode}_metadata.${this._getFileExtension(format)}`;
 
-    const link = document.createElement('a');
-    link.href = window.URL.createObjectURL(blob);
-    link.download = filename;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    window.URL.revokeObjectURL(link.href);
+    triggerBlobDownload(blob, filename);
   }
 
   private _getMimeType(format: string): string {

--- a/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
+++ b/libs/vre/pages/project/project/src/lib/project-settings/resource-metadata/resource-metadata.component.ts
@@ -114,13 +114,12 @@ export class ResourceMetadataComponent implements OnDestroy {
   }
 
   private _getFileExtension(format: string): string {
-    switch (format.toLowerCase()) {
+    const extension = format.toLocaleLowerCase();
+    switch (extension) {
       case 'csv':
-        return 'csv';
       case 'tsv':
-        return 'tsv';
       case 'json':
-        return 'json';
+        return extension;
       default:
         return 'txt';
     }

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/representation.service.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/representation.service.ts
@@ -4,6 +4,7 @@ import { ReadDocumentFileValue } from '@dasch-swiss/dsp-js';
 import { ProjectApiService } from '@dasch-swiss/vre/3rd-party-services/api';
 import { AppConfigService } from '@dasch-swiss/vre/core/config';
 import { AccessTokenService, UserService } from '@dasch-swiss/vre/core/session';
+import { triggerBlobDownload } from '@dasch-swiss/vre/shared/app-common';
 import { map, Observable, take } from 'rxjs';
 import { FileRepresentationInput, ParentResourceInput } from './representation-inputs';
 import { ResourceUtil } from './resource.util';
@@ -98,11 +99,7 @@ export class RepresentationService {
           fileName = url.split('/').pop()!;
         }
 
-        const a = document.createElement('a');
-        a.href = window.URL.createObjectURL(res.body!);
-        a.download = fileName;
-        a.click();
-        window.URL.revokeObjectURL(a.href);
+        triggerBlobDownload(res.body!, fileName);
       });
   }
 }

--- a/libs/vre/shared/app-common/src/index.ts
+++ b/libs/vre/shared/app-common/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/resource.service';
 export * from './lib/custom-regex';
+export * from './lib/download-file';
 export * from './lib/dsp-resource';
 export * from './lib/property-info-values.interface';
 export * from './lib/generateProperty';

--- a/libs/vre/shared/app-common/src/lib/download-file.spec.ts
+++ b/libs/vre/shared/app-common/src/lib/download-file.spec.ts
@@ -1,0 +1,39 @@
+import { triggerBlobDownload } from './download-file';
+
+describe('triggerBlobDownload', () => {
+  let clickSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // jsdom throws "Not implemented: navigation" on a real anchor click.
+    clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    if (!window.URL.createObjectURL) window.URL.createObjectURL = jest.fn();
+    if (!window.URL.revokeObjectURL) window.URL.revokeObjectURL = jest.fn();
+    jest.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    jest.spyOn(window.URL, 'revokeObjectURL').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('clicks an anchor pointing at the blob, named with the given filename', () => {
+    const blob = new Blob(['a,b\n1,2\n'], { type: 'text/csv;charset=utf-8' });
+
+    triggerBlobDownload(blob, 'export.csv');
+
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(anchor.download).toBe('export.csv');
+    expect(anchor.href).toBe('blob:mock-url');
+  });
+
+  it('revokes the object URL and leaves no anchor behind', () => {
+    triggerBlobDownload(new Blob(['x']), 'export.csv');
+
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    expect(document.body.querySelector('a')).toBeNull();
+  });
+});

--- a/libs/vre/shared/app-common/src/lib/download-file.ts
+++ b/libs/vre/shared/app-common/src/lib/download-file.ts
@@ -1,0 +1,17 @@
+/**
+ * Hands a blob to the browser as a file download under the given name.
+ *
+ * Encoding concerns stay with the caller: which MIME type to declare, and whether the content needs
+ * a UTF-8 BOM, are per-format decisions (see DEV-6987) rather than download mechanics.
+ */
+export const triggerBlobDownload = (blob: Blob, filename: string): void => {
+  const link = document.createElement('a');
+  link.href = window.URL.createObjectURL(blob);
+  link.download = filename;
+  // The anchor is attached to the document before the click and removed after, which is what the
+  // CSV export call sites have always done.
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(link.href);
+};


### PR DESCRIPTION
[DEV-6987](https://linear.app/dasch/issue/DEV-6987)

## Summary

- Both client-side CSV writers built their blob without a UTF-8 BOM, so Excel and Numbers on macOS fell back to the legacy Mac OS Roman codepage: `Museum für Kommunikation` rendered as `Museum f√ºr Kommunikation`. The data in DSP was always correct — only the file lacked the mark saying how to read it.
- The resource-metadata export additionally named its download with **no file extension at all**, so it did not open as a spreadsheet even once the encoding was right.
- The anchor-click download block was duplicated a third time; it is now a single shared helper.

`Blob` already encodes JS strings as UTF-8, so prepending U+FEFF is the only byte-level change: `ef bb bf` in front of otherwise-identical bytes.

## Changes

**1. BOM** — `fix(project): prepend UTF-8 BOM to downloaded CSV exports`
- `download-dialog-resources-tab.component.ts` — Data Browser → Download CSV
- `resource-metadata.component.ts` — Project settings → resource metadata export
- Both blob types now declare `charset=utf-8`
- The metadata export also serves TSV and JSON; the BOM is added for the text-table formats only — it breaks strict JSON parsers

**2. Filename** — `fix(project): add the missing file extension to the metadata export`
- `project_<shortcode>_metadata` → `project_<shortcode>_metadata.csv`
- The extension is derived from the export format, mirroring the existing `_getMimeType` switch, so TSV and JSON are named correctly too rather than hardcoding `.csv` for the one format the UI currently requests

**3. Helper** — `refactor(shared): extract the blob-download anchor block into a helper`
- New `triggerBlobDownload(blob, filename)` in `libs/vre/shared/app-common`, replacing three copies of the same anchor-click block. The copies had already drifted: the two CSV sites attached the anchor to `document.body` before clicking and removed it after, the binary download in `representation.service.ts` did not. The append/remove version becomes the single implementation.
- `app-common` is the right home: the only shared lib both consuming libs already depend on (92 imports from `resource-editor`, 12 from `pages/project/project`), so no new dependency edge, and it already holds framework-free utilities like `handle-xml.ts`.
- Encoding stays at the call sites — MIME type and BOM are per-format decisions, not download mechanics. `representation.service.ts` had **no encoding defect**: it streams `res.body` from the server with `responseType: 'blob'` and never builds a Blob, so there is no charset decision and a BOM would corrupt binary files.

**Accepted trade-off:** a BOM surfaces as a stray U+FEFF in the first header cell for consumers that read the file as plain `utf-8` rather than `utf-8-sig`. For a human-facing download button, spreadsheet compatibility wins.

## Test Plan

Every new test was verified to **fail against the unfixed/unrefactored code** and pass after.

- `nx run-many --target=test` for `vre-pages-project-project`, `vre-resource-editor-resource-editor`, `vre-shared-app-common` → **588 passing / 1 skipped**
- `nx run-many --target=lint` for the same three → clean; `prettier --check` clean
- `nx run dsp-app:build --skip-nx-cache` → bundle generation complete

New coverage:
- `download-dialog-resources-tab.component.spec.ts` — non-ASCII fixture (`für` / `Genève` / `Mähr`); asserts the first three bytes are `ef bb bf` and that the remainder decodes back to the exact input, so `für` is still the precomposed `c3 bc`. The existing `blobArg.type` assertion was updated alongside.
- `resource-metadata.component.spec.ts` (new file — this component had no spec) — same byte-level BOM assertion, plus the download filename ending in `.csv`.
- `download-file.spec.ts` (new) — the helper points the anchor at the blob's object URL, names it, clicks once, revokes the URL and leaves no anchor in the DOM. Mutation-checked: removing `download`, `removeChild` or `revokeObjectURL` fails it.

BOM assertions are made at **byte** level via `FileReader`, deliberately not through a decoded string: UTF-8 decoding strips a leading BOM, so a string-level assertion would have passed against the unfixed code too. (jsdom's `Blob` implements neither `arrayBuffer()` nor `text()`, hence `FileReader`.)

## Notes

- The stray U+00A0 before `</p>` in the DaSCHCon 2025 descriptions in project `0810` is a genuine data artifact (paste-from-Word) and renders as an ordinary space once the encoding is right. Not a code fix.
- Unrelated to this PR, worth a check on a German/Swiss-locale Excel: a BOM fixes decoding, not delimiters — a comma-delimited `.csv` can still land in a single column, since Excel uses the system list separator.