### PR TITLE
fix(ontology): load project ontologies and lists once per editor visit (DEV-7130)

### DIFF
--- a/libs/vre/pages/ontology/ontology/src/lib/forms/property-form/edit-property-form-dialog.component.ts
+++ b/libs/vre/pages/ontology/ontology/src/lib/forms/property-form/edit-property-form-dialog.component.ts
@@ -8,7 +8,6 @@ import {
   MatDialogRef,
 } from '@angular/material/dialog';
 import { StringLiteralV2 } from '@dasch-swiss/vre/3rd-party-services/open-api';
-import { ProjectPageService } from '@dasch-swiss/vre/pages/project/project';
 import { LoadingButtonDirective } from '@dasch-swiss/vre/ui/progress-indicator';
 import { DialogHeaderComponent } from '@dasch-swiss/vre/ui/ui';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -70,8 +69,7 @@ export class EditPropertyFormDialogComponent implements OnInit {
   constructor(
     private readonly _dialogRef: MatDialogRef<EditPropertyFormDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: CreatePropertyDialogData | EditPropertyDialogData,
-    private _oes: OntologyEditService,
-    private _projectPageService: ProjectPageService
+    private _oes: OntologyEditService
   ) {}
 
   ngOnInit() {
@@ -108,7 +106,6 @@ export class EditPropertyFormDialogComponent implements OnInit {
         .createProperty$(propertyData, this.data.assignToClass)
         .pipe(take(1))
         .subscribe(_ => {
-          this._projectPageService.reloadProject();
           this._dialogRef.close();
         });
     }

--- a/libs/vre/pages/ontology/ontology/src/lib/forms/resource-class-form/create-resource-class-dialog.component.ts
+++ b/libs/vre/pages/ontology/ontology/src/lib/forms/resource-class-form/create-resource-class-dialog.component.ts
@@ -8,7 +8,6 @@ import {
   MatDialogRef,
 } from '@angular/material/dialog';
 import { StringLiteralV2 } from '@dasch-swiss/vre/3rd-party-services/open-api';
-import { ProjectPageService } from '@dasch-swiss/vre/pages/project/project';
 import { DefaultClass } from '@dasch-swiss/vre/shared/app-helper-services';
 import { LoadingButtonDirective } from '@dasch-swiss/vre/ui/progress-indicator';
 import { DialogHeaderComponent } from '@dasch-swiss/vre/ui/ui';
@@ -66,7 +65,6 @@ export class CreateResourceClassDialogComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DefaultClass,
     public dialogRef: MatDialogRef<CreateResourceClassDialogComponent>,
-    private _projectPageService: ProjectPageService,
     private _oes: OntologyEditService
   ) {}
 
@@ -88,7 +86,6 @@ export class CreateResourceClassDialogComponent {
       )
       .subscribe(() => {
         this.loading = false;
-        this._projectPageService.reloadProject();
         this.dialogRef.close();
       });
   }

