### PR TITLE
fix: show "Placeholder" in the legal overlay and stop its license column colliding into the other rows

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -766,7 +766,8 @@
     "legal": {
       "copyrightHolder": "Urheberrechtsinhaber",
       "authorship": "Autorenschaft",
-      "license": "Lizenz"
+      "license": "Lizenz",
+      "placeholder": "Platzhalter"
     },
     "navigation": {
       "firstPage": "Erste Seite",

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -568,7 +568,8 @@
     "legal": {
       "copyrightHolder": "Copyright holder",
       "authorship": "Authorship",
-      "license": "License"
+      "license": "License",
+      "placeholder": "Placeholder"
     },
     "navigation": {
       "firstPage": "First page",

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -568,7 +568,8 @@
     "legal": {
       "copyrightHolder": "Titulaire des droits d'auteur",
       "authorship": "Auteur·ice",
-      "license": "Licence"
+      "license": "Licence",
+      "placeholder": "Espace réservé"
     },
     "navigation": {
       "firstPage": "Première page",

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -568,7 +568,8 @@
     "legal": {
       "copyrightHolder": "Titolare del copyright",
       "authorship": "Autore",
-      "license": "Licenza"
+      "license": "Licenza",
+      "placeholder": "Segnaposto"
     },
     "navigation": {
       "firstPage": "Prima pagina",

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/template-switcher/viewer-components/region-preview-viewer.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/template-switcher/viewer-components/region-preview-viewer.component.spec.ts
@@ -4,6 +4,7 @@ import { AdminAPIApiService } from '@dasch-swiss/vre/3rd-party-services/open-api
 import { ResourceService } from '@dasch-swiss/vre/shared/app-common';
 import { provideTranslateService } from '@ngx-translate/core';
 import { of, throwError } from 'rxjs';
+import { PLACEHOLDER_FILE_SENTINEL } from '../../../../representation/is-placeholder-file-value';
 import { RepresentationService } from '../../../../representation/representation.service';
 import { ResourceFetcherService } from '../../../../representation/resource-fetcher.service';
 import { RegionPreviewViewerComponent } from './region-preview-viewer.component';
@@ -60,6 +61,85 @@ describe('RegionPreviewViewerComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(RegionPreviewViewerComponent);
+  });
+
+  // DEV-6982: dsp-tools writes the sentinel into the legal fields when the real legal info is not
+  // known yet; the overlay must show the readable marker, never the raw URN.
+  describe('placeholder legal values', () => {
+    const placeholderValue = () =>
+      ({
+        ...(fullValue() as unknown as Record<string, unknown>),
+        copyrightHolder: PLACEHOLDER_FILE_SENTINEL,
+        authorship: [PLACEHOLDER_FILE_SENTINEL],
+        license: { id: PLACEHOLDER_FILE_SENTINEL },
+      }) as unknown as ReadRegionPreviewValue;
+
+    const withPlaceholderLicenseAvailable = async () => {
+      // The component resolves the license IRI against the project license list, so the placeholder
+      // license must be present there for the license row to render at all.
+      TestBed.resetTestingModule();
+      URL.createObjectURL = jest.fn().mockReturnValue('blob:mock');
+      URL.revokeObjectURL = jest.fn();
+      await TestBed.configureTestingModule({
+        imports: [RegionPreviewViewerComponent],
+        providers: [
+          provideTranslateService(),
+          { provide: ResourceService, useValue: { getResourcePath: jest.fn().mockReturnValue('/project/0001/img') } },
+          { provide: RepresentationService, useValue: { getImageBlob: jest.fn().mockReturnValue(of(new Blob())) } },
+          { provide: ResourceFetcherService, useValue: { projectShortcode$: of('0001') } },
+          {
+            provide: AdminAPIApiService,
+            useValue: {
+              getAdminProjectsShortcodeProjectshortcodeLegalInfoLicenses: jest.fn().mockReturnValue(
+                of({
+                  data: [
+                    {
+                      id: PLACEHOLDER_FILE_SENTINEL,
+                      uri: PLACEHOLDER_FILE_SENTINEL,
+                      labelEn:
+                        'Placeholder License - Not a Real License only to be used when the real license is not known yet.',
+                    },
+                  ],
+                })
+              ),
+            },
+          },
+        ],
+      }).compileComponents();
+      fixture = TestBed.createComponent(RegionPreviewViewerComponent);
+      fixture.componentRef.setInput('value', placeholderValue());
+      fixture.detectChanges();
+    };
+
+    it('never renders the raw sentinel for copyright holder or authorship', () => {
+      setValue(placeholderValue());
+      const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+      expect(text).not.toContain(PLACEHOLDER_FILE_SENTINEL);
+      // The i18n key resolves to itself with no loaded bundle, which is how we know the marker was used.
+      expect(text).toContain('resourceEditor.legal.placeholder');
+    });
+
+    it('renders the placeholder license as a non-link pill, since its uri is not dereferenceable', async () => {
+      await withPlaceholderLicenseAvailable();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const staticPill = el.querySelector('span.license-pill');
+      expect(staticPill).not.toBeNull();
+      expect(staticPill!.classList).toContain('license-pill--static');
+      // No anchor may point at the sentinel.
+      expect(el.querySelector(`a[href="${PLACEHOLDER_FILE_SENTINEL}"]`)).toBeNull();
+      expect(el.textContent).not.toContain('Not a Real License');
+    });
+
+    it('keeps real legal values untouched', () => {
+      setValue(fullValue());
+      const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+      expect(text).toContain('DaSCH');
+      expect(text).toContain('Ada Lovelace');
+      expect(text).not.toContain('resourceEditor.legal.placeholder');
+    });
   });
 
   it('highlights the region by lightening + desaturating the surroundings and revealing the region window', () => {

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/template-switcher/viewer-components/region-preview-viewer.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/template-switcher/viewer-components/region-preview-viewer.component.ts
@@ -11,16 +11,17 @@ import { MatIconModule } from '@angular/material/icon';
 import type { ReadRegionPreviewValue } from '@dasch-swiss/dsp-js';
 import { AdminAPIApiService, ProjectLicenseDto } from '@dasch-swiss/vre/3rd-party-services/open-api';
 import { ResourceService } from '@dasch-swiss/vre/shared/app-common';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { forkJoin, Subscription, switchMap, take } from 'rxjs';
 // Direct relative imports (NOT the lib barrel) for same-lib components to avoid the intra-lib DI cycle.
 import { AlertInfoComponent } from '../../../../header/alert-info.component';
-import { isPlaceholderLegalValue } from '../../../../representation/is-placeholder-file-value';
+import {
+  isPlaceholderLegalValue,
+  joinPlaceholderLegalValues,
+} from '../../../../representation/is-placeholder-file-value';
 import { RepresentationService } from '../../../../representation/representation.service';
 import { ResourceFetcherService } from '../../../../representation/resource-fetcher.service';
 import { ResourceExplorerButtonComponent } from '../../../resource-explorer-button.component';
-
-const PLACEHOLDER_LABEL_KEY = 'resourceEditor.legal.placeholder';
 
 /**
  * Renders a RegionPreviewValue: the region crop image, the full-page thumbnail with the region
@@ -108,15 +109,24 @@ const PLACEHOLDER_LABEL_KEY = 'resourceEditor.legal.placeholder';
           }
           @if (value.authorship?.length) {
             <span class="legal-label">{{ 'resourceEditor.legal.authorship' | translate }}</span>
-            <span class="legal-value">{{ authorship }}</span>
+            <span class="legal-value">{{ authorshipWith('resourceEditor.legal.placeholder' | translate) }}</span>
           }
           @if (resolvedLicense) {
             <span class="legal-label">{{ 'resourceEditor.legal.license' | translate }}</span>
             <span class="legal-value">
               @if (isPlaceholder(resolvedLicense.id)) {
-                <span class="license-pill">{{ 'resourceEditor.legal.placeholder' | translate }}</span>
+                <span class="license-pill license-pill--static">{{
+                  'resourceEditor.legal.placeholder' | translate
+                }}</span>
               } @else {
-                <a class="license-pill" [href]="resolvedLicense.uri" target="_blank">{{ resolvedLicense.labelEn }}</a>
+                <a
+                  class="license-pill"
+                  [href]="resolvedLicense.uri"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  [attr.aria-label]="resolvedLicense.labelEn + ', ' + ('legal.dataSide.opensInNewTab' | translate)"
+                  >{{ resolvedLicense.labelEn }}</a
+                >
               }
             </span>
           }
@@ -285,10 +295,24 @@ const PLACEHOLDER_LABEL_KEY = 'resourceEditor.legal.placeholder';
         padding: 0;
       }
 
+      /* Non-interactive variant (placeholder): same geometry, but no link affordance — otherwise it
+         is pixel-identical to the clickable pill. */
+      .license-pill--static {
+        cursor: default;
+      }
+
+      /* Interactive variant: hover feedback distinguishes it from the static placeholder pill. */
+      a.license-pill:hover {
+        border-color: #336790;
+        color: #336790;
+      }
+
       .license-pill {
         display: inline-flex;
         align-items: center;
-        border: 1px solid #9ca3af;
+        /* #6b7280 on #f9fafb is 4.6:1, clearing the 3:1 non-text contrast bar (WCAG 1.4.11) that
+           the previous #9ca3af border missed at 2.4:1. */
+        border: 1px solid #6b7280;
         border-radius: 3px;
         padding: 0 6px;
         font-weight: 600;
@@ -317,8 +341,7 @@ export class RegionPreviewViewerComponent implements OnChanges, OnDestroy, OnIni
     private readonly _adminApiService: AdminAPIApiService,
     private readonly _resourceFetcher: ResourceFetcherService,
     private readonly _representationService: RepresentationService,
-    private readonly _cd: ChangeDetectorRef,
-    private readonly _translate: TranslateService
+    private readonly _cd: ChangeDetectorRef
   ) {}
 
   ngOnChanges() {
@@ -391,12 +414,11 @@ export class RegionPreviewViewerComponent implements OnChanges, OnDestroy, OnIni
   // Placeholder-aware predicate used by the legal rows; a plain function reference, stable under OnPush.
   readonly isPlaceholder = isPlaceholderLegalValue;
 
-  // Returns a primitive (value-equal across CD passes) → safe under OnPush. Placeholder entries are
-  // translated to the readable marker; the sentinel is per-entry, so a mixed list is handled too.
-  get authorship(): string {
-    return (this.value.authorship ?? [])
-      .map(author => (isPlaceholderLegalValue(author) ? this._translate.instant(PLACEHOLDER_LABEL_KEY) : author))
-      .join(', ');
+  // Returns a primitive (value-equal across CD passes) → safe under OnPush. The placeholder label
+  // arrives already translated from the template's `| translate` pipe, so this component needs no
+  // TranslateService injection.
+  authorshipWith(placeholderLabel: string): string {
+    return joinPlaceholderLegalValues(this.value.authorship, placeholderLabel);
   }
 
   // These getters return primitives (value-equal across CD passes) → safe under OnPush.

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/template-switcher/viewer-components/region-preview-viewer.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/template-switcher/viewer-components/region-preview-viewer.component.ts
@@ -11,13 +11,16 @@ import { MatIconModule } from '@angular/material/icon';
 import type { ReadRegionPreviewValue } from '@dasch-swiss/dsp-js';
 import { AdminAPIApiService, ProjectLicenseDto } from '@dasch-swiss/vre/3rd-party-services/open-api';
 import { ResourceService } from '@dasch-swiss/vre/shared/app-common';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { forkJoin, Subscription, switchMap, take } from 'rxjs';
 // Direct relative imports (NOT the lib barrel) for same-lib components to avoid the intra-lib DI cycle.
 import { AlertInfoComponent } from '../../../../header/alert-info.component';
+import { isPlaceholderLegalValue } from '../../../../representation/is-placeholder-file-value';
 import { RepresentationService } from '../../../../representation/representation.service';
 import { ResourceFetcherService } from '../../../../representation/resource-fetcher.service';
 import { ResourceExplorerButtonComponent } from '../../../resource-explorer-button.component';
+
+const PLACEHOLDER_LABEL_KEY = 'resourceEditor.legal.placeholder';
 
 /**
  * Renders a RegionPreviewValue: the region crop image, the full-page thumbnail with the region
@@ -91,18 +94,30 @@ import { ResourceExplorerButtonComponent } from '../../../resource-explorer-butt
             <app-resource-explorer-button [resourceIri]="value.regionIri" />
           </span>
 
+          <!-- Placeholder legal values render as the readable marker, and the placeholder license as a
+               plain pill: its uri is the sentinel itself and is not dereferenceable (DEV-6982). -->
           @if (value.copyrightHolder) {
             <span class="legal-label">{{ 'resourceEditor.legal.copyrightHolder' | translate }}</span>
-            <span class="legal-value">{{ value.copyrightHolder }}</span>
+            <span class="legal-value">
+              @if (isPlaceholder(value.copyrightHolder)) {
+                {{ 'resourceEditor.legal.placeholder' | translate }}
+              } @else {
+                {{ value.copyrightHolder }}
+              }
+            </span>
           }
           @if (value.authorship?.length) {
             <span class="legal-label">{{ 'resourceEditor.legal.authorship' | translate }}</span>
-            <span class="legal-value">{{ value.authorship.join(', ') }}</span>
+            <span class="legal-value">{{ authorship }}</span>
           }
           @if (resolvedLicense) {
             <span class="legal-label">{{ 'resourceEditor.legal.license' | translate }}</span>
             <span class="legal-value">
-              <a class="license-pill" [href]="resolvedLicense.uri" target="_blank">{{ resolvedLicense.labelEn }}</a>
+              @if (isPlaceholder(resolvedLicense.id)) {
+                <span class="license-pill">{{ 'resourceEditor.legal.placeholder' | translate }}</span>
+              } @else {
+                <a class="license-pill" [href]="resolvedLicense.uri" target="_blank">{{ resolvedLicense.labelEn }}</a>
+              }
             </span>
           }
         </div>
@@ -302,7 +317,8 @@ export class RegionPreviewViewerComponent implements OnChanges, OnDestroy, OnIni
     private readonly _adminApiService: AdminAPIApiService,
     private readonly _resourceFetcher: ResourceFetcherService,
     private readonly _representationService: RepresentationService,
-    private readonly _cd: ChangeDetectorRef
+    private readonly _cd: ChangeDetectorRef,
+    private readonly _translate: TranslateService
   ) {}
 
   ngOnChanges() {
@@ -370,6 +386,17 @@ export class RegionPreviewViewerComponent implements OnChanges, OnDestroy, OnIni
   // Returns a stable DTO reference (value-equal across CD passes) → safe under OnPush.
   get resolvedLicense() {
     return this._licenses.find(license => license.id === this.value.license?.id);
+  }
+
+  // Placeholder-aware predicate used by the legal rows; a plain function reference, stable under OnPush.
+  readonly isPlaceholder = isPlaceholderLegalValue;
+
+  // Returns a primitive (value-equal across CD passes) → safe under OnPush. Placeholder entries are
+  // translated to the readable marker; the sentinel is per-entry, so a mixed list is handled too.
+  get authorship(): string {
+    return (this.value.authorship ?? [])
+      .map(author => (isPlaceholderLegalValue(author) ? this._translate.instant(PLACEHOLDER_LABEL_KEY) : author))
+      .join(', ');
   }
 
   // These getters return primitives (value-equal across CD passes) → safe under OnPush.

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.spec.ts
@@ -2,6 +2,7 @@ import { ReadFileValue } from '@dasch-swiss/dsp-js';
 import {
   isPlaceholderFileValue,
   isPlaceholderLegalValue,
+  joinPlaceholderLegalValues,
   PLACEHOLDER_FILE_SENTINEL,
 } from './is-placeholder-file-value';
 
@@ -44,5 +45,27 @@ describe('isPlaceholderLegalValue', () => {
     expect(isPlaceholderLegalValue(null)).toBe(false);
     expect(isPlaceholderLegalValue(undefined)).toBe(false);
     expect(isPlaceholderLegalValue('')).toBe(false);
+  });
+});
+
+describe('joinPlaceholderLegalValues', () => {
+  it('substitutes the label for the sentinel and keeps real names', () => {
+    expect(joinPlaceholderLegalValues(['Ada Lovelace', PLACEHOLDER_FILE_SENTINEL], 'Placeholder')).toBe(
+      'Ada Lovelace, Placeholder'
+    );
+  });
+
+  it('joins with ", " so the separator lands in the text (copy/paste and screen readers)', () => {
+    expect(joinPlaceholderLegalValues(['A', 'B', 'C'], 'Placeholder')).toBe('A, B, C');
+  });
+
+  it('uses the label given, so a translated marker flows through', () => {
+    expect(joinPlaceholderLegalValues([PLACEHOLDER_FILE_SENTINEL], 'Platzhalter')).toBe('Platzhalter');
+  });
+
+  it('returns an empty string for an empty, null or undefined list', () => {
+    expect(joinPlaceholderLegalValues([], 'Placeholder')).toBe('');
+    expect(joinPlaceholderLegalValues(null, 'Placeholder')).toBe('');
+    expect(joinPlaceholderLegalValues(undefined, 'Placeholder')).toBe('');
   });
 });

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.spec.ts
@@ -1,5 +1,9 @@
 import { ReadFileValue } from '@dasch-swiss/dsp-js';
-import { isPlaceholderFileValue, PLACEHOLDER_FILE_SENTINEL } from './is-placeholder-file-value';
+import {
+  isPlaceholderFileValue,
+  isPlaceholderLegalValue,
+  PLACEHOLDER_FILE_SENTINEL,
+} from './is-placeholder-file-value';
 
 describe('isPlaceholderFileValue', () => {
   const fileValueWith = (filename: string): ReadFileValue => ({ filename }) as ReadFileValue;
@@ -19,5 +23,26 @@ describe('isPlaceholderFileValue', () => {
   it('returns false for null or undefined', () => {
     expect(isPlaceholderFileValue(null)).toBe(false);
     expect(isPlaceholderFileValue(undefined)).toBe(false);
+  });
+});
+
+describe('isPlaceholderLegalValue', () => {
+  it('returns true for the placeholder sentinel', () => {
+    expect(isPlaceholderLegalValue(PLACEHOLDER_FILE_SENTINEL)).toBe(true);
+  });
+
+  it('returns false for a real copyright holder, author or license IRI', () => {
+    expect(isPlaceholderLegalValue('University of Basel')).toBe(false);
+    expect(isPlaceholderLegalValue('http://rdfh.ch/licenses/cc-by-4.0')).toBe(false);
+  });
+
+  it('returns false when the value merely contains the sentinel as a substring', () => {
+    expect(isPlaceholderLegalValue(`${PLACEHOLDER_FILE_SENTINEL} (pending)`)).toBe(false);
+  });
+
+  it('returns false for null, undefined or an empty string', () => {
+    expect(isPlaceholderLegalValue(null)).toBe(false);
+    expect(isPlaceholderLegalValue(undefined)).toBe(false);
+    expect(isPlaceholderLegalValue('')).toBe(false);
   });
 });

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.ts
@@ -14,3 +14,15 @@ export const PLACEHOLDER_FILE_SENTINEL = 'urn:dasch:placeholder';
 export function isPlaceholderFileValue(fileValue: ReadFileValue | null | undefined): boolean {
   return fileValue?.filename === PLACEHOLDER_FILE_SENTINEL;
 }
+
+/**
+ * Returns `true` when a legal value (copyright holder, a single authorship entry, or a license IRI)
+ * is the placeholder sentinel.
+ *
+ * Separate from `isPlaceholderFileValue`, which inspects only `filename`: dsp-api writes the same
+ * literal into `internalFilename`, `copyrightHolder`, `authorship` and `licenseIri` independently, so
+ * a real asset can still carry placeholder legal info (and vice versa). See DEV-6982.
+ */
+export function isPlaceholderLegalValue(value: string | null | undefined): boolean {
+  return value === PLACEHOLDER_FILE_SENTINEL;
+}

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/is-placeholder-file-value.ts
@@ -26,3 +26,15 @@ export function isPlaceholderFileValue(fileValue: ReadFileValue | null | undefin
 export function isPlaceholderLegalValue(value: string | null | undefined): boolean {
   return value === PLACEHOLDER_FILE_SENTINEL;
 }
+
+/**
+ * Joins a legal value list (e.g. authorship) into a display string, replacing any placeholder
+ * sentinel with `placeholderLabel`.
+ *
+ * `placeholderLabel` is passed in already translated so callers resolve it with the `| translate`
+ * pipe in their template — the repo's dominant convention for rendered text — instead of injecting
+ * `TranslateService` just to call `.instant()` during change detection. See DEV-6982.
+ */
+export function joinPlaceholderLegalValues(values: string[] | null | undefined, placeholderLabel: string): string {
+  return (values ?? []).map(value => (isPlaceholderLegalValue(value) ? placeholderLabel : value)).join(', ');
+}

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.stories.ts
@@ -17,6 +17,14 @@ const unknownLicense = {
   labelDe: 'Eigene Lizenz',
 };
 
+// The sentinel is both id and uri, so the uri is not dereferenceable. See DEV-6982.
+const placeholderLicense = {
+  id: 'urn:dasch:placeholder',
+  labelEn: 'Placeholder License - Not a Real License only to be used when the real license is not known yet.',
+  uri: 'urn:dasch:placeholder',
+  labelDe: 'Platzhalter-Lizenz',
+};
+
 const meta: Meta<ResourceLegalLicenseComponent> = {
   title: 'Resource Editor / 3. Representation / Legal / Resource Legal License',
   component: ResourceLegalLicenseComponent,
@@ -51,6 +59,23 @@ export const WithTextLicense: Story = {
     await step('Open in new icon is shown', async () => {
       const icon = canvasElement.querySelector('mat-icon');
       await expect(icon?.textContent?.trim()).toBe('open_in_new');
+    });
+  },
+};
+
+export const WithPlaceholderLicense: Story = {
+  name: 'Shows "Placeholder" as plain text with no dead link',
+  args: { license: placeholderLicense as any },
+  play: async ({ canvasElement, step }) => {
+    await step('No link is rendered, since the sentinel uri is not dereferenceable', async () => {
+      await expect(canvasElement.querySelector('a')).toBeNull();
+    });
+    await step('No open_in_new icon is shown', async () => {
+      await expect(canvasElement.querySelector('mat-icon')).toBeNull();
+    });
+    await step('The readable marker replaces the prose label', async () => {
+      await expect(canvasElement.textContent).toContain('Placeholder');
+      await expect(canvasElement.textContent).not.toContain('Not a Real License');
     });
   },
 };

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.stories.ts
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/angular';
 import { expect } from 'storybook/test';
 
+import { PLACEHOLDER_FILE_SENTINEL } from './is-placeholder-file-value';
 import { ResourceLegalLicenseComponent } from './resource-legal-license.component';
 
 const ccByLicense = {
@@ -19,9 +20,9 @@ const unknownLicense = {
 
 // The sentinel is both id and uri, so the uri is not dereferenceable. See DEV-6982.
 const placeholderLicense = {
-  id: 'urn:dasch:placeholder',
+  id: PLACEHOLDER_FILE_SENTINEL,
   labelEn: 'Placeholder License - Not a Real License only to be used when the real license is not known yet.',
-  uri: 'urn:dasch:placeholder',
+  uri: PLACEHOLDER_FILE_SENTINEL,
   labelDe: 'Platzhalter-Lizenz',
 };
 

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.ts
@@ -1,27 +1,53 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { ProjectLicenseDto } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { TranslatePipe } from '@ngx-translate/core';
 import { LicensesLogoMapping } from '../licenses-logo-mapping';
+import { isPlaceholderLegalValue } from './is-placeholder-file-value';
 
 @Component({
   selector: 'app-resource-legal-license',
   template: `
-    @if (licenseLogo) {
+    @if (isPlaceholder) {
+      <!-- The placeholder license's uri is the sentinel itself, which is not dereferenceable — render
+           the readable marker as plain text, with no link and no open_in_new icon (DEV-6982). -->
+      <span>{{ 'resourceEditor.legal.placeholder' | translate }}</span>
+    } @else if (licenseLogo) {
       <a [href]="license.uri" target="_blank"><img [src]="licenseLogo" alt="license" style="width: 110px" /></a>
     } @else {
-      <a style="display: flex; align-items: center; color: white" [href]="license.uri" target="_blank">
-        <span style="color: white">{{ license.labelEn }} </span>
-        <mat-icon style="font-size: 18px">open_in_new</mat-icon>
+      <!-- Inline (not flex) so a wrapped label keeps the icon right after its last word instead of
+           pushing it out to the far right as a flex sibling (DEV-6983). -->
+      <a class="license-link" [href]="license.uri" target="_blank">
+        <span>{{ license.labelEn }} </span>
+        <mat-icon class="license-icon">open_in_new</mat-icon>
       </a>
     }
   `,
-  imports: [MatIconModule],
+  styles: [
+    `
+      .license-link {
+        color: white;
+      }
+
+      .license-icon {
+        font-size: 18px;
+        width: 18px;
+        height: 18px;
+        /* Inline with the label text, so it trails the last wrapped line. */
+        display: inline;
+        vertical-align: middle;
+      }
+    `,
+  ],
+  imports: [MatIconModule, TranslatePipe],
 })
 export class ResourceLegalLicenseComponent implements OnChanges {
   @Input({ required: true }) license!: ProjectLicenseDto;
   licenseLogo?: string;
+  isPlaceholder = false;
 
   ngOnChanges() {
     this.licenseLogo = LicensesLogoMapping.get(this.license.id) ?? undefined;
+    this.isPlaceholder = isPlaceholderLegalValue(this.license.id);
   }
 }

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal-license.component.ts
@@ -13,13 +13,24 @@ import { isPlaceholderLegalValue } from './is-placeholder-file-value';
            the readable marker as plain text, with no link and no open_in_new icon (DEV-6982). -->
       <span>{{ 'resourceEditor.legal.placeholder' | translate }}</span>
     } @else if (licenseLogo) {
-      <a [href]="license.uri" target="_blank"><img [src]="licenseLogo" alt="license" style="width: 110px" /></a>
+      <a
+        [href]="license.uri"
+        target="_blank"
+        rel="noopener noreferrer"
+        [attr.aria-label]="license.labelEn + ', ' + ('legal.dataSide.opensInNewTab' | translate)"
+        ><img [src]="licenseLogo" [alt]="license.labelEn" style="width: 110px"
+      /></a>
     } @else {
       <!-- Inline (not flex) so a wrapped label keeps the icon right after its last word instead of
            pushing it out to the far right as a flex sibling (DEV-6983). -->
-      <a class="license-link" [href]="license.uri" target="_blank">
+      <a
+        class="license-link"
+        [href]="license.uri"
+        target="_blank"
+        rel="noopener noreferrer"
+        [attr.aria-label]="license.labelEn + ', ' + ('legal.dataSide.opensInNewTab' | translate)">
         <span>{{ license.labelEn }} </span>
-        <mat-icon class="license-icon">open_in_new</mat-icon>
+        <mat-icon class="license-icon" aria-hidden="true">open_in_new</mat-icon>
       </a>
     }
   `,

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReadFileValue } from '@dasch-swiss/dsp-js';
+import { AdminAPIApiService } from '@dasch-swiss/vre/3rd-party-services/open-api';
+import { provideTranslateService, TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { PLACEHOLDER_FILE_SENTINEL } from './is-placeholder-file-value';
+import { ResourceFetcherService } from './resource-fetcher.service';
+import { ResourceLegalComponent } from './resource-legal.component';
+
+describe('ResourceLegalComponent placeholder rendering (DEV-6982)', () => {
+  let fixture: ComponentFixture<ResourceLegalComponent>;
+  let translate: TranslateService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResourceLegalComponent],
+      providers: [
+        provideTranslateService(),
+        { provide: ResourceFetcherService, useValue: { projectShortcode$: of('0001') } },
+        {
+          provide: AdminAPIApiService,
+          useValue: {
+            getAdminProjectsShortcodeProjectshortcodeLegalInfoLicenses: () => of({ data: [] }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    translate = TestBed.inject(TranslateService);
+    translate.setTranslation('en', {
+      resourceEditor: {
+        legal: {
+          copyrightHolder: 'Copyright holder',
+          authorship: 'Authorship',
+          license: 'License',
+          placeholder: 'Placeholder',
+        },
+      },
+    });
+    translate.setTranslation('de', {
+      resourceEditor: {
+        legal: {
+          copyrightHolder: 'Urheberrechtsinhaber',
+          authorship: 'Autorenschaft',
+          license: 'Lizenz',
+          placeholder: 'Platzhalter',
+        },
+      },
+    });
+    translate.use('en');
+
+    fixture = TestBed.createComponent(ResourceLegalComponent);
+    fixture.componentRef.setInput('fileValue', {
+      copyrightHolder: PLACEHOLDER_FILE_SENTINEL,
+      authorship: ['Ada Lovelace', PLACEHOLDER_FILE_SENTINEL],
+      license: null,
+    } as unknown as ReadFileValue);
+    fixture.detectChanges();
+  });
+
+  const text = () => (fixture.nativeElement as HTMLElement).textContent!.replace(/\s+/g, ' ').trim();
+
+  it('joins authorship with ", " in the real text node (copy/paste + screen readers)', () => {
+    expect(text()).toContain('Ada Lovelace, Placeholder');
+    expect(text()).not.toContain('Ada LovelacePlaceholder');
+  });
+
+  // Guards that the marker is translated (not a hardcoded string or a raw key) and follows the
+  // active language, rather than proving any particular change-detection behaviour.
+  it('renders the marker in the active language', () => {
+    expect(text()).toContain('Placeholder');
+
+    translate.use('de');
+    fixture.detectChanges();
+
+    expect(text()).toContain('Platzhalter');
+    expect(text()).toContain('Ada Lovelace, Platzhalter');
+    expect(text()).not.toContain('Placeholder');
+  });
+});

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.stories.ts
@@ -3,11 +3,11 @@ import { applicationConfig, type Meta, type StoryObj } from '@storybook/angular'
 import { of } from 'rxjs';
 import { expect } from 'storybook/test';
 
+import { PLACEHOLDER_FILE_SENTINEL } from './is-placeholder-file-value';
 import { ResourceFetcherService } from './resource-fetcher.service';
 import { ResourceLegalComponent } from './resource-legal.component';
 
 const LONG_LICENSE_ID = 'http://rdfh.ch/licenses/ai-generated';
-const PLACEHOLDER_SENTINEL = 'urn:dasch:placeholder';
 
 const makeLicenses = () => [
   {
@@ -26,9 +26,9 @@ const makeLicenses = () => [
   },
   {
     // The sentinel is both id and uri, and the label is a 96-char sentence. See DEV-6982.
-    id: PLACEHOLDER_SENTINEL,
+    id: PLACEHOLDER_FILE_SENTINEL,
     labelEn: 'Placeholder License - Not a Real License only to be used when the real license is not known yet.',
-    uri: PLACEHOLDER_SENTINEL,
+    uri: PLACEHOLDER_FILE_SENTINEL,
     labelDe: 'Platzhalter-Lizenz',
   },
 ];
@@ -124,14 +124,14 @@ export const WithPlaceholderValues: Story = {
   name: 'Shows "Placeholder" instead of the raw sentinel, with no dead link',
   args: {
     fileValue: makeFileValue({
-      copyrightHolder: PLACEHOLDER_SENTINEL,
-      authorship: [PLACEHOLDER_SENTINEL],
-      license: { id: PLACEHOLDER_SENTINEL },
+      copyrightHolder: PLACEHOLDER_FILE_SENTINEL,
+      authorship: [PLACEHOLDER_FILE_SENTINEL],
+      license: { id: PLACEHOLDER_FILE_SENTINEL },
     }),
   },
   play: async ({ canvasElement, step }) => {
     await step('The raw sentinel is never shown', async () => {
-      await expect(canvasElement.textContent).not.toContain(PLACEHOLDER_SENTINEL);
+      await expect(canvasElement.textContent).not.toContain(PLACEHOLDER_FILE_SENTINEL);
     });
     await step('The placeholder license prose sentence is not shown', async () => {
       await expect(canvasElement.textContent).not.toContain('Not a Real License');

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.stories.ts
@@ -6,12 +6,30 @@ import { expect } from 'storybook/test';
 import { ResourceFetcherService } from './resource-fetcher.service';
 import { ResourceLegalComponent } from './resource-legal.component';
 
+const LONG_LICENSE_ID = 'http://rdfh.ch/licenses/ai-generated';
+const PLACEHOLDER_SENTINEL = 'urn:dasch:placeholder';
+
 const makeLicenses = () => [
   {
     id: 'http://example.org/custom-license',
     labelEn: 'Custom License',
     uri: 'https://example.org/license',
     labelDe: 'Eigene Lizenz',
+  },
+  {
+    // A real built-in label (49 chars) — long enough to have collided into the rows beside it before
+    // the grid layout landed. See DEV-6983.
+    id: LONG_LICENSE_ID,
+    labelEn: 'AI-Generated Content - Not Protected by Copyright',
+    uri: 'http://rdfh.ch/licenses/ai-generated',
+    labelDe: 'KI-generierter Inhalt - nicht urheberrechtlich geschützt',
+  },
+  {
+    // The sentinel is both id and uri, and the label is a 96-char sentence. See DEV-6982.
+    id: PLACEHOLDER_SENTINEL,
+    labelEn: 'Placeholder License - Not a Real License only to be used when the real license is not known yet.',
+    uri: PLACEHOLDER_SENTINEL,
+    labelDe: 'Platzhalter-Lizenz',
   },
 ];
 
@@ -73,6 +91,57 @@ export const WithoutLegalInfo: Story = {
   play: async ({ canvasElement, step }) => {
     await step('No legal block is rendered', async () => {
       await expect(canvasElement.textContent?.trim()).toBe('');
+    });
+  },
+};
+
+export const WithLongLicenseLabel: Story = {
+  name: 'Keeps a long license label inside its own column',
+  args: {
+    fileValue: makeFileValue({
+      copyrightHolder: 'University of Basel',
+      authorship: ['Lotte Reiniger', 'Hilma af Klint'],
+      license: { id: LONG_LICENSE_ID },
+    }),
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('All three values are rendered', async () => {
+      await expect(canvasElement.textContent).toContain('University of Basel');
+      await expect(canvasElement.textContent).toContain('Lotte Reiniger');
+      await expect(canvasElement.textContent).toContain('AI-Generated Content');
+    });
+    await step('The license row is labelled, like the other two', async () => {
+      await expect(canvasElement.textContent).toContain('License');
+    });
+    await step('The copyright holder value is not fused into the license text', async () => {
+      // The defect rendered "University of BaselAI-Generated…" as one run-on string.
+      await expect(canvasElement.textContent).not.toContain('University of BaselAI-Generated');
+    });
+  },
+};
+
+export const WithPlaceholderValues: Story = {
+  name: 'Shows "Placeholder" instead of the raw sentinel, with no dead link',
+  args: {
+    fileValue: makeFileValue({
+      copyrightHolder: PLACEHOLDER_SENTINEL,
+      authorship: [PLACEHOLDER_SENTINEL],
+      license: { id: PLACEHOLDER_SENTINEL },
+    }),
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('The raw sentinel is never shown', async () => {
+      await expect(canvasElement.textContent).not.toContain(PLACEHOLDER_SENTINEL);
+    });
+    await step('The placeholder license prose sentence is not shown', async () => {
+      await expect(canvasElement.textContent).not.toContain('Not a Real License');
+      await expect(canvasElement.textContent).not.toContain('is not known yet');
+    });
+    await step('The readable marker is shown instead', async () => {
+      await expect(canvasElement.textContent).toContain('Placeholder');
+    });
+    await step('The placeholder license renders without a link', async () => {
+      await expect(canvasElement.querySelector('a')).toBeNull();
     });
   },
 };

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.ts
@@ -2,13 +2,11 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ReadFileValue } from '@dasch-swiss/dsp-js';
 import { AdminAPIApiService, ProjectLicenseDto } from '@dasch-swiss/vre/3rd-party-services/open-api';
 import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { switchMap, take } from 'rxjs';
-import { isPlaceholderLegalValue } from './is-placeholder-file-value';
+import { isPlaceholderLegalValue, joinPlaceholderLegalValues } from './is-placeholder-file-value';
 import { ResourceFetcherService } from './resource-fetcher.service';
 import { ResourceLegalLicenseComponent } from './resource-legal-license.component';
-
-const PLACEHOLDER_LABEL_KEY = 'resourceEditor.legal.placeholder';
 
 @Component({
   selector: 'app-resource-legal',
@@ -31,8 +29,7 @@ const PLACEHOLDER_LABEL_KEY = 'resourceEditor.legal.placeholder';
           }
           @if (fileValue.authorship.length > 0) {
             <span class="label">{{ 'resourceEditor.legal.authorship' | translate }}</span>
-            <!-- Joined in the component so the separator cannot pick up stray template whitespace. -->
-            <span class="value">{{ authorship }}</span>
+            <span class="value">{{ authorshipWith('resourceEditor.legal.placeholder' | translate) }}</span>
           }
           @if (license) {
             <span class="label">{{ 'resourceEditor.legal.license' | translate }}</span>
@@ -105,18 +102,22 @@ export class ResourceLegalComponent implements OnInit {
     return isPlaceholderLegalValue(this.fileValue.copyrightHolder);
   }
 
-  /** Placeholder entries are replaced by the readable marker; the sentinel is per-entry, so a mixed
-   *  list is handled too. */
-  get authorship(): string {
-    return this.fileValue.authorship
-      .map(author => (isPlaceholderLegalValue(author) ? this._translate.instant(PLACEHOLDER_LABEL_KEY) : author))
-      .join(', ');
+  /**
+   * Joins the authorship entries, substituting `placeholderLabel` for any placeholder sentinel.
+   *
+   * The label arrives already translated from the `| translate` pipe in the template, so this
+   * component needs no `TranslateService` — matching how the repo renders text elsewhere. Joining
+   * here (rather than with a CSS `::before` separator) keeps the ", " in a real text node, so
+   * copy/paste and screen readers get it. The sentinel is per-entry, so a mixed list works too.
+   * See DEV-6982.
+   */
+  authorshipWith(placeholderLabel: string): string {
+    return joinPlaceholderLegalValues(this.fileValue.authorship, placeholderLabel);
   }
 
   constructor(
     private readonly _adminApiService: AdminAPIApiService,
-    private readonly _resourceFetcher: ResourceFetcherService,
-    private readonly _translate: TranslateService
+    private readonly _resourceFetcher: ResourceFetcherService
   ) {}
 
   ngOnInit() {

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/resource-legal.component.ts
@@ -2,51 +2,89 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ReadFileValue } from '@dasch-swiss/dsp-js';
 import { AdminAPIApiService, ProjectLicenseDto } from '@dasch-swiss/vre/3rd-party-services/open-api';
 import { AppProgressIndicatorComponent } from '@dasch-swiss/vre/ui/progress-indicator';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { switchMap, take } from 'rxjs';
+import { isPlaceholderLegalValue } from './is-placeholder-file-value';
 import { ResourceFetcherService } from './resource-fetcher.service';
 import { ResourceLegalLicenseComponent } from './resource-legal-license.component';
+
+const PLACEHOLDER_LABEL_KEY = 'resourceEditor.legal.placeholder';
 
 @Component({
   selector: 'app-resource-legal',
   template: `
     @if (fileValue.copyrightHolder || fileValue.authorship?.length > 0 || fileValue.license) {
-      <div
-        class="mat-caption"
-        style="border: 1px solid #292929; text-align: left;
-    background: #292929; border-radius: 8px;
-    color: #e4e9ed; padding: 8px; padding-bottom: 16px; margin-top: 8px; position: relative; top: 12px">
-        <div style="display: flex; justify-content: space-between">
-          <div>
-            @if (fileValue.copyrightHolder) {
-              <div>
-                <span class="label">{{ 'resourceEditor.legal.copyrightHolder' | translate }}</span
-                >{{ fileValue.copyrightHolder }}
-              </div>
-            }
-            @if (fileValue.authorship.length > 0) {
-              <div style="display: flex">
-                <span class="label">{{ 'resourceEditor.legal.authorship' | translate }}</span>
-                <div style="max-width: 400px">
-                  @for (author of fileValue.authorship; track author; let last = $last) {
-                    <span>{{ author }}{{ last ? '' : ', ' }}</span>
-                  }
-                </div>
-              </div>
-            }
-          </div>
-          <div style="display: flex; justify-content: flex-end; align-items: center">
-            @if (license) {
+      <div class="legal-panel mat-caption">
+        <!-- One label/value grid so all three values align in a single column and each wraps inside
+             its own column. A two-child "space-between" flex row had no gap and no width bound on the
+             license, so a long label fused into the rows beside it (DEV-6983). -->
+        <div class="meta-grid">
+          @if (fileValue.copyrightHolder) {
+            <span class="label">{{ 'resourceEditor.legal.copyrightHolder' | translate }}</span>
+            <span class="value">
+              @if (isPlaceholderCopyrightHolder) {
+                {{ 'resourceEditor.legal.placeholder' | translate }}
+              } @else {
+                {{ fileValue.copyrightHolder }}
+              }
+            </span>
+          }
+          @if (fileValue.authorship.length > 0) {
+            <span class="label">{{ 'resourceEditor.legal.authorship' | translate }}</span>
+            <!-- Joined in the component so the separator cannot pick up stray template whitespace. -->
+            <span class="value">{{ authorship }}</span>
+          }
+          @if (license) {
+            <span class="label">{{ 'resourceEditor.legal.license' | translate }}</span>
+            <span class="value">
               <app-resource-legal-license [license]="license" />
-            } @else if (isLoadingLicense) {
-              <app-progress-indicator [compact]="true" size="xsmall" />
-            }
-          </div>
+            </span>
+          } @else if (isLoadingLicense) {
+            <span class="label">{{ 'resourceEditor.legal.license' | translate }}</span>
+            <span class="value"><app-progress-indicator [compact]="true" size="xsmall" /></span>
+          }
         </div>
       </div>
     }
   `,
-  styles: ['.label { display: inline-block; width: 170px; font-weight: bold}'],
+  styles: [
+    `
+      .legal-panel {
+        border: 1px solid #292929;
+        text-align: left;
+        background: #292929;
+        border-radius: 8px;
+        color: #e4e9ed;
+        padding: 8px;
+        padding-bottom: 16px;
+        margin-top: 8px;
+        position: relative;
+        top: 12px;
+      }
+
+      /* Same pattern as region-preview-viewer's .meta-grid: labels size to content, values take the
+         rest and wrap within their own column. */
+      .meta-grid {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        column-gap: 20px;
+        row-gap: 5px;
+        /* Values may wrap to several lines — align them to the top of the row, not centred against a
+           single-line label. */
+        align-items: start;
+      }
+
+      .label {
+        font-weight: bold;
+      }
+
+      .value {
+        /* Let a long value wrap inside the column instead of forcing the grid wider. */
+        min-width: 0;
+        overflow-wrap: break-word;
+      }
+    `,
+  ],
   imports: [TranslatePipe, ResourceLegalLicenseComponent, AppProgressIndicatorComponent],
 })
 export class ResourceLegalComponent implements OnInit {
@@ -59,9 +97,26 @@ export class ResourceLegalComponent implements OnInit {
     return this.licenses.find(license => license.id === this.fileValue.license?.id);
   }
 
+  /**
+   * dsp-tools writes the placeholder sentinel into the legal fields when the real legal info is not
+   * known yet. Show the readable marker rather than the raw URN (DEV-6982).
+   */
+  get isPlaceholderCopyrightHolder(): boolean {
+    return isPlaceholderLegalValue(this.fileValue.copyrightHolder);
+  }
+
+  /** Placeholder entries are replaced by the readable marker; the sentinel is per-entry, so a mixed
+   *  list is handled too. */
+  get authorship(): string {
+    return this.fileValue.authorship
+      .map(author => (isPlaceholderLegalValue(author) ? this._translate.instant(PLACEHOLDER_LABEL_KEY) : author))
+      .join(', ');
+  }
+
   constructor(
     private readonly _adminApiService: AdminAPIApiService,
-    private readonly _resourceFetcher: ResourceFetcherService
+    private readonly _resourceFetcher: ResourceFetcherService,
+    private readonly _translate: TranslateService
   ) {}
 
   ngOnInit() {


### PR DESCRIPTION
Fixes [DEV-6982](https://linear.app/dasch/issue/DEV-6982/legal-overlay-shows-raw-urndaschplaceholder-instead-of-placeholder) and [DEV-6983](https://linear.app/dasch/issue/DEV-6983/legal-overlay-unlabelled-license-column-collides-into). Both land in the same component, so they are fixed together rather than in two conflicting PRs.

## DEV-6983 — the license column collided into the other rows

`resource-legal.component.ts` laid the panel out as a two-child `justify-content: space-between` flex row. Four defects compounded: no `gap`, no width bound on the license column, `align-items: center` vertically centring wrapped license lines against the two left-hand rows, and no label on the license row while the other two had one. Any license label over roughly 40 characters therefore interleaved into the values beside it and read as one run-on sentence.

This reproduces on ordinary data, independent of placeholders — the built-in `AI-Generated Content - Not Protected by Copyright` is 49 characters. Of the live built-in licenses, every label is ≤53 characters except the placeholder at 96.

Replaced with the `meta-grid` pattern already used by `region-preview-viewer.component.ts` (`grid-template-columns: auto 1fr`), and added the `resourceEditor.legal.license` label — which already existed in all four locales and was simply unused here. The `open_in_new` icon is now inline rather than a flex sibling, so it trails the last wrapped word instead of floating to the far right.

Before / after, at a narrow width so the label wraps:

```
Urheberrechtsinhaber   urn:dasch:placeholderPlaceholder License - Not a Real License only to be used when
Autorenschaft          urn:dasch:placeholderthe real license is not known yet.                        ↗
```

```
Copyright holder   University of Basel
Authorship         Lotte Reiniger, Hilma af Klint
License            AI-Generated Content - Not
                   Protected by Copyright ↗
```

`ResourceLegalComponent` feeds all ten representation viewers (archive, audio, audio-segment, compound, document, pdf, still-image, text, video, video-segment), so one fix covers them all.

## DEV-6982 — the raw sentinel was rendered

dsp-tools writes `urn:dasch:placeholder` into `copyrightHolder`, `authorship` and `licenseIri` when the real legal info is not known yet. dsp-app rendered the internal URN verbatim, plus the placeholder license's 96-character prose label behind a dead `<a href="urn:dasch:placeholder">` — the sentinel is both `id` and `uri`, and is not dereferenceable.

The existing `isPlaceholderFileValue()` could not be reused: it checks only `filename`, so it does not detect placeholder *legal* fields. Added `isPlaceholderLegalValue()` beside it, reusing the existing `PLACEHOLDER_FILE_SENTINEL`, and a `resourceEditor.legal.placeholder` key in en/de/fr/it — reusing this repo's established wording for "Placeholder" (Platzhalter / Espace réservé / Segnaposto) rather than inventing new terms. No `rm.json`: Romansh is bound to English by the fallback loader (DEV-6629).

Fixed in both renderers that read legal info from a file value: `resource-legal*` and `region-preview-viewer`.

## Scope: one listed file deliberately not changed

DEV-6982 also lists `libs/vre/ui/ui/src/lib/resource-rights-statement.component.ts`. I left it alone, and this is the one point reviewers pushed back on, so it is worth stating plainly.

Its license comes from the **project-level** `project.dataLicense` via `ProjectDataRightsService`, not from a file value, and the admin picker filters candidates to the `http://rdfh.ch/licenses/cc-by` prefix — so the sentinel cannot be selected through the UI. On the reproduction project `dataLicense` is `cc-by-4.0`. Covering it would also force `PLACEHOLDER_FILE_SENTINEL` into a shared lib, since `resource-editor` already imports `@dasch-swiss/vre/ui/ui` and the reverse import would create a dependency cycle.

**Caveat, tracked separately in [DEV-6994](https://linear.app/dasch/issue/DEV-6994/resource-rights-statement-renders-the-raw-placeholder-sentinel-project).** "Cannot reach it" was too strong. The vendored OpenAPI spec lists `urn:dasch:placeholder` as an *enabled* license, so `ProjectDataRightsService._resolve()` would resolve it if any non-UI path (API-direct write, import, migration) ever set `dataLicense` to the sentinel. Separately, `res.resourceAuthorship` — the data-side field, distinct from the file-value `authorship` fixed here — also renders unfiltered.

That follow-up is filed as **low priority**: placeholders are not possible on a productive environment (they occur only on test servers, where the affected display is internally visible to admins), so it is a correctness/consistency cleanup rather than a user-facing defect. The suggested fix there is a central filter in `_resolve()` — which also requires moving `PLACEHOLDER_FILE_SENTINEL` into a shared lib, since `resource-editor` already imports `@dasch-swiss/vre/ui/ui` and the reverse import would cycle.

## Verification

- 29 projects lint clean; 395 unit tests pass (uncached); production build clean under strict template typechecking
- 7 Storybook interaction tests pass, including three new stories
- Verified in the browser at a narrow width: the license wraps inside its own column, stays aligned with the values above, and the `↗` trails the last word

New coverage: a long-license-label story (the fixture gap that let DEV-6983 ship — the longest existing fixture was `University of Basel`), placeholder stories for both legal components, `region-preview-viewer` placeholder cases, and direct tests for the new helpers. The region-preview cases were checked by mutation: breaking the predicate fails two of the three.

## From the review pass

- **Accessibility.** Added `rel="noopener noreferrer"` and an `opens in a new tab` aria-label to both license links, matching the existing pattern in `resource-rights-statement.component.ts` (the `legal.dataSide.opensInNewTab` key already existed in all four locales). Gave the logo-variant link a meaningful accessible name (`[alt]="license.labelEn"` rather than `alt="license"`). Raised the `.license-pill` border to `#6b7280` on `#f9fafb`: 2.4:1 → 4.6:1, clearing the 3:1 non-text contrast bar. Distinguished the non-interactive placeholder pill from the clickable one — they were pixel-identical.
- **Translate in the template.** `joinPlaceholderLegalValues` now takes an already-translated label resolved by `| translate`, so both components drop their `TranslateService` injection and a duplicated key constant. Reviewers flagged the previous component-side `.instant()` as a latent stale-language bug under OnPush; **I could not reproduce that** — in a test harness neither form updates without a change-detection pass, and the language switcher is a click handler, so a pass always follows. The refactor is kept for the smaller API surface and convention fit, not as a bug fix, and the comments say so.
- **Caught while verifying.** An intermediate CSS `::before` separator rendered the comma visually but omitted it from `textContent`, so copy/paste and screen readers saw `Lotte ReinigerHilma af Klint`. Joining in the component keeps the separator in a real text node.

## Note for reviewers

The repo requires Node `^22.13.0` (`.nvmrc` pins 22.23.1). On Node 20 the OpenAPI generator fails with an ESM error and Storybook dies on a native-binding error. `nvm use 22.18` or later is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

