### PR TITLE
fix(styles): restore default font-size on .material-icons (DEV-7068)

### DIFF
--- a/apps/dsp-app/src/styles/_font.scss
+++ b/apps/dsp-app/src/styles/_font.scss
@@ -73,10 +73,14 @@
    imported in `_config.scss`. That import was removed (DEV-7068): because it was pulled into every
    component that `@use`s the config partial, the production build inlined it per-component, where
    view encapsulation made its `font-size: 24px` out-specify Angular Material's 18px sizing and
-   clipped the glyphs. Declaring the class once here keeps it global, so Material's own sizing wins.
+   clipped the glyphs. Declaring the class once here keeps it global, so Material's contextual
+   sizing rules (e.g. `.mat-mdc-button > .mat-icon`) still out-specify it.
+   `font-size` must stay: Material's base `.mat-icon` rule sets only a 24px box, no font-size, so a
+   standalone `<mat-icon>` would otherwise inherit the body font-size and render undersized.
    `font-feature-settings: 'liga'` is what turns the icon name into a glyph. */
 .material-icons {
   font-family: 'Material Icons';
+  font-size: 24px;
   font-weight: normal;
   font-style: normal;
   line-height: 1;


### PR DESCRIPTION
Follow-up to #3384. That PR fixed the production glyph clipping correctly, but a wrong premise in the replacement CSS made every standalone icon render undersized — visible on dev.dasch.swiss.

## Root cause

#3384 removed the remote Google Fonts stylesheet and re-declared `.material-icons` locally, **deliberately omitting `font-size`**, on the stated grounds that "Material's own sizing keeps winning".

That holds only for icons *inside* Material components. Material's base rule (`@angular/material` 21.2.10, `icon.mjs`) is:

```css
.mat-icon { display:inline-block; height:24px; width:24px; overflow:hidden; /* no font-size */ }
```

There is no `font-size`. Material supplies one only in **contextual** rules:

| Rule | Size | Specificity |
| --- | --- | --- |
| `.mat-mdc-*-button > .mat-icon` | `1.125rem` | 0,2,0 |
| `.mat-icon.mat-icon-inline` | `inherit` | 0,2,0 |
| `.mat-mdc-chip-edit/-remove .mat-icon` | 18px | 0,2,0 |
| `.mat-step-icon .mat-icon` | 16px | 0,2,0 |
| form-field subscript/label `.mat-icon` | `inherit` | 0,2,0 |

So for a **standalone** `<mat-icon>` nothing replaced the removed declaration. The glyph fell back to the inherited body font-size and rendered small inside its 24px box.

## Fix

Restore `font-size: 24px` — the value the Google stylesheet supplied.

Because the declaration lives in the **global** stylesheet it stays at specificity 0,1,0 and loses to every contextual rule above, so the 18px button sizing that DEV-7068 was about keeps winning. This is the same global-vs-scoped argument #3384 made; it just needed the property present to be sized at all.

**Why this cannot recreate DEV-7068:** that bug required the rule to become component-scoped (`.material-icons[_ngcontent-…]` → 0,2,0, out-specifying Material's 18px), which happened because `_config.scss` was `@use`d by 20+ components. `_font.scss` is `@use`d **only** from `styles.scss`, the single global `styles` entry in `project.json` — so it cannot be inlined per-component.

The comment is also corrected: its previous wording stated the very assumption that caused this regression and invited the line's removal again.

## Blast radius

`MatIconRegistry._defaultFontSetClass = ['material-icons', 'mat-ligature-font']`, so MatIcon stamps the class on every font icon automatically — no template writes it by hand (0 occurrences).

| Group | Effect |
| --- | --- |
| Standalone font icons (bulk of ~240 `<mat-icon>`) | **Fixed** — 24px restored |
| Icons in Material buttons / chips / steppers / form-fields | Unchanged (0,2,0 wins) |
| App's 3 scoped rules (`_elements.scss:159`, `property-info`, `order-by`) | Unchanged — all nested |
| `svgIcon` icons (4) | Unaffected — no font glyph |
| `[inline]` icons | None in codebase |

One CSS declaration; no template, TS, or component style touched. Restores pre-#3384 behaviour for the affected set.

## Verification

Against a real `nx run dsp-app:build:production` bundle:

- global `.material-icons{…font-size:24px…}` emitted ✔
- **0** occurrences of `.material-icons[_ngcontent-…]` — the DEV-7068 mechanism is absent ✔
- **0** references to `fonts.googleapis.com` ✔
- `.mat-mdc-button > .mat-icon{font-size:1.125rem}` present **unencapsulated**, so it still out-specifies ✔
- `npx sass` compiles clean (exit 0) ✔

Note that this regression was **not** optimization-dependent (unlike the original clipping): the missing declaration was in a global stylesheet, so all builds were equally affected. Deployment builds a single `production` image (`Makefile` → `nx run dsp-app:build:production`) that is promoted by tag, so dev/stage/prod run the same artefact — dev.dasch.swiss is a full witness for both bugs.

**Not covered:** I have not done a visual pass on a running app. The residual risk is an icon that happened to look better at the inherited size, or a tight custom container that 24px overflows — I found no such case in the SCSS, but that class of thing only rendering catches. Worth a QA look alongside the #3384 re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
