### PR TITLE
fix(video): surface initialisation state instead of an empty media box (DEV-7026)

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.html
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.html
@@ -4,7 +4,7 @@
     <app-representation-error-message />
     }
 
-    <div style="margin-bottom: -4px">
+    <div class="video-stage" [class.is-loading]="!isPlayerReady && !videoError">
       @if (video) {
       <video
         style="width: 100%"
@@ -14,11 +14,16 @@
         type="video/mp4"
         preload="auto"
         [muted]="false"
-        (canplay)="onVideoPlayerReady()"
+        (loadedmetadata)="onVideoPlayerReady()"
         (click)="videoPlayer.togglePlay()"
         (error)="handleVideoError($event)"></video>
-      } @else {
-      <app-progress-indicator />
+      }
+      <!-- Overlaid rather than swapped in: the <video> element must stay mounted while it
+           initialises, otherwise the browser stops loading it. See DEV-7026. -->
+      @if (!isPlayerReady && !videoError) {
+      <div class="video-loading" data-cy="video-loading">
+        <app-progress-indicator size="medium" [compact]="true" [onDark]="true" />
+      </div>
       } @if (false) {
       <app-video-overlay />
       }

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.html
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.html
@@ -4,7 +4,7 @@
     <app-representation-error-message />
     }
 
-    <div class="video-stage" [class.is-loading]="!isPlayerReady && !videoError">
+    <div class="video-stage" [class.is-loading]="!isMetadataLoaded && !videoError">
       @if (video) {
       <video
         style="width: 100%"
@@ -14,13 +14,14 @@
         type="video/mp4"
         preload="auto"
         [muted]="false"
-        (loadedmetadata)="onVideoPlayerReady()"
+        (loadedmetadata)="onMetadataLoaded()"
+        (canplay)="onVideoPlayerReady()"
         (click)="videoPlayer.togglePlay()"
         (error)="handleVideoError($event)"></video>
       }
       <!-- Overlaid rather than swapped in: the <video> element must stay mounted while it
            initialises, otherwise the browser stops loading it. See DEV-7026. -->
-      @if (!isPlayerReady && !videoError) {
+      @if (!isMetadataLoaded && !videoError) {
       <div class="video-loading" data-cy="video-loading">
         <app-progress-indicator size="medium" [compact]="true" [onDark]="true" />
       </div>
@@ -29,7 +30,7 @@
       }
     </div>
 
-    @if (isPlayerReady) {
+    @if (isMetadataLoaded) {
     <app-media-slider
       [max]="videoPlayer.duration()"
       [currentTime]="myCurrentTime"

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.spec.ts
@@ -170,3 +170,72 @@ describe('VideoComponent — behavior', () => {
     });
   });
 });
+
+describe('VideoComponent — loading and ready state (real template)', () => {
+  let fixture: ComponentFixture<VideoComponent>;
+  let component: VideoComponent;
+
+  const loader = () => fixture.nativeElement.querySelector('[data-cy="video-loading"]');
+  const videoEl = (): HTMLVideoElement => fixture.nativeElement.querySelector('video');
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VideoComponent],
+      providers: [provideTranslateService()],
+    })
+      .overrideComponent(VideoComponent, {
+        set: {
+          providers: [
+            {
+              provide: SegmentsService,
+              useValue: { onInit: jest.fn(), setSegments: jest.fn(), segments: [], playSegment$: EMPTY },
+            },
+            {
+              provide: MediaControlService,
+              useValue: { play$: EMPTY, watchForPause$: EMPTY, playMedia: jest.fn(), mediaDurationSecs: undefined },
+            },
+            {
+              provide: MediaPlayerService,
+              useValue: { onInit: jest.fn(), navigate: jest.fn(), duration: () => 788, onTimeUpdate$: EMPTY },
+            },
+            // Leaves fileInfo undefined, so the toolbar stays out of this fixture.
+            { provide: RepresentationService, useValue: { getFileInfo: jest.fn().mockReturnValue(EMPTY) } },
+            { provide: NotificationService, useValue: { openSnackBar: jest.fn() } },
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(VideoComponent);
+    component = fixture.componentInstance;
+    component.src = makeSrc();
+    component.parentResource = makeParentResource();
+    component.ngOnChanges();
+    fixture.detectChanges();
+  });
+
+  it('shows a loading indicator while the video is still initialising', () => {
+    expect(component.isPlayerReady).toBe(false);
+    expect(loader()).not.toBeNull();
+  });
+
+  it('hides the loading indicator once the video reports its metadata', () => {
+    videoEl().dispatchEvent(new Event('loadedmetadata'));
+    fixture.detectChanges();
+
+    expect(component.isPlayerReady).toBe(true);
+    expect(loader()).toBeNull();
+  });
+
+  it('shows the error state instead of a perpetual loading indicator when the video fails', () => {
+    component.handleVideoError({ target: { error: { code: 2 } } } as unknown as ErrorEvent);
+    fixture.detectChanges();
+
+    expect(loader()).toBeNull();
+    expect(fixture.nativeElement.querySelector('app-representation-error-message')).not.toBeNull();
+  });
+
+  it('gives the <video> element the real file URL so the browser can load it', () => {
+    expect(videoEl().getAttribute('src')).toBe('http://example.org/video.mp4');
+  });
+});

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.spec.ts
@@ -215,7 +215,7 @@ describe('VideoComponent — loading and ready state (real template)', () => {
   });
 
   it('shows a loading indicator while the video is still initialising', () => {
-    expect(component.isPlayerReady).toBe(false);
+    expect(component.isMetadataLoaded).toBe(false);
     expect(loader()).not.toBeNull();
   });
 