--- a/libs/vre/pages/ontology/ontology/src/lib/services/ontology-edit.service.ts
+++ b/libs/vre/pages/ontology/ontology/src/lib/services/ontology-edit.service.ts
@@ -43,6 +43,7 @@ import {
   map,
   Observable,
   of,
+  ReplaySubject,
   skip,
   switchMap,
   take,
@@ -62,6 +63,15 @@ export class OntologyEditService {
   private _currentOntology = new BehaviorSubject<ReadOntology | null>(null);
   currentOntology$ = this._currentOntology.asObservable();
 
+  // All ontologies of the current project, owned and managed by this service alone:
+  // loaded once per service instance (see constructor) and nexted on every update or
+  // delete, so the many internal subscribers (one per class card) share one request
+  // and reliably receive changes (DEV-7130).
+  private _projectOntologiesSubject = new BehaviorSubject<ReadOntology[] | null>(null);
+  private _projectOntologies$: Observable<ReadOntology[]> = this._projectOntologiesSubject.pipe(
+    filter((ontologies): ontologies is ReadOntology[] => ontologies !== null)
+  );
+
   latestChangedItem = new BehaviorSubject<string | undefined>(undefined);
 
   currentOntologyEntityNames$ = this.currentOntology$.pipe(
@@ -73,15 +83,15 @@ export class OntologyEditService {
     })
   );
 
-  private _getListsInProject$ = this._projectPageService.currentProject$.pipe(
-    switchMap(project => this._listApiService.listInProject(project.id)),
-    map(response => response.lists)
-  );
+  // Loaded once per service instance (see constructor) so the many subscribers of the
+  // property streams below share one request instead of each firing their own (DEV-7130).
+  private _listsInProjectSubject = new ReplaySubject<ListNodeInfo[]>(1);
+  private _listsInProject$ = this._listsInProjectSubject.asObservable();
 
   currentOntologyProperties$: Observable<PropertyInfo[]> = combineLatest([
     this.currentOntology$,
-    this._projectPageService.ontologies$,
-    this._getListsInProject$,
+    this._projectOntologies$,
+    this._listsInProject$,
   ]).pipe(
     map(([currentOntology, allOntologies, allLists]) => {
       if (!currentOntology) return [];
@@ -91,8 +101,8 @@ export class OntologyEditService {
   );
 
   currentProjectsProperties$: Observable<PropertyInfo[]> = combineLatest([
-    this._projectPageService.ontologies$,
-    this._getListsInProject$,
+    this._projectOntologies$,
+    this._listsInProject$,
   ]).pipe(
     map(([ontologies, allLists]) => {
       const allProps = ontologies.flatMap(o =>
@@ -191,6 +201,18 @@ export class OntologyEditService {
     private _listApiService: ListApiService,
     private _localizationService: LocalizationService
   ) {
+    this._projectPageService.currentProject$
+      .pipe(
+        take(1),
+        switchMap(project => this._listApiService.listInProject(project.id)),
+        takeUntilDestroyed()
+      )
+      .subscribe(response => this._listsInProjectSubject.next(response.lists));
+
+    this._projectPageService.ontologies$
+      .pipe(take(1), takeUntilDestroyed())
+      .subscribe(ontologies => this._projectOntologiesSubject.next(ontologies));
+
     // skip(1): currentLanguage$ is a BehaviorSubject, we ignore the initial value
     // emitted at subscription time.
     this._localizationService.currentLanguage$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => {
@@ -205,12 +227,12 @@ export class OntologyEditService {
     this._isTransacting.next(true);
     this._canDeletePropertyMap.clear();
 
-    this._projectPageService.ontologies$.pipe(take(1)).subscribe(ontologies => {
-      const ontologyFromStore = ontologies.find(onto => OntologyService.getOntologyNameFromIri(onto.id) == label);
+    this._projectOntologies$.pipe(take(1)).subscribe(ontologies => {
+      const ontologyToInit = ontologies.find(onto => OntologyService.getOntologyNameFromIri(onto.id) == label);
 
-      if (ontologyFromStore) {
-        this._currentOntology.next(ontologyFromStore);
-        this._currentOntologyInfo.next(ontologyFromStore);
+      if (ontologyToInit) {
+        this._currentOntology.next(ontologyToInit);
+        this._currentOntologyInfo.next(ontologyToInit);
         this._isTransacting.next(false);
       } else {
         this._loadOntologyByLabel(label);
@@ -238,6 +260,7 @@ export class OntologyEditService {
       .pipe(
         tap(() => {
           this._currentOntology.next(null);
+          this._removeProjectOntology(id);
         })
       );
   }
@@ -504,9 +527,31 @@ export class OntologyEditService {
       });
   }
 
+  private _upsertProjectOntology(ontology: ReadOntology) {
+    const ontologies = this._projectOntologiesSubject.value;
+    if (!ontologies) {
+      return;
+    }
+    const exists = ontologies.some(onto => onto.id === ontology.id);
+    this._projectOntologiesSubject.next(
+      exists ? ontologies.map(onto => (onto.id === ontology.id ? ontology : onto)) : [...ontologies, ontology]
+    );
+  }
+
+  private _removeProjectOntology(ontologyId: string) {
+    const ontologies = this._projectOntologiesSubject.value;
+    if (!ontologies) {
+      return;
+    }
+    this._projectOntologiesSubject.next(ontologies.filter(onto => onto.id !== ontologyId));
+  }
+
   private _afterUpdateOntology(onto: ReadOntology, highLightItem?: string) {
     this._currentOntologyInfo.next(onto);
     this._currentOntology.next(onto);
+    // Push the fresh ontology into the project-wide state so every subscriber
+    // (class cards, property menus, page streams) receives the update.
+    this._upsertProjectOntology(onto);
     this._canDeletePropertyMap.clear();
     this._isTransacting.next(false);
     this.latestChangedItem.next(highLightItem);


### PR DESCRIPTION
## Problem

The ontology editor's derived streams were built on the cold `ProjectPageService.ontologies$` and a cold lists request. Neither is shared, so both re-issued their full request set on every re-subscription — each class card and property menu triggered its own `getOntologiesByProjectIri` plus one `getOntology` per project ontology. Opening a data model with several ontologies and many classes produced a burst of redundant `allentities` requests.

## Change

`OntologyEditService` now owns this state instead of reading it through a cold stream:

- Project ontologies are held in `_projectOntologiesSubject`, seeded once in the constructor. The service's lifetime is one visit to `OntologyPageComponent`, so that's one request set per visit.
- Lists are held in `_listsInProjectSubject` (a `ReplaySubject(1)`), likewise loaded once.
- The derived streams (`currentOntologyProperties$`, `currentProjectsProperties$`) read from these subjects.
- Mutations keep the snapshot current: `_afterUpdateOntology` upserts via `_upsertProjectOntology`, and `deleteOntology$` removes via `_removeProjectOntology`. Every subscriber still sees each change, without refetching.

The `reloadProject()` calls in the create-property and create-resource-class dialogs became dead weight — the editor no longer reads that stream, so the project GET they triggered was discarded. Removed them along with the `ProjectPageService` injections that existed only to serve them.

## Notes

The editor holds a snapshot for the duration of a visit, so a sibling ontology changed concurrently by another user is picked up on re-entry rather than mid-visit. That was already true — there is no push or invalidation mechanism; the cold streams merely refetched often enough to hide it. Getting both fresh data and few requests needs an actual invalidation mechanism, which is out of scope here.

Follow-up (not in this PR): the remaining direct consumers of `ProjectPageService.ontologies$` — `gui-attr-link`, `create-ontology-form-dialog`, `data-class-view` — still fire a full request set per subscription. That's the broader "where should project-ontology state live" refactor.

## Testing

- `nx run dsp-app:lint` — passes
- `nx run vre-pages-ontology-ontology:test` — passes
- `tsc-errors` output is byte-identical with and without this change (diffed against a stash), so no new type errors and no orphaned symbols