### PR TITLE
fix(representation): show a no-access message instead of an endless spinner for restricted media (DEV-7016)

### DIFF
--- a/apps/dsp-app/src/assets/i18n/de.json
+++ b/apps/dsp-app/src/assets/i18n/de.json
@@ -624,6 +624,7 @@
       "text": {
         "title": "Text (csv, txt, xml)"
       },
+      "noPermission": "Sie haben keine Berechtigung, diese Mediendatei anzuzeigen.",
       "placeholder": {
         "title": "Platzhalter – Datei noch nicht verfügbar",
         "message": "Diese Ressource verweist auf einen Platzhalter. Die eigentliche Datei wurde noch nicht geliefert."

--- a/apps/dsp-app/src/assets/i18n/en.json
+++ b/apps/dsp-app/src/assets/i18n/en.json
@@ -641,6 +641,7 @@
       "text": {
         "title": "Text (csv, txt, xml)"
       },
+      "noPermission": "You do not have permission to view this media file.",
       "placeholder": {
         "title": "Placeholder – asset not yet available",
         "message": "This resource references a placeholder. The actual file has not been delivered yet."

--- a/apps/dsp-app/src/assets/i18n/fr.json
+++ b/apps/dsp-app/src/assets/i18n/fr.json
@@ -641,6 +641,7 @@
       "text": {
         "title": "Texte (csv, txt, xml)"
       },
+      "noPermission": "Vous n’avez pas la permission de consulter ce fichier multimédia.",
       "placeholder": {
         "title": "Espace réservé – fichier pas encore disponible",
         "message": "Cette ressource référence un espace réservé. Le fichier réel n’a pas encore été livré."

--- a/apps/dsp-app/src/assets/i18n/it.json
+++ b/apps/dsp-app/src/assets/i18n/it.json
@@ -641,6 +641,7 @@
       "text": {
         "title": "Testo (csv, txt, xml)"
       },
+      "noPermission": "Non hai il permesso di visualizzare questo file multimediale.",
       "placeholder": {
         "title": "Segnaposto – file non ancora disponibile",
         "message": "Questa risorsa fa riferimento a un segnaposto. Il file effettivo non è ancora stato fornito."

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/representation-restricted.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/representation-restricted.component.spec.ts
@@ -1,0 +1,24 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideTranslateService } from '@ngx-translate/core';
+import { RepresentationRestrictedComponent } from './representation-restricted.component';
+
+describe('RepresentationRestrictedComponent', () => {
+  let component: RepresentationRestrictedComponent;
+  let fixture: ComponentFixture<RepresentationRestrictedComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RepresentationRestrictedComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [provideTranslateService()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RepresentationRestrictedComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/representation-restricted.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/representation-restricted.component.stories.ts
@@ -1,0 +1,21 @@
+import { type Meta, type StoryObj } from '@storybook/angular';
+import { expect } from 'storybook/test';
+
+import { RepresentationRestrictedComponent } from './representation-restricted.component';
+
+const meta: Meta<RepresentationRestrictedComponent> = {
+  title: 'Resource Editor / 3. Representation / Restricted',
+  component: RepresentationRestrictedComponent,
+};
+export default meta;
+type Story = StoryObj<RepresentationRestrictedComponent>;
+
+export const ShowsNoPermissionMessageWhenFileValueIsWithheld: Story = {
+  name: 'Shows a no-permission message when the file value is withheld',
+  play: async ({ canvasElement, step }) => {
+    await step('Alert banner is rendered instead of a player or spinner', async () => {
+      await expect(canvasElement.querySelector('app-alert-info')).not.toBeNull();
+      await expect(canvasElement.querySelector('app-progress-indicator')).toBeNull();
+    });
+  },
+};

--- a/libs/vre/resource-editor/resource-editor/src/lib/representation/representation-restricted.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/representation/representation-restricted.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { AlertInfoComponent } from '../header/alert-info.component';
+
+/**
+ * Shown in place of the media area when the resource is viewable but its file value is withheld,
+ * i.e. `getFileValue()` returns `null` while `userHasPermission` is still `V`/`RV`/`CR`.
+ *
+ * Without this, the AV wrappers passed the `null` file value on to the player, which threw before
+ * ever becoming ready and left the progress indicator spinning forever (DEV-7016). The wording is
+ * deliberately media-neutral so the same component serves video, audio and their segments.
+ */
+@Component({
+  selector: 'app-representation-restricted',
+  imports: [AlertInfoComponent, TranslatePipe],
+  template: `
+    <app-alert-info>
+      <p>{{ 'resourceEditor.representations.noPermission' | translate }}</p>
+    </app-alert-info>
+  `,
+})
+export class RepresentationRestrictedComponent {}

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio-segment.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio-segment.component.stories.ts
@@ -46,6 +46,30 @@ const makeAudioResource = (): ReadResource =>
     },
   }) as unknown as ReadResource;
 
+/**
+ * Parent audio whose file value is withheld: the resource itself is viewable but
+ * Constants.HasAudioFileValue is absent, so `getFileValue()` returns `null` (DEV-7016).
+ */
+const makeAudioResourceWithoutFile = (): ReadResource =>
+  ({
+    id: AUDIO_IRI,
+    attachedToProject: 'http://rdfh.ch/projects/0869',
+    attachedToUser: 'http://rdfh.ch/users/test',
+    userHasPermission: 'V',
+    properties: {},
+  }) as unknown as ReadResource;
+
+const dspApiStub = (parentResource: ReadResource) => ({
+  v2: {
+    res: { getResource: () => of(parentResource) },
+    search: {
+      doSearchIncomingLinks: () => of({ resources: [], mayHaveMoreResults: false }),
+      doExtendedSearch: () => of({ resources: [], mayHaveMoreResults: false }),
+      doSearchIncomingRegions: () => of({ resources: [], mayHaveMoreResults: false }),
+    },
+  },
+});
+
 const makeResource = (permission = 'CR'): DspResource => {
   const titlePropId = 'http://0.0.0.0:3333/ontology/0001/example/v2#hasTitle';
   const titleDef = makeTextPropDef(titlePropId, 'Title');
@@ -95,19 +119,7 @@ const meta: Meta<ResourceAudioSegmentComponent> = {
           },
         },
         { provide: ResourceFetcherService, useValue: resourceFetcherServiceStub() },
-        {
-          provide: DspApiConnectionToken,
-          useValue: {
-            v2: {
-              res: { getResource: () => of(makeAudioResource()) },
-              search: {
-                doSearchIncomingLinks: () => of({ resources: [], mayHaveMoreResults: false }),
-                doExtendedSearch: () => of({ resources: [], mayHaveMoreResults: false }),
-                doSearchIncomingRegions: () => of({ resources: [], mayHaveMoreResults: false }),
-              },
-            },
-          },
-        },
+        { provide: DspApiConnectionToken, useValue: dspApiStub(makeAudioResource()) },
         {
           provide: RepresentationService,
           useValue: { getFileInfo: () => of({ originalFilename: 'audio.mp3' }), downloadProjectFile: () => {} },
@@ -152,6 +164,25 @@ export const ReadOnly: Story = {
   play: async ({ canvasElement, step }) => {
     await step('Restriction banner is rendered', async () => {
       await expect(canvasElement.querySelector('app-resource-restriction')).not.toBeNull();
+    });
+  },
+};
+
+export const WithheldParentFileValue: Story = {
+  name: 'Shows a no-permission message instead of an endless spinner when the parent file value is withheld',
+  args: { resource: makeResource() },
+  decorators: [
+    applicationConfig({
+      providers: [{ provide: DspApiConnectionToken, useValue: dspApiStub(makeAudioResourceWithoutFile()) }],
+    }),
+  ],
+  play: async ({ canvasElement, step }) => {
+    await step('No-permission message is rendered', async () => {
+      await expect(canvasElement.querySelector('app-representation-restricted')).not.toBeNull();
+    });
+    await step('Neither the player nor a spinner is rendered', async () => {
+      await expect(canvasElement.querySelector('app-audio')).toBeNull();
+      await expect(canvasElement.querySelector('app-progress-indicator')).toBeNull();
     });
   },
 };

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio-segment.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio-segment.component.ts
@@ -11,6 +11,7 @@ import { ResourceDefaultTabsComponent } from '../../properties/resource-default-
 import { getFileValue } from '../../representation/get-file-value';
 import { isPlaceholderFileValue } from '../../representation/is-placeholder-file-value';
 import { RepresentationPlaceholderComponent } from '../../representation/representation-placeholder.component';
+import { RepresentationRestrictedComponent } from '../../representation/representation-restricted.component';
 import { ResourceLegalComponent } from '../../representation/resource-legal.component';
 import { ResourceRepresentationContainerComponent } from '../../representation/resource-representation-container.component';
 import { Segment } from '../../representation/segments/segment';
@@ -28,17 +29,21 @@ const HAS_SEGMENT_BOUNDS = 'http://api.knora.org/ontology/knora-api/v2#hasSegmen
     }
     <app-resource-header [resource]="resource" />
     @if (parentResource$ | async; as parentResource) {
-      <app-resource-legal [fileValue]="getFileValue(parentResource)" />
-      @if (isPlaceholder(parentResource)) {
-        <app-representation-placeholder />
+      @if (getFileValue(parentResource); as file) {
+        <app-resource-legal [fileValue]="file" />
+        @if (isPlaceholder(parentResource)) {
+          <app-representation-placeholder />
+        } @else {
+          <app-resource-representation-container height="small">
+            <app-audio
+              [src]="file"
+              [parentResource]="parentResource"
+              [start]="start"
+              [overrideSegments]="currentSegments" />
+          </app-resource-representation-container>
+        }
       } @else {
-        <app-resource-representation-container height="small">
-          <app-audio
-            [src]="getFileValue(parentResource)"
-            [parentResource]="parentResource"
-            [start]="start"
-            [overrideSegments]="currentSegments" />
-        </app-resource-representation-container>
+        <app-representation-restricted />
       }
     }
     <app-resource-default-tabs [resource]="resource" style="display: block; margin-top: 50px" />
@@ -50,6 +55,7 @@ const HAS_SEGMENT_BOUNDS = 'http://api.knora.org/ontology/knora-api/v2#hasSegmen
     ResourceHeaderComponent,
     ResourceLegalComponent,
     RepresentationPlaceholderComponent,
+    RepresentationRestrictedComponent,
     AudioComponent,
     ResourceRepresentationContainerComponent,
     ResourceDefaultTabsComponent,
@@ -95,7 +101,7 @@ export class ResourceAudioSegmentComponent implements OnInit {
   }
 
   getFileValue(resource: ReadResource) {
-    return getFileValue(resource)!;
+    return getFileValue(resource);
   }
 
   isPlaceholder(resource: ReadResource) {

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio.component.stories.ts
@@ -44,6 +44,24 @@ const makeResource = (permission = 'CR'): DspResource => {
   return generateDspResource(addDescriptionToResource(res, permission));
 };
 
+/**
+ * Resource is viewable but the file value is withheld, i.e. `hasAudioFileValue` is absent while
+ * `userHasPermission` is still `V` (DEV-7016).
+ */
+const makeResourceWithWithheldFile = (): DspResource => {
+  const res = new ReadResource();
+  res.id = 'http://rdfh.ch/resource/1';
+  res.type = 'http://api.dasch.swiss/ontology/knora-api/v2#AudioRepresentation';
+  res.label = 'My Storybook Audio';
+  res.attachedToProject = 'http://rdfh.ch/projects/0001';
+  res.attachedToUser = 'http://rdfh.ch/users/test';
+  res.userHasPermission = 'V';
+  res.hasPermissions = DEFAULT_HAS_PERMISSIONS;
+  res.creationDate = '2024-03-15T10:30:00Z';
+  res.properties = {};
+  return generateDspResource(addDescriptionToResource(res, 'V'));
+};
+
 const segmentsServiceStub: Partial<SegmentsService> = {
   segments: [],
   onInit: () => {},
@@ -112,6 +130,20 @@ export const ReadOnly: Story = {
   play: async ({ canvasElement, step }) => {
     await step('Restriction banner is rendered', async () => {
       await expect(canvasElement.querySelector('app-resource-restriction')).not.toBeNull();
+    });
+  },
+};
+
+export const WithheldFileValue: Story = {
+  name: 'Shows a no-permission message instead of an endless spinner when the file value is withheld',
+  args: { resource: makeResourceWithWithheldFile() },
+  play: async ({ canvasElement, step }) => {
+    await step('No-permission message is rendered', async () => {
+      await expect(canvasElement.querySelector('app-representation-restricted')).not.toBeNull();
+    });
+    await step('Neither the player nor a spinner is rendered', async () => {
+      await expect(canvasElement.querySelector('app-audio')).toBeNull();
+      await expect(canvasElement.querySelector('app-progress-indicator')).toBeNull();
     });
   },
 };

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/audio/resource-audio.component.ts
@@ -7,6 +7,7 @@ import { ResourceMediaTabsComponent } from '../../properties/resource-media-tabs
 import { getFileValue } from '../../representation/get-file-value';
 import { isPlaceholderFileValue } from '../../representation/is-placeholder-file-value';
 import { RepresentationPlaceholderComponent } from '../../representation/representation-placeholder.component';
+import { RepresentationRestrictedComponent } from '../../representation/representation-restricted.component';
 import { ResourceLegalComponent } from '../../representation/resource-legal.component';
 import { ResourceRepresentationContainerComponent } from '../../representation/resource-representation-container.component';
 import { SegmentsService } from '../../representation/segments/segments.service';
@@ -19,13 +20,17 @@ import { AudioComponent } from './audio.component';
       <app-resource-restriction />
     }
     <app-resource-header [resource]="resource" />
-    <app-resource-legal [fileValue]="fileValue" />
-    @if (isPlaceholder) {
-      <app-representation-placeholder />
+    @if (fileValue; as file) {
+      <app-resource-legal [fileValue]="file" />
+      @if (isPlaceholder) {
+        <app-representation-placeholder />
+      } @else {
+        <app-resource-representation-container height="small">
+          <app-audio [src]="file" [parentResource]="resource.res" />
+        </app-resource-representation-container>
+      }
     } @else {
-      <app-resource-representation-container height="small">
-        <app-audio [src]="fileValue" [parentResource]="resource.res" />
-      </app-resource-representation-container>
+      <app-representation-restricted />
     }
     <app-resource-media-tabs [resource]="resource" style="display: block; margin-top: 50px" />
   `,
@@ -35,6 +40,7 @@ import { AudioComponent } from './audio.component';
     ResourceHeaderComponent,
     ResourceLegalComponent,
     RepresentationPlaceholderComponent,
+    RepresentationRestrictedComponent,
     AudioComponent,
     ResourceRepresentationContainerComponent,
     ResourceMediaTabsComponent,
@@ -44,7 +50,7 @@ export class ResourceAudioComponent {
   @Input({ required: true }) resource!: DspResource;
 
   get fileValue() {
-    return getFileValue(this.resource.res)!;
+    return getFileValue(this.resource.res);
   }
 
   get isPlaceholder() {

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video-segment.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video-segment.component.stories.ts
@@ -52,6 +52,30 @@ const makeVideoResource = (): ReadResource =>
     },
   }) as unknown as ReadResource;
 
+/**
+ * Parent video whose file value is withheld: the resource itself is viewable but
+ * Constants.HasMovingImageFileValue is absent, so `getFileValue()` returns `null` (DEV-7016).
+ */
+const makeVideoResourceWithoutFile = (): ReadResource =>
+  ({
+    id: VIDEO_IRI,
+    attachedToProject: 'http://rdfh.ch/projects/0869',
+    attachedToUser: 'http://rdfh.ch/users/test',
+    userHasPermission: 'V',
+    properties: {},
+  }) as unknown as ReadResource;
+
+const dspApiStub = (parentResource: ReadResource) => ({
+  v2: {
+    res: { getResource: () => of(parentResource) },
+    search: {
+      doSearchIncomingLinks: () => of({ resources: [], mayHaveMoreResults: false }),
+      doExtendedSearch: () => of({ resources: [], mayHaveMoreResults: false }),
+      doSearchIncomingRegions: () => of({ resources: [], mayHaveMoreResults: false }),
+    },
+  },
+});
+
 const makeResource = (permission = 'CR'): DspResource => {
   const titlePropId = 'http://0.0.0.0:3333/ontology/0001/example/v2#hasTitle';
   const titleDef = makeTextPropDef(titlePropId, 'Title');
@@ -102,19 +126,7 @@ const meta: Meta<ResourceVideoSegmentComponent> = {
           },
         },
         { provide: ResourceFetcherService, useValue: resourceFetcherServiceStub('0869') },
-        {
-          provide: DspApiConnectionToken,
-          useValue: {
-            v2: {
-              res: { getResource: () => of(makeVideoResource()) },
-              search: {
-                doSearchIncomingLinks: () => of({ resources: [], mayHaveMoreResults: false }),
-                doExtendedSearch: () => of({ resources: [], mayHaveMoreResults: false }),
-                doSearchIncomingRegions: () => of({ resources: [], mayHaveMoreResults: false }),
-              },
-            },
-          },
-        },
+        { provide: DspApiConnectionToken, useValue: dspApiStub(makeVideoResource()) },
         {
           provide: RepresentationService,
           useValue: { getFileInfo: () => of({ originalFilename: 'video.mp4' }), downloadProjectFile: () => {} },
@@ -159,6 +171,25 @@ export const ReadOnly: Story = {
   play: async ({ canvasElement, step }) => {
     await step('Restriction banner is rendered', async () => {
       await expect(canvasElement.querySelector('app-resource-restriction')).not.toBeNull();
+    });
+  },
+};
+
+export const WithheldParentFileValue: Story = {
+  name: 'Shows a no-permission message instead of an endless spinner when the parent file value is withheld',
+  args: { resource: makeResource() },
+  decorators: [
+    applicationConfig({
+      providers: [{ provide: DspApiConnectionToken, useValue: dspApiStub(makeVideoResourceWithoutFile()) }],
+    }),
+  ],
+  play: async ({ canvasElement, step }) => {
+    await step('No-permission message is rendered', async () => {
+      await expect(canvasElement.querySelector('app-representation-restricted')).not.toBeNull();
+    });
+    await step('Neither the player nor a spinner is rendered', async () => {
+      await expect(canvasElement.querySelector('app-video')).toBeNull();
+      await expect(canvasElement.querySelector('app-progress-indicator')).toBeNull();
     });
   },
 };

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video-segment.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video-segment.component.ts
@@ -11,6 +11,7 @@ import { ResourceDefaultTabsComponent } from '../../properties/resource-default-
 import { getFileValue } from '../../representation/get-file-value';
 import { isPlaceholderFileValue } from '../../representation/is-placeholder-file-value';
 import { RepresentationPlaceholderComponent } from '../../representation/representation-placeholder.component';
+import { RepresentationRestrictedComponent } from '../../representation/representation-restricted.component';
 import { ResourceLegalComponent } from '../../representation/resource-legal.component';
 import { Segment } from '../../representation/segments/segment';
 import { SegmentsService } from '../../representation/segments/segments.service';
@@ -27,15 +28,19 @@ const HAS_SEGMENT_BOUNDS = 'http://api.knora.org/ontology/knora-api/v2#hasSegmen
     }
     <app-resource-header [resource]="resource" />
     @if (parentResource$ | async; as parentResource) {
-      <app-resource-legal [fileValue]="getFileValue(parentResource)" />
-      @if (isPlaceholder(parentResource)) {
-        <app-representation-placeholder />
+      @if (getFileValue(parentResource); as file) {
+        <app-resource-legal [fileValue]="file" />
+        @if (isPlaceholder(parentResource)) {
+          <app-representation-placeholder />
+        } @else {
+          <app-video
+            [src]="file"
+            [parentResource]="parentResource"
+            [start]="start"
+            [overrideSegments]="currentSegments" />
+        }
       } @else {
-        <app-video
-          [src]="getFileValue(parentResource)"
-          [parentResource]="parentResource"
-          [start]="start"
-          [overrideSegments]="currentSegments" />
+        <app-representation-restricted />
       }
     }
     <app-resource-default-tabs [resource]="resource" style="display: block; margin-top: 50px" />
@@ -47,6 +52,7 @@ const HAS_SEGMENT_BOUNDS = 'http://api.knora.org/ontology/knora-api/v2#hasSegmen
     ResourceHeaderComponent,
     ResourceLegalComponent,
     RepresentationPlaceholderComponent,
+    RepresentationRestrictedComponent,
     VideoComponent,
     ResourceDefaultTabsComponent,
   ],
@@ -91,7 +97,7 @@ export class ResourceVideoSegmentComponent implements OnInit {
   }
 
   getFileValue(resource: ReadResource) {
-    return getFileValue(resource)!;
+    return getFileValue(resource);
   }
 
   isPlaceholder(resource: ReadResource) {

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video.component.stories.ts
@@ -44,6 +44,24 @@ const makeResource = (permission = 'CR'): DspResource => {
   return generateDspResource(addDescriptionToResource(res, permission));
 };
 
+/**
+ * Resource is viewable but the file value is withheld, i.e. `hasMovingImageFileValue` is absent
+ * while `userHasPermission` is still `V` (DEV-7016).
+ */
+const makeResourceWithWithheldFile = (): DspResource => {
+  const res = new ReadResource();
+  res.id = 'http://rdfh.ch/resource/1';
+  res.type = 'http://api.dasch.swiss/ontology/knora-api/v2#MovingImageRepresentation';
+  res.label = 'My Storybook Video';
+  res.attachedToProject = 'http://rdfh.ch/projects/0869';
+  res.attachedToUser = 'http://rdfh.ch/users/test';
+  res.userHasPermission = 'V';
+  res.hasPermissions = DEFAULT_HAS_PERMISSIONS;
+  res.creationDate = '2024-03-15T10:30:00Z';
+  res.properties = {};
+  return generateDspResource(addDescriptionToResource(res, 'V'));
+};
+
 const segmentsServiceStub: Partial<SegmentsService> = {
   segments: [],
   onInit: () => {},
@@ -115,6 +133,20 @@ export const ReadOnly: Story = {
   play: async ({ canvasElement, step }) => {
     await step('Restriction banner is rendered', async () => {
       await expect(canvasElement.querySelector('app-resource-restriction')).not.toBeNull();
+    });
+  },
+};
+
+export const WithheldFileValue: Story = {
+  name: 'Shows a no-permission message instead of an endless spinner when the file value is withheld',
+  args: { resource: makeResourceWithWithheldFile() },
+  play: async ({ canvasElement, step }) => {
+    await step('No-permission message is rendered', async () => {
+      await expect(canvasElement.querySelector('app-representation-restricted')).not.toBeNull();
+    });
+    await step('Neither the player nor a spinner is rendered', async () => {
+      await expect(canvasElement.querySelector('app-video')).toBeNull();
+      await expect(canvasElement.querySelector('app-progress-indicator')).toBeNull();
     });
   },
 };

--- a/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource/video/resource-video.component.ts
@@ -7,6 +7,7 @@ import { ResourceMediaTabsComponent } from '../../properties/resource-media-tabs
 import { getFileValue } from '../../representation/get-file-value';
 import { isPlaceholderFileValue } from '../../representation/is-placeholder-file-value';
 import { RepresentationPlaceholderComponent } from '../../representation/representation-placeholder.component';
+import { RepresentationRestrictedComponent } from '../../representation/representation-restricted.component';
 import { ResourceLegalComponent } from '../../representation/resource-legal.component';
 import { SegmentsService } from '../../representation/segments/segments.service';
 import { VideoComponent } from './video.component';
@@ -18,11 +19,15 @@ import { VideoComponent } from './video.component';
       <app-resource-restriction />
     }
     <app-resource-header [resource]="resource" />
-    <app-resource-legal [fileValue]="fileValue" />
-    @if (isPlaceholder) {
-      <app-representation-placeholder />
+    @if (fileValue; as file) {
+      <app-resource-legal [fileValue]="file" />
+      @if (isPlaceholder) {
+        <app-representation-placeholder />
+      } @else {
+        <app-video [src]="file" [parentResource]="resource.res" />
+      }
     } @else {
-      <app-video [src]="fileValue" [parentResource]="resource.res" />
+      <app-representation-restricted />
     }
     <app-resource-media-tabs [resource]="resource" style="display: block; margin-top: 50px" />
   `,
@@ -32,6 +37,7 @@ import { VideoComponent } from './video.component';
     ResourceHeaderComponent,
     ResourceLegalComponent,
     RepresentationPlaceholderComponent,
+    RepresentationRestrictedComponent,
     VideoComponent,
     ResourceMediaTabsComponent,
   ],
@@ -40,7 +46,7 @@ export class ResourceVideoComponent {
   @Input({ required: true }) resource!: DspResource;
 
   get fileValue() {
-    return getFileValue(this.resource.res)!;
+    return getFileValue(this.resource.res);
   }
 
   get isPlaceholder() {


### PR DESCRIPTION
Fixes [DEV-7016](https://linear.app/dasch/issue/DEV-7016).

## Problem

When a time-based media resource is viewable but its file value is withheld (`userHasPermission: "V"`, `hasMovingImageFileValue`/`hasAudioFileValue` absent), the media area rendered a black box with an endlessly rotating spinner instead of telling the user they have no access. Reproduced on STAGE while logged out.

`getFileValue()` returns `null` in that case, but all four AV wrappers asserted non-null with `!` and passed the `null` on:

- `<app-resource-legal>` reads `.copyrightHolder` / `.license` on `null` → the `TypeError: Cannot read properties of null` spam on every change-detection cycle.
- `<app-video>` / `<app-audio>` throw inside `bypassSecurityTrustUrl(null.fileUrl)` before the player can become ready, so the progress indicator never gets cleared — the `(error)` handler only fires for a real `<video>` element error.

The existing `<app-resource-restriction>` banner does not cover this: it is gated on `userHasPermission === 'RV'`, and here the resource is `V` with only the file value hidden.

## Change

Treat "no accessible file value" as a first-class state in the AV wrappers:

- Drop the `!` from `getFileValue(...)` so the nullability is visible to the template.
- Guard the legal panel and the player with `@if (fileValue; as file)`.
- Render a new media-neutral `<app-representation-restricted>` in the `@else`, reusing the existing yellow `app-alert-info`. One component serves video, audio and both segment variants.
- New i18n key `resourceEditor.representations.noPermission` in en/de/fr/it.

Applied to all four wrappers: `resource-video`, `resource-video-segment`, `resource-audio`, `resource-audio-segment`.

## Verification

- `nx test vre-resource-editor-resource-editor` — 48 suites, 405 passed, 1 skipped.
- Angular compiler (`ngc --noEmit`, `strictTemplates: true`) on the lib — no new diagnostics; the only remaining errors are pre-existing `TS7016` missing-declaration notes for `jsonld` and `ckeditor5-custom-build`.
- ESLint clean on all changed files; Prettier clean.
- i18n key parity verified across de/fr/it against `en.json`.
- Regression story per wrapper asserting the message renders while neither the player nor a spinner does.

## Notes for review

- **de/fr/it wording is my own, not PM-supplied** — worth a look from whoever owns the translations.
- Composes with #3371 (DEV-7026) as predicted in the issue thread: guarding at the wrapper means `<app-video>`/`<app-audio>` never mount without a file value, so that PR's relocated overlay never renders in this path. No change needed on either side.
- **Out of scope, same latent bug:** `resource-archive`, `resource-pdf`, `resource-document`, `resource-text` and `resource-image` use the identical `getFileValue(...)!` pattern. They do not spin forever, but they will throw on the legal panel under the same conditions. Happy to file a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)