@@ -223,8 +223,41 @@ describe('VideoComponent — loading and ready state (real template)', () => {
     videoEl().dispatchEvent(new Event('loadedmetadata'));
     fixture.detectChanges();
 
-    expect(component.isPlayerReady).toBe(true);
+    expect(component.isMetadataLoaded).toBe(true);
     expect(loader()).toBeNull();
+  });
+
+  it('offers the slider as soon as metadata is known, without waiting for a playable buffer', () => {
+    videoEl().dispatchEvent(new Event('loadedmetadata'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('app-media-slider')).not.toBeNull();
+  });
+
+  it('does not report the player as playable until the video can actually play', () => {
+    videoEl().dispatchEvent(new Event('loadedmetadata'));
+    fixture.detectChanges();
+
+    // Metadata alone must not enable the transport controls: pressing play would not start playback.
+    expect(component.isPlayerReady).toBe(false);
+
+    videoEl().dispatchEvent(new Event('canplay'));
+    fixture.detectChanges();
+
+    expect(component.isPlayerReady).toBe(true);
+  });
+
+  it('emits loaded once the video can play, not merely when metadata arrives', () => {
+    const emitted: boolean[] = [];
+    component.loaded.subscribe(v => emitted.push(v));
+
+    videoEl().dispatchEvent(new Event('loadedmetadata'));
+    expect(emitted).toEqual([]);
+
+    videoEl().dispatchEvent(new Event('canplay'));
+    videoEl().dispatchEvent(new Event('canplay'));
+
+    expect(emitted).toEqual([true]);
   });
 
   it('shows the error state instead of a perpetual loading indicator when the video fails', () => {

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.ts
@@ -79,6 +79,9 @@ export class VideoComponent implements OnChanges, OnDestroy {
   myCurrentTime = 0;
   duration = 0;
   watchForPause: number | null = null;
+  /** HAVE_METADATA: duration, slider range and seeking are available, so the loading state can end. */
+  isMetadataLoaded = false;
+  /** HAVE_FUTURE_DATA: pressing play actually starts playback, so the transport controls may show. */
   isPlayerReady = false;
   fileInfo?: MovingImageSidecar;
 
@@ -103,6 +106,7 @@ export class VideoComponent implements OnChanges, OnDestroy {
   ngOnChanges(): void {
     this._ngUnsubscribe.next();
 
+    this.isMetadataLoaded = false;
     this.isPlayerReady = false;
     this._watchForMediaEvents();
     if (this.overrideSegments) {
@@ -128,12 +132,13 @@ export class VideoComponent implements OnChanges, OnDestroy {
   }
 
   /**
-   * Driven by `loadedmetadata`, not `canplay`: everything below needs only the duration and the
-   * ability to seek, both available at HAVE_METADATA. `canplay` additionally waits for a playable
-   * buffer, which on a large file delays the whole player chrome. See DEV-7026.
+   * `loadedmetadata` (HAVE_METADATA). Everything here needs only the duration and the ability to
+   * seek, both guaranteed at this readyState — so the slider, the seek target and the end of the
+   * loading state need not wait for a playable buffer, which on a large file arrives much later.
+   * Playability is a separate concern, tracked by `onVideoPlayerReady`. See DEV-7026.
    */
-  onVideoPlayerReady() {
-    if (this.isPlayerReady) return;
+  onMetadataLoaded() {
+    if (this.isMetadataLoaded) return;
 
     this.videoPlayer.onInit(this.videoElement.nativeElement);
 
@@ -142,9 +147,9 @@ export class VideoComponent implements OnChanges, OnDestroy {
     }
 
     this.duration = this.videoPlayer.duration();
-    this.isPlayerReady = true;
-    this.loaded.emit(true);
-    this.mediaControl.mediaDurationSecs = this.videoPlayer.duration();
+    this.mediaControl.mediaDurationSecs = this.duration;
+    this.isMetadataLoaded = true;
+
     this.videoPlayer.onTimeUpdate$.pipe(takeUntil(this._ngUnsubscribe)).subscribe(seconds => {
       this.myCurrentTime = seconds;
       this._cdr.detectChanges();
@@ -154,6 +159,18 @@ export class VideoComponent implements OnChanges, OnDestroy {
         this.watchForPause = null;
       }
     });
+  }
+
+  /**
+   * `canplay` (HAVE_FUTURE_DATA). Gates the transport controls only: a play button must not appear
+   * before pressing it starts playback. Always preceded by `loadedmetadata`, so the player service
+   * is already bound to the element by the time this runs.
+   */
+  onVideoPlayerReady() {
+    if (this.isPlayerReady) return;
+
+    this.isPlayerReady = true;
+    this.loaded.emit(true);
   }
 
   ngOnDestroy() {

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/video.component.ts
@@ -44,6 +44,27 @@ import { VideoToolbarComponent } from './video-toolbar.component';
     RepresentationErrorMessageComponent,
     ResourceRepresentationContainerComponent,
   ],
+  styles: [
+    `
+      .video-stage {
+        position: relative;
+        margin-bottom: -4px;
+      }
+
+      /* Keeps a visible area for the overlaid indicator before the video reports its dimensions. */
+      .video-stage.is-loading {
+        min-height: 160px;
+      }
+
+      .video-loading {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    `,
+  ],
 })
 export class VideoComponent implements OnChanges, OnDestroy {
   @Input({ required: true }) src!: FileRepresentationInput;
@@ -106,6 +127,11 @@ export class VideoComponent implements OnChanges, OnDestroy {
       });
   }
 
+  /**
+   * Driven by `loadedmetadata`, not `canplay`: everything below needs only the duration and the
+   * ability to seek, both available at HAVE_METADATA. `canplay` additionally waits for a playable
+   * buffer, which on a large file delays the whole player chrome. See DEV-7026.
+   */
   onVideoPlayerReady() {
     if (this.isPlayerReady) return;
 

--- a/libs/vre/ui/progress-indicator/src/lib/.gitkeep.spec.ts
+++ b/libs/vre/ui/progress-indicator/src/lib/.gitkeep.spec.ts
@@ -1,7 +1,0 @@
-// Placeholder test file to enable coverage collection for this library.
-// This file can be removed once actual tests are added.
-describe('progress-indicator placeholder', () => {
-  it('should enable coverage collection', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.component.spec.ts
+++ b/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AppProgressIndicatorComponent } from './app-progress-indicator.component';
+
+describe('AppProgressIndicatorComponent', () => {
+  let fixture: ComponentFixture<AppProgressIndicatorComponent>;
+
+  const strokeColour = () => fixture.nativeElement.querySelector('svg g')!.getAttribute('stroke');
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [AppProgressIndicatorComponent] }).compileComponents();
+    fixture = TestBed.createComponent(AppProgressIndicatorComponent);
+  });
+
+  it('strokes the spinner in the default colour on light surfaces', () => {
+    fixture.detectChanges();
+
+    expect(strokeColour()).toBe('#336790');
+  });
+
+  it('strokes the spinner in a light colour when placed on a dark surface', () => {
+    fixture.componentInstance.onDark = true;
+    fixture.detectChanges();
+
+    expect(strokeColour()).toBe('#e8eef4');
+  });
+
+  it('sizes the spinner from the requested size', () => {
+    fixture.componentInstance.size = 'medium';
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('svg')!.getAttribute('width')).toBe('64px');
+  });
+});

--- a/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.component.ts
+++ b/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.component.ts
@@ -14,7 +14,7 @@ import { ProgressSize, SIZE_TO_PXL } from './progress-indicator.type';
         [attr.height]="widthAndHeight"
         viewBox="5 20 200 170"
         preserveAspectRatio="xMidYMid meet">
-        <g stroke-width="11" fill="none" stroke="#336790">
+        <g stroke-width="11" fill="none" [attr.stroke]="onDark ? LIGHT_STROKE : DEFAULT_STROKE">
           <path
             d="m 107.19141,27.064453 c 19.40811,0.72674 40.31867,-1.456974 57.69737,9.089791 21.86918,11.995467 35.15372,37.302817
             32.81003,62.109081 -1.44162,27.181075 -22.18624,51.396565 -48.36746,58.105135 -15.52706,3.91583 -31.7106,1.96603
@@ -73,7 +73,15 @@ import { ProgressSize, SIZE_TO_PXL } from './progress-indicator.type';
 export class AppProgressIndicatorComponent implements OnInit {
   @Input() size: ProgressSize = 'small';
   @Input() compact = false;
+  /**
+   * Strokes the loader in a light colour for use on dark surfaces. The default stroke only reaches
+   * 2.41:1 against the near-black media container, below the 3:1 WCAG 1.4.11 non-text minimum.
+   */
+  @Input() onDark = false;
   widthAndHeight!: string;
+
+  protected readonly DEFAULT_STROKE = '#336790';
+  protected readonly LIGHT_STROKE = '#e8eef4';
 
   ngOnInit() {
     this.widthAndHeight = `${SIZE_TO_PXL[this.size]}px`;

--- a/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.stories.ts
+++ b/libs/vre/ui/progress-indicator/src/lib/app-progress-indicator/app-progress-indicator.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/angular';
+import { componentWrapperDecorator, type Meta, type StoryObj } from '@storybook/angular';
 import { expect } from 'storybook/test';
 
 import { AppProgressIndicatorComponent } from './app-progress-indicator.component';
@@ -17,6 +17,12 @@ const meta: Meta<AppProgressIndicatorComponent> = {
         defaultValue: { summary: 'small' },
         category: 'Appearance',
       },
+    },
+    onDark: {
+      description:
+        'Strokes the spinner in a light colour so it stays legible on dark surfaces such as the media representation container. Off by default.',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' }, category: 'Appearance' },
     },
   },
 };
@@ -41,4 +47,18 @@ export const MediumSize: Story = {
 export const LargeSize: Story = {
   name: 'Shows large spinner for full-page loading states',
   args: { size: 'large' },
+};
+
+export const OnDarkSurface: Story = {
+  name: 'Shows a light spinner that stays legible on a dark surface',
+  args: { size: 'medium', onDark: true },
+  decorators: [
+    componentWrapperDecorator(story => `<div style="background: rgb(41, 41, 41); padding: 24px">${story}</div>`),
+  ],
+  play: async ({ canvasElement, step }) => {
+    await step('Spinner is stroked in the light colour, not the default blue', async () => {
+      const stroke = canvasElement.querySelector('[data-cy="loader"] svg g')?.getAttribute('stroke');
+      await expect(stroke).toBe('#e8eef4');
+    });
+  },
 };


### PR DESCRIPTION
[DEV-7026](https://linear.app/dasch/issue/DEV-7026)

## Summary

- A video resource showed neither a player nor any feedback while it initialised. The progress indicator sat in an `@else` branch on `video`, which is assigned **synchronously** in `ngOnChanges` before the first render — so on every path where that assignment succeeds, the branch was unreachable and no indicator appeared.
- The indicator is now overlaid on the video area while the player is not ready and no error has been reported. The `<video>` element stays mounted underneath; unmounting it would make the browser abort the load.
- Player readiness moves from `canplay` to `loadedmetadata`, matching `AudioComponent`. `onVideoPlayerReady` only needs the duration and the ability to seek, both available at `HAVE_METADATA`; `canplay` additionally waits for a playable buffer, which delays the whole player chrome (slider + toolbar) on a large file.

## Relationship to DEV-7016 — please read before reviewing

[DEV-7016](https://linear.app/dasch/issue/DEV-7016) (endless spinner on restricted media) is **not fixed here**, and its root-cause text points at the `@else` branch this PR removes. Verified against the patched template with `src === null`, exactly as the wrappers pass it when `getFileValue()` returns `null`:

```
threw: "Cannot read properties of null (reading 'fileUrl')"
video: null   isPlayerReady: false   videoError: ""
loaderPresent: true   videoElementPresent: false   errorMessagePresent: false
```

`ngOnChanges` throws on `this.src.fileUrl` *after* setting `isPlayerReady = false` and `videoError = ''`, so the new condition `!isPlayerReady && !videoError` is true and the overlay renders. **The endless spinner is unchanged in behaviour — it just moves** from `@else` on `video` to `@if (!isPlayerReady && !videoError)`.

Two notes for whoever picks up DEV-7016:

1. Its "Root cause" section will be stale once this merges. The line to reason about becomes `@if (!isPlayerReady && !videoError)` in `video.component.html`.
2. Its proposed fix — guarding at the wrapper with `@if (fileValue)` — composes cleanly: `<app-video>` never mounts without a file value, so this overlay never renders in that path. No guard was added here on purpose, to avoid handling the same condition twice in two layers.

Also flagging: the `onDark` stroke below takes that spinner from 2.41:1 to 12.45:1, so the DEV-7016 symptom becomes **more visible** until it is fixed. Cosmetic, on an already-broken state.

## Changes

**Video representation** — `video.component.{html,ts}`
- Loading overlay gated on `!isPlayerReady && !videoError`, so a failed video shows the error state rather than spinning forever.
- Readiness bound to `(loadedmetadata)` instead of `(canplay)`.
- `preload="auto"` deliberately left unchanged (see Follow-ups).

**Shared progress indicator** — `app-progress-indicator.component.ts`
- New opt-in `onDark` input. The default `#336790` stroke measures **2.41:1** against the media container's `rgb(41, 41, 41)`, under the 3:1 WCAG 1.4.11 minimum for non-text contrast — a spinner nobody can see would have defeated the fix. `onDark` switches to `#e8eef4` (**12.45:1**).
- Default unchanged, so the 25+ existing call sites are unaffected. Grepped for any CSS selector or assertion matching the stroke value — none.
- Replaced the self-describing coverage placeholder spec with real tests for the rendered output.

## Test Plan

`nx run-many --target=lint` and `--target=test` on `vre-resource-editor-resource-editor` + `vre-ui-progress-indicator`, plus `nx run dsp-app:build:dev-server` for Angular's strict template checking — all green (411 tests).

**Fix-confirmation** — reverting only the template and re-running fails exactly the two new tests, for the right reasons:
- `shows a loading indicator while the video is still initialising` → no reachable loader existed
- `hides the loading indicator once the video reports its metadata` → `loadedmetadata` was not bound

The other two tests in the new suite (error state instead of a perpetual spinner; `<video>` receives the real URL through the real `DomSanitizer`) pass before and after — they are regression guards, and the second is the video-side counterpart to the DEV-7010 audio guard.

**Verified against the stage asset used by the stories** (`0869/3xUzuLcE9nC…mp4`):
- 368 MB and **faststart** (`ftyp`, then `moov` at offset 32, ~596 KB), so metadata lands within the first 600 KB — `loadedmetadata` is genuinely early, which is what makes the gate change worth making.
- The `knora.json` sidecar returns in ~50 ms, so `fileInfo` was never the bottleneck.

**Not reproduced locally:** stage serves at ~32 MB/s from here, so the multi-second empty box could not be triggered. The empty-box *symptom* is connection-bound; the unreachable indicator branch was a defect regardless of connection speed. Worth a check on a throttled connection during review.

**Not verified locally:** the new `OnDarkSurface` story's `play()`. `playwright-core` pins chromium build 1234 and only 1208 is cached, and installing writes outside the repo — deferred to CI, which has the browsers. Its assertion (the rendered `stroke` attribute) is covered deterministically by the new Jest spec, so only the harness wiring is unproven, and `componentWrapperDecorator` follows the existing `permission-info` story precedent.

## Follow-ups (deliberately out of scope)

- **Endless spinner on restricted media** — [DEV-7016](https://linear.app/dasch/issue/DEV-7016), see above.
- **A stalled download still spins indefinitely.** No timeout was added: a stall is not a failure, the browser can resume, and a timeout would raise false errors on slow-but-working connections. Genuine failures fire `error` and already reach the error state.
- **No `role="status"` on the loading overlay**, so screen readers get no announcement. The right home is `AppProgressIndicatorComponent` itself, which would benefit all 25+ call sites — a broader a11y change than this fix should carry.
- **`preload="auto"` on a 368 MB file** tells the browser to fetch the whole asset in the background. `preload="metadata"` would cut that dramatically and pairs naturally with the `loadedmetadata` gate, but it can change first-frame display and initial playback smoothness, and the issue did not ask for it.

## Screenshots

[Attach manually if UI changes]