### PR TITLE
fix(styles): undo the .material-icons regressions from #3384 / #3406 (DEV-7011)

### DIFF
--- a/apps/dsp-app/src/styles/_font.scss
+++ b/apps/dsp-app/src/styles/_font.scss
@@ -59,7 +59,13 @@
     U+FEFF, U+FFFD;
 }
 
-/* material-icons */
+/* material-icons - loaded locally, not via the Google Fonts stylesheet `_config.scss` used to
+   `@import`: that import reached every component `@use`ing the config partial, so a production
+   build inlined its `.material-icons { font-size: 24px }` into each one, where view encapsulation
+   let it out-specify Material's sizing and clip glyphs inside `mat-button` (DEV-7011).
+   No global `.material-icons` class belongs here: `mat-icon` already supplies the family, box
+   size and `liga` setting, and a global rule would compete with component styles on source
+   order. */
 @font-face {
   font-family: 'Material Icons';
   font-style: normal;
@@ -67,29 +73,4 @@
   font-display: swap;
   src: local('Material Icons'), local('MaterialIcons-Regular'),
     url(../assets/fonts/material-icons/MaterialIcons-Regular.ttf) format('truetype');
-}
-
-/* The `.material-icons` class used to come from the remote Google Fonts stylesheet that was
-   imported in `_config.scss`. That import was removed (DEV-7068): because it was pulled into every
-   component that `@use`s the config partial, the production build inlined it per-component, where
-   view encapsulation made its `font-size: 24px` out-specify Angular Material's 18px sizing and
-   clipped the glyphs. Declaring the class once here keeps it global, so Material's contextual
-   sizing rules (e.g. `.mat-mdc-button > .mat-icon`) still out-specify it.
-   `font-size` must stay: Material's base `.mat-icon` rule sets only a 24px box, no font-size, so a
-   standalone `<mat-icon>` would otherwise inherit the body font-size and render undersized.
-   `font-feature-settings: 'liga'` is what turns the icon name into a glyph. */
-.material-icons {
-  font-family: 'Material Icons';
-  font-size: 24px;
-  font-weight: normal;
-  font-style: normal;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  font-feature-settings: 'liga';
-  -webkit-font-smoothing: antialiased;
 }

--- a/apps/dsp-app/src/styles/_font.scss
+++ b/apps/dsp-app/src/styles/_font.scss
@@ -65,12 +65,14 @@
    let it out-specify Material's sizing and clip glyphs inside `mat-button` (DEV-7011).
    No global `.material-icons` class belongs here: `mat-icon` already supplies the family, box
    size and `liga` setting, and a global rule would compete with component styles on source
-   order. */
+   order.
+   No `font-display` either: the default `auto` keeps the glyph area blank until the font
+   loads, which is what Google's stylesheet did. `swap` would paint the ligature's source
+   text instead, flashing "filter_list" in the UI before the glyph arrives. */
 @font-face {
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
   src: local('Material Icons'), local('MaterialIcons-Regular'),
     url(../assets/fonts/material-icons/MaterialIcons-Regular.ttf) format('truetype');
 }


### PR DESCRIPTION
## Problem

Two follow-ups to the original clipping fix each introduced a new issue. This keeps the part that actually fixed the clipping and undoes the rest.

**The clipping (DEV-7011)** came from one line: the Google Fonts `@import` in `_config.scss`. 33 component stylesheets `@use` that partial, including `incoming-resource-pager.component.scss`, so a production build inlined the remote sheet's `.material-icons { font-size: 24px }` into each of them. View encapsulation then let it out-specify Angular Material's icon sizing inside `mat-button`, clipping the `east` arrow.

Removing that import (#3384) is what fixes it, and **it stays removed.**

Two regressions came from the rest of that chain:

| Symptom | Cause |
|---|---|
| Icons render at 24px, then **shrink** | #3384 hand-rolled a global `.material-icons` class to stand in for the remote sheet; #3406 added `font-size: 24px` back to it. As a plain single-class rule in the global sheet it ties with — and loses to — component rules injected later when lazy route chunks load. |
| Icons briefly show their **name as text** ("filter_list", "east") | #3384 also added `font-display: swap` to the icon `@font-face`, pattern-matched from the Roboto faces above it. `swap` paints a fallback immediately; for an icon font that "fallback" is the ligature's own source text. |

## Change

1. **Drop the global `.material-icons` class.** Icons go back to being sized by Angular Material alone, with nothing in the global sheet competing on source order.
2. **Drop `font-display: swap`** from the icon `@font-face`. The default `auto` (≈ `block`) keeps the glyph area blank until the font loads.

The local `@font-face` is kept — it replaces what the remote stylesheet used to load. The Roboto faces keep their `swap`, which is correct for text.

## Why this is safe

Removing the class:
- No template uses `class="material-icons"` — every icon in the app is `<mat-icon>`.
- Nothing uses the Outlined family the old import also pulled in.
- `mat-icon` already supplies the font family, the 24px box and `font-feature-settings: 'liga'`.
- The one remaining `.material-icons` rule (`.action-bubble` 18px in `_elements.scss`) is a deliberate local override that sizes *down* and has an equivalent `.mat-icon` rule beside it.

Removing `font-display`:
- Neither the pre-#3384 local `@font-face` nor Google's stylesheet (`fonts.googleapis.com/icon?family=Material+Icons`, verified — it sets no `font-display`) ever set it. Blank-then-glyph is the behaviour that shipped for years.
- The icon `@font-face` is now byte-identical to its pre-#3384 state.

Verified by compiling the global stylesheet before/after: the only CSS removed is the global class and the one declaration.

## Testing

⚠️ **Not verified in a production build.** This checkout cannot build — Node 20.11.1 hits `ERR_REQUIRE_ESM` in both the OpenAPI generator and the Angular compiler (pre-existing, unrelated to this change). The reasoning above is from the compiled global stylesheet, the git history and the build config, not an observed artifact.

Since the per-component inlining only happens in an optimized build, **this needs a look on dev after deploy**:

- [ ] Incoming-links pager: `east` / `west` arrows fully visible, not clipped
- [ ] No icon renders large and then shrinks
- [ ] No icon name flashes as text before the glyph appears
- [ ] Spot-check icons in buttons, tabs and menus are unchanged in size

## Out of scope

`MaterialIcons-Regular.ttf` is 356 KB uncompressed (in the repo since the 2023 monorepo conversion). It only controls *how long* the blank window lasts, not whether icons are correct. Converting to `.woff2` (~80 KB) is a worthwhile follow-up but needs a new binary asset, so it is not in this PR.

A pre-existing Prettier warning on `_font.scss` is left untouched to keep this diff to the fix.

Refs DEV-7011, DEV-7068. Follows #3384, #3406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)