### PR TITLE
fix(resource-editor): keep single-value property text selectable (DEV-7034)

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/draggable-value-list.component.stories.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/draggable-value-list.component.stories.ts
@@ -124,3 +124,44 @@ export const Disabled: Story = {
     });
   },
 };
+
+export const SingleValueIsNotDraggable: Story = {
+  name: 'Keeps a single value undraggable so its text stays selectable',
+  args: {
+    values: [makeValues()[0]],
+    resourceIri: 'http://rdfh.ch/resource/1',
+    propertyIri: 'http://example.org/prop',
+    disabled: false,
+    showHandle: false,
+  },
+  render: args => ({
+    props: args,
+    template: `
+      <app-draggable-value-list
+        [values]="values"
+        [resourceIri]="resourceIri"
+        [propertyIri]="propertyIri"
+        [disabled]="disabled"
+        [showHandle]="showHandle">
+        <ng-template let-value let-index="index">
+          <div data-cy="value-item">Value {{ index + 1 }}</div>
+        </ng-template>
+      </app-draggable-value-list>
+    `,
+  }),
+  play: async ({ canvasElement, step }) => {
+    await step('The single value is rendered', async () => {
+      const items = canvasElement.querySelectorAll('[data-cy="value-item"]');
+      await expect(items.length).toBe(1);
+    });
+    await step('No drag handle is rendered', async () => {
+      const handles = canvasElement.querySelectorAll('[cdkdraghandle]');
+      await expect(handles.length).toBe(0);
+    });
+    await step('The row is drag-disabled, so mousedown does not swallow text selection', async () => {
+      const rows = canvasElement.querySelectorAll('.value-row');
+      await expect(rows.length).toBe(1);
+      await expect(rows[0].classList.contains('cdk-drag-disabled')).toBe(true);
+    });
+  },
+};

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/draggable-value-list.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/draggable-value-list.component.ts
@@ -34,7 +34,11 @@ import { ResourceFetcherService } from '../../../representation/resource-fetcher
       [class.has-multiple]="values.length > 1"
       (cdkDropListDropped)="onDrop($event)">
       @for (value of values; track value.id; let index = $index) {
-        <div cdkDrag cdkDragLockAxis="y" [cdkDragDisabled]="disabled || reorderLoading" class="value-row">
+        <div
+          cdkDrag
+          cdkDragLockAxis="y"
+          [cdkDragDisabled]="disabled || reorderLoading || values.length < 2"
+          class="value-row">
           @if (showHandle) {
             <span
               cdkDragHandle

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/property-values.component.spec.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/property-values.component.spec.ts
@@ -101,6 +101,11 @@ describe('PropertyValuesComponent', () => {
       mockResourceFetcherService.resourceVersion = '20230101T000000Z';
       expect(component.canReorder).toBe(false);
     });
+
+    it('should return false when the property holds a single value', () => {
+      component.editModeData = { resource: mockResource, values: [mockValues[0]] };
+      expect(component.canReorder).toBe(false);
+    });
   });
 
   describe('isAnyValueEditing', () => {
@@ -131,6 +136,11 @@ describe('PropertyValuesComponent', () => {
 
     it('should be true when currently adding a value', () => {
       component.currentlyAdding = true;
+      expect(component.dragDropDisabled).toBe(true);
+    });
+
+    it('should be true when the property holds a single value, so its text stays selectable', () => {
+      component.editModeData = { resource: mockResource, values: [mockValues[0]] };
       expect(component.dragDropDisabled).toBe(true);
     });
   });

--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/property-values.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/property-value/property-values.component.ts
@@ -30,7 +30,7 @@ import { PropertyValueService } from './property-value.service';
       [resourceIri]="editModeData.resource.id"
       [propertyIri]="propertyDefinition.id"
       [disabled]="dragDropDisabled"
-      [showHandle]="canReorder && editModeData.values.length > 1"
+      [showHandle]="canReorder"
       (valuesChange)="editModeData.values = $event">
       <ng-template let-value let-index="index">
         <app-property-value [index]="index" style="width: 100%" />
@@ -67,7 +67,11 @@ export class PropertyValuesComponent implements OnChanges {
   }
 
   get canReorder(): boolean {
-    return ResourceUtil.userCanEdit(this.editModeData.resource) && !this._resourceFetcherService.resourceVersion;
+    return (
+      ResourceUtil.userCanEdit(this.editModeData.resource) &&
+      !this._resourceFetcherService.resourceVersion &&
+      this.editModeData.values.length > 1
+    );
   }
 
   get isAnyValueEditing(): boolean {


### PR DESCRIPTION
Fixes [DEV-7034](https://linear.app/dasch/issue/DEV-7034/single-value-property-fields-text-cant-be-selectedcopied-click).

## Problem

In the resource editor, text in a **single-value** property could not be selected with the mouse, so it could not be copied. Any mousedown on the value immediately entered drag/reorder mode. Multi-value properties were unaffected.

## Root cause

Drag enablement and drag-handle rendering encoded the same invariant — *"this row is draggable"* — in two independent places in `property-values.component.ts`, and they disagreed at exactly one value:

- `showHandle` = `canReorder && values.length > 1`
- `dragDropDisabled` = `!canReorder || …` — **no value-count gate**

So for an editor on a single-value property, drag was enabled while no `cdkDragHandle` was rendered. In `@angular/cdk/drag-drop`:

- `DragRef._pointerDown` falls back to the root element as the drag surface when `_handles.length === 0`, so mousedown anywhere in `.value-row` starts the sequence.
- `_initializeDragSequence` calls `DragDropRegistry.startDragging()` **on mousedown, before the 5px drag threshold**.
- `startDragging` registers a global *capturing* `selectstart` listener bound to `_preventDefaultWhileDragging`, which `preventDefault()`s while any drag instance is active.

Text selection was therefore cancelled at the first mousedown, whether or not the row ever actually moved. Multi-value rows were fine because `withHandles()` makes CDK ignore mousedowns outside the handle; read-only users were fine because `disabled` short-circuits `_pointerDown`.

Regression from the value-reorder feature (DEV-6611 / DEV-6856).

## Fix

- Fold the value-count check into `canReorder` and bind `[showHandle]="canReorder"`, so the handle gate and the drag gate derive from **one source of truth** and cannot diverge again.
- Guard `[cdkDragDisabled]` on `values.length < 2` inside `DraggableValueListComponent`, so the component enforces its own invariant regardless of what a caller passes — a row is never draggable-without-a-handle again.

Reordering a single value was a no-op anyway, so nothing is lost functionally.

## Tests

- `property-values.component.spec.ts` — two cases covering the single-value path (`canReorder` false, `dragDropDisabled` true).
- `draggable-value-list.component.stories.ts` — new `SingleValueIsNotDraggable` story asserting the row carries `cdk-drag-disabled` and renders no handle.

## Verification

- `nx test vre-resource-editor-resource-editor --testPathPatterns=property-value` — 42/42 pass
- `nx lint vre-resource-editor-resource-editor` — clean
- `test-storybook` — `draggable-value-list` 3/3 (incl. the new story), `property-values` 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)