### PR TITLE
fix(styles): restore the Google Fonts icon stylesheet (DEV-7011)

### DIFF
--- a/apps/dsp-app/src/styles/_config.scss
+++ b/apps/dsp-app/src/styles/_config.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@import url("https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined");
 
 // colors for text
 $light-text: rgb(255, 255, 255);

--- a/apps/dsp-app/src/styles/_font.scss
+++ b/apps/dsp-app/src/styles/_font.scss
@@ -59,16 +59,7 @@
     U+FEFF, U+FFFD;
 }
 
-/* material-icons - loaded locally, not via the Google Fonts stylesheet `_config.scss` used to
-   `@import`: that import reached every component `@use`ing the config partial, so a production
-   build inlined its `.material-icons { font-size: 24px }` into each one, where view encapsulation
-   let it out-specify Material's sizing and clip glyphs inside `mat-button` (DEV-7011).
-   No global `.material-icons` class belongs here: `mat-icon` already supplies the family, box
-   size and `liga` setting, and a global rule would compete with component styles on source
-   order.
-   No `font-display` either: the default `auto` keeps the glyph area blank until the font
-   loads, which is what Google's stylesheet did. `swap` would paint the ligature's source
-   text instead, flashing "filter_list" in the UI before the glyph arrives. */
+/* material-icons */
 @font-face {
   font-family: 'Material Icons';
   font-style: normal;


### PR DESCRIPTION
## Why

**Icons do not render anywhere on dev or stage, for everyone.** This reverts #3384, #3406 and #3407.

Verified against real production builds of both states (Node 22.23.1, `nx build dsp-app --configuration=production`):

| in shipped `styles-*.css` | `main` (deployed) | this branch |
|---|---|---|
| rules setting icon `font-family` | **0** | 1 |
| `font-feature-settings` (ligatures) | **0** | 2 |
| icon font URLs requested | **0** | 2 |

On `main` the only surviving `.material-icons` rule is `{font-size:18px}` (the `.action-bubble` override). Nothing applies `font-family: Material Icons` and nothing enables `liga`, so icon names can never resolve to glyphs and no icon font is ever requested — exactly the reported symptom.

The immediate cause is **#3407, which is merged** (`f073bffde`, shipped in 13.14.0). It removed the global `.material-icons` class on two claims, both wrong:

1. *"Angular Material already supplies the font family."* Material's `.mat-icon` sets only the 24px **box**. It never sets `font-family` or `font-feature-settings` — it cannot, as it does not know which icon font the app uses.
2. *"No template uses `class="material-icons"`, so it is dead code."* The class never appears in source because `MatIconRegistry` applies it **at runtime**: `_defaultFontSetClass = ['material-icons', 'mat-ligature-font']` is added to every `<mat-icon>`. Grepping templates could not see it.

## Scope

Two files, +2 / −10 against `main`. Both are byte-identical to their pre-#3384 state — the last configuration where icons rendered everywhere.

| | |
|---|---|
| `_config.scss` | Google Fonts icon `@import` restored |
| `_font.scss` | `font-display: swap` and the hand-rolled `.material-icons` class removed |

**Kept deliberately:**

- **#3366** (`iconPositionEnd` on the pager's "Next" arrow) — untouched.
- **The `assignments` → `assignment` fix from #3384** — kept. `assignments` is not a Material icon name, so that tab icon rendered blank. The revert restored the typo; I put the fix back.

## What the built artifact also revealed

Two premises behind #3384 turn out to be wrong, which matters for whoever retries self-hosting:

- **The bundled `MaterialIcons-Regular.ttf` was never used, before or after these PRs.** With `optimization.fonts.inline: true`, the build resolves the Google `@import` at build time and inlines a `@font-face` pointing at `fonts.gstatic.com` — in `.woff2`. The `local()`/`.ttf` `@font-face` in `_font.scss` never won. That is why no request for the `.ttf` was ever observed.
- **The per-component duplication is real** — `.material-icons[_ngcontent-%COMP%]` does appear in the JS chunks, so the encapsulation mechanism #3384 described exists. But the global bundle carries only **one** copy of the class, so "inlined into 33 components" overstated it.

## Consequence

**DEV-7011 (clipped pager arrow) is open again.** One cosmetic defect in one component, versus no icons anywhere — the right trade.

It belongs in `incoming-resource-pager.component.*`. The clipping arrived with #3366's `iconPositionEnd`, which Material uses as a **content-projection selector** on `mat-button` (`ngContentSelectors`: `.material-icons[iconPositionEnd], mat-icon[iconPositionEnd], …`) to slot the icon into the trailing position. That projection change is where the clipping comes from — not the font pipeline. Rebuilding icon font loading to fix one arrow is what escalated a cosmetic bug into an app-wide outage across three PRs.

## Testing

Production build verified locally on Node 22.23.1 (the repo's `.nvmrc`; the earlier PRs in this chain went out unverified because I was on Node 20.11.1, below the `engines` floor of `^22.13.0`, where the build fails with `ERR_REQUIRE_ESM`).

- [x] Production build succeeds
- [x] Shipped CSS applies `font-family: Material Icons` and `font-feature-settings: liga`
- [x] Both style files byte-identical to the pre-#3384 state
- [x] `.action-bubble` 18px override intact and still correctly scoped

Please confirm on dev after deploy:

- [ ] Icons render throughout the app
- [ ] "My Projects" tab icon shows (the `assignment` fix)
- [ ] Incoming-links pager arrow is clipped again — expected, DEV-7011 reopens

Reverts #3384, #3406, #3407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)