### PR TITLE
fix(audio): bind the audio file URL as a plain string (DEV-7010)

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/audio.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/audio.component.spec.ts
@@ -1,6 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DomSanitizer } from '@angular/platform-browser';
 import { ReadAudioFileValue, ReadResource } from '@dasch-swiss/dsp-js';
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { provideTranslateService } from '@ngx-translate/core';
@@ -72,7 +71,6 @@ describe('AudioComponent — behavior', () => {
             { provide: MediaPlayerService, useFactory: () => mediaPlayerMock },
             { provide: RepresentationService, useValue: representationServiceMock },
             { provide: NotificationService, useValue: notificationMock },
-            { provide: DomSanitizer, useValue: { bypassSecurityTrustUrl: (url: string) => url } },
           ],
         },
       })
@@ -145,5 +143,52 @@ describe('AudioComponent — behavior', () => {
     it('completes without error', () => {
       expect(() => component.ngOnDestroy()).not.toThrow();
     });
+  });
+});
+
+describe('AudioComponent — audio element source binding', () => {
+  let fixture: ComponentFixture<AudioComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AudioComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideTranslateService()],
+    })
+      .overrideComponent(AudioComponent, {
+        set: {
+          providers: [
+            {
+              provide: SegmentsService,
+              useValue: { onInit: jest.fn(), setSegments: jest.fn(), segments: [], playSegment$: EMPTY },
+            },
+            { provide: MediaControlService, useValue: { play$: EMPTY, watchForPause$: EMPTY, playMedia: jest.fn() } },
+            { provide: MediaPlayerService, useValue: { duration: () => 0, onTimeUpdate$: EMPTY } },
+            {
+              provide: RepresentationService,
+              useValue: { getFileInfo: jest.fn().mockReturnValue(of({ originalFilename: 'audio-file.mp3' })) },
+            },
+            { provide: NotificationService, useValue: { openSnackBar: jest.fn() } },
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AudioComponent);
+    const component = fixture.componentInstance;
+    component.src = makeSrc();
+    component.parentResource = makeParentResource();
+    component.ngOnChanges({
+      src: new SimpleChange(null, component.src, true),
+      parentResource: new SimpleChange(null, component.parentResource, true),
+    });
+    fixture.detectChanges();
+  });
+
+  it('gives the <audio> element the real file URL so the browser can load it', () => {
+    const audio: HTMLAudioElement | null = fixture.nativeElement.querySelector('audio');
+
+    expect(audio).not.toBeNull();
+    expect(audio!.getAttribute('src')).toBe('http://example.org/audio.mp3');
   });
 });

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/audio.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/audio.component.ts
@@ -11,7 +11,6 @@ import {
   ViewChild,
 } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
-import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { NotificationService } from '@dasch-swiss/vre/ui/notification';
 import { TranslateService } from '@ngx-translate/core';
 import { catchError, EMPTY, Subject, takeUntil } from 'rxjs';
@@ -57,7 +56,7 @@ export class AudioComponent implements OnInit, OnChanges, OnDestroy {
 
   originalFilename?: string;
   failedToLoad = false;
-  audioFileUrl!: SafeUrl;
+  audioFileUrl = '';
 
   duration = 0;
   watchForPause: number | null = null;
@@ -70,7 +69,6 @@ export class AudioComponent implements OnInit, OnChanges, OnDestroy {
   private readonly _translateService = inject(TranslateService);
 
   constructor(
-    private readonly _sanitizer: DomSanitizer,
     public segmentsService: SegmentsService,
     private readonly _mediaControl: MediaControlService,
     private readonly _notification: NotificationService,
@@ -89,7 +87,9 @@ export class AudioComponent implements OnInit, OnChanges, OnDestroy {
         this._resetPlayer();
       }
 
-      this.audioFileUrl = this._sanitizer.bypassSecurityTrustUrl(this.src.fileUrl);
+      // Bound as a plain string: Angular maps audio|src to SecurityContext.NONE, so a SafeUrl
+      // would never be unwrapped and would reach the DOM as its toString() output. See DEV-7010.
+      this.audioFileUrl = this.src.fileUrl;
 
       this._rs
         .getFileInfo(this.src.fileUrl)


### PR DESCRIPTION
[DEV-7010](https://linear.app/dasch/issue/DEV-7010)

## Summary

- The audio player never rendered on **any** audio resource — the `<audio>` element's `src` was the literal string `SafeValue must use [property]=binding: <url> (see …)`.
- Root cause is **not** what the issue describes. The template already used the `[src]` property binding. Angular's DOM security schema simply **does not register `audio|src`**, so the binding resolves to `SecurityContext.NONE` — and in that context Angular never unwraps a `SafeValue`. The `SafeUrl` object was assigned straight to the DOM property and coerced via `toString()`.
- Fix: bind the URL as a plain string. Angular applies no sanitization to a NONE-context binding either way, so the **security posture is unchanged**.

## Why only audio broke

Enumerated from the installed `@angular/compiler` (21.2.9):

| binding | security context | result |
|---|---|---|
| `audio\|src` | **not registered → NONE** | SafeValue stringified → broken |
| `video\|src` | URL | unwrapped correctly → works |
| `img\|src` | URL | unwrapped correctly → works |

`video.component.ts:93` makes the identical `bypassSecurityTrustUrl` call and works fine — which is exactly why the reporter found the `<video>` src clean while audio's was mangled. That asymmetry is the confirming evidence.

Downstream, the broken URL meant the browser could not load the file (`readyState === 0`), so `loadedmetadata` never fired and the toolbar — gated on `isPlayerReady` — never appeared.

## Why nothing caught it

- **TypeScript couldn't:** `SafeValue` is declared as an empty interface (`interface SafeValue {}`), which accepts any value. The same hole let `_resetPlayer()` assign `''` to the `SafeUrl`-typed field.
- **Unit tests couldn't, twice over:** the spec replaced the template with `<div></div>` (so no `<audio>` ever rendered) *and* stubbed `DomSanitizer` to return a plain string (so no real `SafeValue` was ever produced).

## Changes

**`audio.component.ts`** — drop `bypassSecurityTrustUrl`, bind `src.fileUrl` directly; remove the now-unused `DomSanitizer` injection and `SafeUrl` import. Comment records why the sanitizer must not come back.

**`audio.component.spec.ts`** — add a fix-confirmation test that renders the **real** template with the **real** `DomSanitizer` and asserts the `src` is the actual URL. Remove the stale `DomSanitizer` stub from the existing block.

## Test Plan

The new test fails against the unfixed code with precisely the string observed on stage:

```
Expected: "http://example.org/audio.mp3"
Received: "SafeValue must use [property]=binding: http://example.org/audio.mp3 (see …)"
```

- `nx run vre-resource-editor-resource-editor:test` — **404 passed**, 47 suites
- `nx run vre-resource-editor-resource-editor:lint` — clean
- `nx run dsp-app:build` — succeeds (Angular strict template checking)
- `prettier --check` — clean

**Limitation, stated honestly:** the unit test proves the `src` is a real URL; it does not prove `loadedmetadata` fires and the toolbar renders, because jsdom does not load media. That last hop is inferred from the causal chain the issue itself documented.

## Out of scope

The issue's note about a large video showing no player is a **separate** cause (its `src` was already clean — consistent with the table above); tracked as a follow-up.

## Screenshots

[Attach manually if UI changes]