### PR TITLE
chore(deps): cap @swc/core at the @jscutlery/swc-angular peer range

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -180,6 +180,11 @@
       "enabled": false
     },
     {
+      "description": "@swc/core: capped at ~1.15.x by @jscutlery/swc-angular@0.22.0 (frozen above; latest published), which declares peer @swc/core ~1.15.0 — a tilde range accepting patches only. Its companion @jscutlery/swc-angular-plugin ships a compiled WASM swc plugin, loaded via swcAngularJestTransformer in jest.preset.js on every unit-test run, so the narrow range is the author's ABI contract rather than conservatism: overriding the peer would break the jest transform, not just the install. Any minor bump therefore makes npm lock regeneration fail with ERESOLVE — Renovate produces no lock, the PR carries a package.json change alone, and every npm ci in CI fails with EUSAGE (#3346). Lift this cap only together with a @jscutlery/swc-angular release that widens its peer range, and set allowedVersions to that new range verbatim. Only @swc/core needs the cap: @swc/helpers, @swc/jest and @swc-node/register are not peer-constrained by swc-angular, and the @swc/core-* platform binaries are lock-only.",
+      "matchPackageNames": ["@swc/core"],
+      "allowedVersions": "~1.15.0"
+    },
+    {
       "description": "Angular-coupled ecosystem: major version must align with Angular major — upgrade only after ng update",
       "matchPackageNames": [
         "rxjs",


### PR DESCRIPTION
## Problem

[#3346](https://github.com/dasch-swiss/dsp-app/pull/3346) (`@swc/core` 1.15.47 → 1.16.0) is red on all six npm-dependent jobs and cannot be merged. It is not flaky — the update is structurally impossible today.

`@jscutlery/swc-angular@0.22.0` declares `peer @swc/core: "~1.15.0"` — a tilde on the **minor**, so patches only. The existing rules disable `@swc/*` **majors**, so Renovate was free to propose the 1.16.0 **minor**:

1. Renovate bumps `package.json` to `@swc/core@1.16.0`.
2. Lock regeneration hard-fails — `ERESOLVE … peer @swc/core@"~1.15.0" from @jscutlery/swc-angular@0.22.0`.
3. `renovate/artifacts` reports "Artifact file update failure", so the PR carries **`package.json` alone, no `package-lock.json`**.
4. All six red jobs die identically in *Install dependencies* with `npm error code EUSAGE — lock file's @swc/core@1.15.47 does not satisfy @swc/core@1.16.0`. Lint, unit, Storybook and all three E2E jobs are one failure, not six.

`0.22.0` is the latest published `@jscutlery/swc-angular` — nothing accepts `~1.16` — and it is frozen in this config (`enabled: false`), so Renovate cannot lift the ceiling itself. Every merged `@swc/core` bump since the transformer was adopted in #2906 was a `1.15.x` patch (`1.15.18` → `1.15.47`); #3346 is the first attempt to leave the range.

Unrelated to #3343: that branch is rebased on top of #3350 (lock file maintenance), which merged green with `jsdom` holding at 28.1.0. The two share only a failure *shape* — `renovate/artifacts` red → no lock → `npm ci` EUSAGE — not a cause.

## Fix

Cap `@swc/core` with `allowedVersions` set to the upstream peer range verbatim, co-located with the existing `@jscutlery/swc-angular` freeze. `1.15.x` patches keep flowing and automerging as before; 1.16+ is filtered before a PR is opened.

`allowedVersions` rather than `matchUpdateTypes: ["minor"], enabled: false` because the value *is* the peer range — when a `@jscutlery/swc-angular` release widens it, there is exactly one string to change and it is obvious what to change it to.

Scope: only `@swc/core` is constrained. `@swc/helpers`, `@swc/jest` and `@swc-node/register` are not peer-constrained by swc-angular, and the `@swc/core-*` platform binaries are lock-only — all stay in the `swc-deps` group and move normally.

## Why not override the peer

`--legacy-peer-deps` or an `overrides` entry would trade a red install for a broken test transform. `@jscutlery/swc-angular-plugin@0.22.0` ships a compiled `wasm32-wasip1/release/swc_angular_plugin.wasm`, loaded via `swcAngularJestTransformer` in `jest.preset.js:2` on every unit-test run. swc versions its WASM plugin ABI against `swc_core`, which is why the range is a tilde and not a caret.

## Verification

- `renovate.json` parses; exactly one rule matches `@swc/core`.
- `~1.15.0` resolves to `>=1.15.0 <1.16.0`, so 1.15.47 (current) and future 1.15.x patches pass the filter while 1.16.0 does not.
- Config-only change — no lock, no dependency and no production code touched.
- Prettier already reports `renovate.json` as unformatted on `main` (pre-existing, long single-line `matchPackageNames` arrays in the webpack rules) and CI is green there, so it is not gated; formatting deliberately left untouched to keep the diff to five lines.

No fix-confirmation test applies: this is Renovate configuration, and the confirmation is that no further `@swc/core` minor PR is opened.

## After merge

Close #3346 and delete `renovate/swc-deps`. Renovate would auto-close it once 1.16.0 is filtered, but doing it by hand is worth it now — `prConcurrentLimit` is `2`, so a permanently-red PR burns half the automated queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3346
