### PR TITLE
fix(ck-editor): show the link balloon inside dialogs (DEV-6997)

### DIFF
--- a/libs/vre/ui/ui/src/lib/ck-editor/ck-editor.component.ts
+++ b/libs/vre/ui/ui/src/lib/ck-editor/ck-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, ReactiveFormsModule, ValidatorFn } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
@@ -27,7 +27,8 @@ const Editor = (EditorNs as EditorNamespace).default ?? EditorNs;
       [formControl]="footnoteControl"
       [config]="ckEditor.config"
       [editor]="editor"
-      style="margin-bottom: 22px; display: block;" />
+      style="margin-bottom: 22px; display: block;"
+      (ready)="onEditorReady()" />
     @if (control.touched && control.errors?.['crossProjectLink']; as error) {
       <mat-error>
         <div>{{ crossProjectLinkError.message | translate }}</div>
@@ -67,6 +68,39 @@ export class CkEditorComponent implements OnInit, OnDestroy {
 
   private readonly _destroy$ = new Subject<void>();
   private _crossProjectValidator?: ValidatorFn;
+
+  constructor(private readonly _elementRef: ElementRef<HTMLElement>) {}
+
+  /**
+   * CKEditor renders its floating UI (link balloon, dropdown panels) into a
+   * `.ck-body-wrapper` it appends to `document.body`. Since Angular CDK 21 a
+   * dialog is a `popover`, which the browser promotes to the *top layer* — it
+   * paints above all ordinary content no matter how high a z-index the balloon
+   * asks for. So inside a dialog the balloon opens and is positioned correctly
+   * but stays hidden behind the dialog, which is why the link button looked
+   * dead there while in-DOM toggles such as bold kept working (DEV-6997).
+   *
+   * Nothing can win against the top layer from the outside, so move the wrapper
+   * into the popover to put it in the same layer. CKEditor recreates the
+   * wrapper whenever it is no longer connected, so relocating it is safe.
+   *
+   * The popover itself is `pointer-events: none` — the CDK re-enables clicks on
+   * the pane inside it — so the relocated wrapper has to opt back in, otherwise
+   * the balloon is visible but its input and Save/Cancel buttons swallow no
+   * clicks.
+   */
+  onEditorReady() {
+    const popover = this._elementRef.nativeElement.closest('[popover]');
+    if (!popover) {
+      return;
+    }
+
+    const bodyWrapper = document.querySelector<HTMLElement>('.ck-body-wrapper');
+    if (bodyWrapper && !popover.contains(bodyWrapper)) {
+      bodyWrapper.style.pointerEvents = 'auto';
+      popover.appendChild(bodyWrapper);
+    }
+  }
 
   ngOnInit() {
     if (this.projectShortcode) {


### PR DESCRIPTION
Fixes [DEV-6997](https://linear.app/dasch/issue/DEV-6997/rich-text-editor-link-button-does-nothing-while-creating-a).

## Problem

In a rich-text field, the **link** button did nothing while creating a resource, and in the view shown right after creation. All other formatting (bold, italic, …) worked. The workaround was to close the resource and reopen it from search.

## Cause

CKEditor renders its floating UI — the link balloon and dropdown panels — into a `.ck-body-wrapper` it appends to `document.body`.

Since **Angular CDK 21 a dialog is rendered in a `popover`**, which the browser promotes to the **top layer**. Top-layer elements paint above all ordinary content regardless of z-index. The balloon did open and position itself correctly, but stayed behind the dialog surface and never received a click.

That explains every symptom:

- Bold/italic are in-DOM toolbar buttons, so they kept working.
- Only the out-of-DOM floating UI failed.
- Reopening from search renders on a plain routed page with no dialog — hence the workaround.

This is the recent regression: the CDK 21 switch to popover-based overlays.

## Fix

No z-index can win against the top layer from outside it, so move the wrapper into the popover to place it in the same layer.

The popover is `pointer-events: none` and the CDK re-enables clicks only on the pane inside it, so the relocated wrapper has to opt back in too — without that the balloon is visible but its URL input and Save/Cancel buttons swallow no clicks.

CKEditor recreates the wrapper whenever it is no longer connected, so relocating it is safe. Outside a dialog `closest('[popover]')` finds nothing and the editor is left untouched.

## Verification

Verified in Chrome against a reproduction using the real CKEditor bundle in an actual CDK-style popover:

| | Before | After |
|---|---|---|
| Balloon reachable | `COVERED: true`, topmost `cdk-overlay-popover` | topmost is the balloon |
| Save button | `pointer-events: none`, not clickable | clickable |
| End-to-end | — | typing a URL + Save yields `<a href="https://dasch.swiss">` in the editor data |

Also confirmed by the reporter in the real app: balloon appears and Save/Cancel work.

- `vre-ui-ui` lint clean, tests pass (46/46)
- `dsp-app` builds
- Non-dialog (routed page) path unchanged — guard returns early

🤖 Generated with [Claude Code](https://claude.com/claude-code)