### PR TITLE
fix: let the mouse wheel scroll the resource page over media viewers

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/still-image/open-sea-dragon.service.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/still-image/open-sea-dragon.service.ts
@@ -26,6 +26,8 @@ export class OpenSeaDragonService {
 
   private _drawing = false;
 
+  private _wheelZoomEnabled = false;
+
   get drawing() {
     return this._drawing;
   }
@@ -57,6 +59,7 @@ export class OpenSeaDragonService {
 
     this._viewer = new OpenSeadragon.Viewer(viewerConfig);
     this._addCustomHandlers(this._viewer);
+    this._gateWheelZoomBehindInteraction(this._viewer);
   }
 
   toggleDrawing(): void {
@@ -89,6 +92,39 @@ export class OpenSeaDragonService {
 
   zoom(direction: 1 | -1) {
     this._viewer.viewport.zoomBy(1 + direction * this._ZOOM_FACTOR);
+  }
+
+  /**
+   * Keeps the wheel available to the resource page until the user actually works with the image.
+   *
+   * OpenSeadragon consumes every wheel event over its canvas in order to zoom, which left the
+   * resource page unscrollable by mouse whenever the pointer sat over the image (DEV-6998). A
+   * pointer press inside the viewer enables wheel zooming, a press anywhere else disables it again,
+   * so the zoom gesture itself is unchanged for anyone who is looking at the image.
+   *
+   * The wheel listener runs in the capture phase on the viewer's outer element so that
+   * `stopPropagation()` keeps the event away from OpenSeadragon's own listener on the inner canvas —
+   * and away from its scroll throttle, which calls `preventDefault()` on the events it skips and
+   * would otherwise make the page scroll stutter. The default action is deliberately left intact,
+   * because the default *is* the page scroll.
+   */
+  private _gateWheelZoomBehindInteraction(viewer: OpenSeadragon.Viewer): void {
+    const onPressOutside = (event: PointerEvent) => {
+      this._wheelZoomEnabled = viewer.element.contains(event.target as Node);
+    };
+    document.addEventListener('pointerdown', onPressOutside);
+    viewer.addOnceHandler('destroy', () => document.removeEventListener('pointerdown', onPressOutside));
+
+    viewer.element.addEventListener(
+      'wheel',
+      (event: WheelEvent) => {
+        // Fullscreen has no page left to scroll, so the wheel keeps zooming there unconditionally.
+        if (!this._wheelZoomEnabled && !viewer.isFullPage()) {
+          event.stopPropagation();
+        }
+      },
+      { capture: true }
+    );
   }
 
   private _addCustomHandlers(viewer: OpenSeadragon.Viewer): void {

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/vector-image/vector-image.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/vector-image/vector-image.component.spec.ts
@@ -240,6 +240,8 @@ describe('VectorImageComponent', () => {
   });
 
   describe('onWheel', () => {
+    const insideTarget = {};
+
     beforeEach(() => {
       // Mock containerRef
       component.containerRef = {
@@ -250,8 +252,20 @@ describe('VectorImageComponent', () => {
             left: 0,
             top: 0,
           }),
+          contains: (node: unknown) => node === insideTarget,
         },
       } as any;
+      // wheel zooming is gated behind a press inside the viewer
+      component.onDocumentPointerDown({ target: insideTarget } as unknown as PointerEvent);
+    });
+
+    it('should zoom in on wheel up', () => {
+      const zoomSpy = jest.spyOn(component.viewerService, 'zoom');
+      const event = new WheelEvent('wheel', { deltaY: -100 });
+
+      component.onWheel(event);
+
+      expect(zoomSpy).toHaveBeenCalledWith(1, expect.any(Number), expect.any(Number));
     });
 
     it('should zoom out on wheel down', () => {
@@ -263,11 +277,40 @@ describe('VectorImageComponent', () => {
       expect(zoomSpy).toHaveBeenCalledWith(-1, expect.any(Number), expect.any(Number));
     });
 
-    it('should zoom in on wheel up', () => {
-      const zoomSpy = jest.spyOn(component.viewerService, 'zoom');
-      const event = new WheelEvent('wheel', { deltaY: -100 });
+    it('should suppress the page scroll while it zooms', () => {
+      const event = new WheelEvent('wheel', { deltaY: -100, cancelable: true });
 
       component.onWheel(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should let the page scroll before the viewer has been pressed', () => {
+      component.onDocumentPointerDown({ target: {} } as unknown as PointerEvent);
+      const zoomSpy = jest.spyOn(component.viewerService, 'zoom');
+      const event = new WheelEvent('wheel', { deltaY: 100, cancelable: true });
+
+      component.onWheel(event);
+
+      expect(zoomSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('should stop zooming again once the press lands outside the viewer', () => {
+      component.onDocumentPointerDown({ target: {} } as unknown as PointerEvent);
+      const zoomSpy = jest.spyOn(component.viewerService, 'zoom');
+
+      component.onWheel(new WheelEvent('wheel', { deltaY: -100 }));
+
+      expect(zoomSpy).not.toHaveBeenCalled();
+    });
+
+    it('should zoom without a press while in fullscreen', () => {
+      component.onDocumentPointerDown({ target: {} } as unknown as PointerEvent);
+      component.isFullscreen = true;
+      const zoomSpy = jest.spyOn(component.viewerService, 'zoom');
+
+      component.onWheel(new WheelEvent('wheel', { deltaY: -100 }));
 
       expect(zoomSpy).toHaveBeenCalledWith(1, expect.any(Number), expect.any(Number));
     });

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/vector-image/vector-image.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/vector-image/vector-image.component.ts
@@ -122,6 +122,7 @@ export class VectorImageComponent implements OnChanges, AfterViewInit, OnDestroy
   private _lastTranslateY = 0;
   private _containerWidth = 0;
   private _containerHeight = 0;
+  private _wheelZoomEnabled = false;
   private readonly _destroyRef = inject(DestroyRef);
 
   constructor(
@@ -205,7 +206,23 @@ export class VectorImageComponent implements OnChanges, AfterViewInit, OnDestroy
     }
   }
 
+  /**
+   * Enables wheel zooming only once the user presses inside the viewer, and disables it again on a
+   * press anywhere else — the same gate the still image viewer applies, so that the wheel stays
+   * available to scroll the resource page while the pointer merely passes over the SVG (DEV-6998).
+   */
+  @HostListener('document:pointerdown', ['$event'])
+  onDocumentPointerDown(event: PointerEvent): void {
+    const container = this.containerRef?.nativeElement;
+    this._wheelZoomEnabled = !!container && container.contains(event.target as Node);
+  }
+
   onWheel(event: WheelEvent): void {
+    // Fullscreen has no page left to scroll, so the wheel keeps zooming there unconditionally.
+    if (!this._wheelZoomEnabled && !this.isFullscreen) {
+      return;
+    }
+
     event.preventDefault();
     if (!this.containerRef?.nativeElement) return;
     const direction = event.deltaY > 0 ? -1 : 1;


### PR DESCRIPTION
[DEV-6998](https://linear.app/dasch/issue/DEV-6998)

## Summary

Wheel zooming in the media viewers is gated behind an interaction: a pointer press inside the viewer enables it, a press anywhere else disables it again. The wheel gesture itself is unchanged for anyone working with the image — but the resource page can now be scrolled with the mouse while the pointer is merely passing over the media.

**No change to the zoom gesture, the zoom range, or any modifier key.**

## Root cause

`<body>` is the resource page's scroll element (no `height`/`overflow` in `styles.scss`) and the viewer fills most of the viewport (900px). OpenSeadragon registers a **non-passive** `wheel` listener on its canvas and calls `preventDefault()` on every wheel event to zoom — so with the pointer over the image the page could not be scrolled by mouse at all. Keyboard scrolling acts on the focused document, which is why it kept working. The SVG viewer reproduced the same trap with its own `preventDefault()`.

Measured on unfixed `main` (`app.dev.dasch.swiss`), **Firefox and Chrome alike**: `defaultPrevented: true`, `scrollY 0 → 0`.

### Corrections to the issue's analysis

- **`gestureSettingsMouse.scrollToZoom = false` would not have fixed it.** `onCanvasScroll` sets `preventDefault = true` independently of that flag, so the page still would not scroll — and wheel-zoom would be gone.
- **Not a regression from the OpenSeadragon v6 bump (#3073).** `onCanvasScroll` is byte-identical in 4.1.1, 5.0.1 and 6.0.2 — the behaviour predates it by years.
- **Not Firefox-specific.** Modern Firefox uses `wheel`, never the legacy `DOMMouseScroll` path; Chrome behaves identically. Stefan reported using Firefox *and* seeing no symptom, so Firefox was never the variable.

### Approaches rejected along the way

- **`cooperativeGestures: true`** (OSD 6.1.0) — works, but replaces wheel-zoom with Ctrl/Cmd+wheel for every user and project. An unrequested global UX change; rejected in review.
- **Zoom-limit passthrough** — pass the wheel to the page once zooming out further is impossible. Rejected after measuring the real app: it rests at zoom `0.5463` while `getHomeZoom()` is `0.5171` and `getMinZoom()` is `0.4654`, and zoom-out from rest genuinely works for three more ticks (`0.5463 → 0.4703 → 0.4657 → 0.4654`). Any correct threshold would have shrunk the image three times before the page moved. The premise "zooming out does nothing anyway" is false here, most likely because of `visibilityRatio: 1.0`.

## Changes

**Image viewer** — `open-sea-dragon.service.ts`: capture-phase `wheel` listener on `viewer.element`, gated on a `_wheelZoomEnabled` flag driven by a document-level `pointerdown`. Bypassed while `isFullPage()`. The document listener is removed on the viewer's `destroy` event, so it cannot leak across resource navigations.

Capture phase is deliberate: `stopPropagation()` keeps the event away from OpenSeadragon's listener on the inner canvas *and* from its `minScrollDeltaTime: 50` throttle, whose skipped-event branch calls `preventDefault()` unconditionally. Intercepting any later would suppress most of a wheel spin and make the page scroll stutter. The default action is untouched — the default *is* the page scroll.

**SVG viewer** — `vector-image.component.ts`: the same gate via a `document:pointerdown` host listener; fullscreen zooms unconditionally.

**PDF viewer** left alone — it never zoomed on wheel, only via its toolbar.

## Test plan

- `nx run vre-resource-editor-resource-editor:test` — 47 suites, 398 passed. `:lint` clean. `npm run build-prod` succeeds.
- **Fix-confirmation test**: a new case asserts that an unmodified wheel neither zooms nor calls `preventDefault()` before the viewer has been pressed — verified it **fails** against the unfixed handler. Plus cases for re-disabling on an outside press and for the fullscreen bypass.

### Browser verification — real app, dev API, Firefox and Chrome

| Check | Firefox | Chrome |
|---|---|---|
| 5 rapid wheel-down ticks scroll the page | PASS `0 → 600` | PASS `0 → 600` |
| gate intercepts before OpenSeadragon sees the events | PASS | PASS |
| wheel-**up** over the image scrolls the page back up | PASS `600 → 360` | PASS `600 → 360` |
| after pressing the image, wheel zooms and the page stays put | PASS | PASS |
| after pressing outside, the wheel scrolls the page again | PASS | PASS |

The full 600px for 5×120 is the smoothness evidence: nothing was throttled or suppressed.

## Known rough edges

- **No visual cue.** Someone used to wheel-zoom will wheel over the image and get a page scroll instead of a zoom. That is a sensible outcome rather than a dead gesture, and the toolbar zoom buttons are unaffected, but a cursor change or a brief hint may be wanted — happy to add it.
- **The toolbar sits outside `viewer.element`**, so clicking a toolbar zoom button disables wheel zooming until the image is pressed again. The buttons themselves keep working. Widening the activation region to the whole representation block would fix it at the cost of coupling the service to that element.
- **Touch** is unverified — no device available. The gate keys on `pointerdown`, so a tap or drag on the image activates it.

## Still open on the report

This fixes a real, longstanding, browser-independent trap, but it is **not confirmed** to be what Barbara reported: the behaviour is years old, while she describes it as recent. One question decides it, asked on the issue — *does the page scroll when the cursor is beside or below the image?* DEV-6998 should stay open until she answers, rather than being closed by this merge.
