### PR TITLE
docs: drop /latest segment from docs.dasch.swiss links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ Stories are auto-discovered from any `*.stories.ts` file under `libs/` or `apps/
 
 ## Issues & Contributions
 
-- [Developer docs](https://docs.dasch.swiss/latest/DSP-APP/contribution)
+- [Developer docs](https://docs.dasch.swiss/DSP-APP/contribution)
 
 To report an issue or contribute, contact us at [support@dasch.swiss](mailto:support@dasch.swiss).

--- a/docs/contribution/docs-documentation.md
+++ b/docs/contribution/docs-documentation.md
@@ -1,7 +1,7 @@
 # DSP-APP Documentation
 
 This is the DSP-APP documentation, based on [MkDocs](https://www.mkdocs.org) and published
-under [https://docs.dasch.swiss/latest/DSP-APP/](https://docs.dasch.swiss/latest/DSP-APP/).
+under [https://docs.dasch.swiss/DSP-APP/](https://docs.dasch.swiss/DSP-APP/).
 
 Images like screenshots and so on have to be stored in `assets/images`.
 


### PR DESCRIPTION
## Summary
- Drop the `/latest` segment from `docs.dasch.swiss` links now that the docs site is a single flat, unversioned site (`/latest/...` still resolves via a permanent compat shim, but new references shouldn't emit it).
- Updated `README.md` and `docs/contribution/docs-documentation.md`.
- Left `libs/vre/3rd-party-services/open-api/dsp-api_spec.yaml` untouched: it's curl'd wholesale from the live dsp-api dev server via `npm run update-openapi`, the `/latest` links there originate in dsp-api's own endpoint annotations (already fixed upstream), and the next automated resync will pick up the fix on its own.

Resolves [DEV-6965](https://linear.app/dasch/issue/DEV-6965/stop-emitting-docsdaschswisslatest-links-from-dsp-app).

## Test plan
- [x] `grep -rn "docs.dasch.swiss/latest" .` (excluding the vendored OpenAPI spec) returns no results
- [x] Visually confirmed both edited links render correctly in the Markdown files