### PR TITLE
fix(resource-editor,help-page): stop button icons being clipped (DEV-7011)

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/incoming-resource-pager.component.scss
+++ b/libs/vre/resource-editor/resource-editor/src/lib/properties/properties-display/incoming-resource-pager.component.scss
@@ -30,6 +30,15 @@
         color: $primary;
         font-weight: 400;
       }
+
+      /* Give each arrow a box as wide as its glyph so it is not cropped.
+         Material narrows button icons to `width: 1.125rem` while `_config.scss`'s imported
+         Google Fonts sheet is inlined per component and keeps `font-size: 24px`, so the glyph
+         is wider than the box that `overflow: hidden` clips it to (DEV-7011). Both arrows are
+         affected; it is only obvious on "Next", whose icon is flush with the button edge. */
+      mat-icon {
+        width: 1em;
+      }
     }
 
     .range {

--- a/libs/vre/shared/app-help-page/src/lib/grid/grid.component.scss
+++ b/libs/vre/shared/app-help-page/src/lib/grid/grid.component.scss
@@ -56,6 +56,10 @@
 
         .mat-icon.suffix {
           margin-left: 16px;
+          /* Match the box to the glyph so the trailing icon is not cropped: Material narrows
+             button icons to `width: 1.125rem` while the per-component copy of the imported
+             Google Fonts sheet keeps `font-size: 24px` (DEV-7011). */
+          width: 1em;
         }
       }
     }


### PR DESCRIPTION
## Root cause

Angular Material narrows icons inside a text button to `width: 1.125rem` (18px). `_config.scss` `@import`s the Google Fonts icon stylesheet, and that import is inlined into **every component that `@use`s the partial**, so the sheet's `.material-icons { font-size: 24px }` lands in the component's encapsulated styles as:

```css
.material-icons[_ngcontent-ng-c417689689] { font-size: 24px; }
```

At **(0,2,0)** that ties Material's `.mat-mdc-button > .mat-icon` and wins on source order (component styles are injected after the global sheet). So the glyph stays 24px inside an 18px-wide box with `overflow: hidden`, and gets cropped.

Measured on stage, clean page load:

| icon | font-size | box | client/scroll | clipped |
|---|---|---|---|---|
| pager `west` | 24px | 18×24 | 18/24 | **yes** |
| pager `east` | 24px | 18×24 | 18/24 | **yes** |
| /help `launch` ×7, `mail` ×2 | 24px | 18×24 | 18/24 | **yes** |
| `language`, `unfold_more` (other components) | 18px | 18×18 | 18/18 | no |

## Fix

Give the affected icons a box as wide as their glyph:

```scss
mat-icon { width: 1em; }
```

After: box 24×24, 24/24, all unclipped — verified on the live stage pages and visually confirmed.

## Answers to the review points

**"There is also a `west` button in the same component."** Correct, and it *is* also clipped — same `18/24`. The crop is just easier to see on the trailing icon, which sits flush with the button edge, while the leading icon's `-4px` start offset hides it. The fix now covers both arrows, not only `east`.

**"Changing font-size is not an obvious fix / hides the intention."** Agreed — dropped. `width: 1em` says what we actually want: *the box should be as wide as the glyph*. It also holds whatever font-size the icon ends up inheriting, so it does not encode a magic number.

**"Is there a solution with margin?"** No — verified experimentally. The crop happens *inside* the element (`overflow: hidden` on a box narrower than its content), so moving the box with margin cannot change it. Adding `margin-right` left the icon clipped at `18/24`. Note the /help grid already had `margin-left: 16px` on these icons and they were clipped anyway. Only changing the box (`width`) or the glyph (`font-size`) fixes it; `width` is the one that expresses the intent.

## Codebase sweep for other clipping icon buttons

33 component stylesheets `@use` the config partial. Of those, 5 place a `mat-icon` inside a text/outlined/raised `mat-button`:

| component | icons | status |
|---|---|---|
| `incoming-resource-pager` | `west`, `east` | **fixed here** |
| `app-help-page/grid` | `launch`, `mail` | **fixed here** |
| `property-info` | `edit`, `delete` (`mat-button`) | at risk, not reachable on stage to confirm |
| `sort-button` | `sort` (`matButton="text"`) | at risk, not reachable on stage to confirm |
| `view-restrictions` | `filter_list` | **not affected** — inside a `<span class="control-label">`, not a button, so Material never narrows it |

I fixed the two I could measure and confirm. The two "at risk" ones have the same structural setup but I could not load them on stage (the view-restrictions route 404s there), so I did not change styling I cannot verify — happy to include them if you can point me at a page where they render, or to leave them for the structural fix below.

Confirmed as **not** an icon-position problem: icons in buttons whose component does not `@use` the config partial measure 18px/18-18 regardless of position. The import is the trigger.

## The real underlying issue

That `@import` reaching 33 component stylesheets is the actual defect — every one of them carries a duplicate `.material-icons` rule that can out-order Material. Moving the font loading out of the partial (a `@font-face`-only file with no `.material-icons` class) would remove this whole class of bug and make these per-component patches unnecessary.

Not attempted here: #3384/#3406/#3407 show that change needs its own ticket and verification rather than riding along with a clipping fix.

## Testing

- [x] Reproduced on stage, clean load: pager both arrows + 9 icons on /help
- [x] Fix verified live on both pages: 24/24, unclipped, visually complete
- [x] Both component stylesheets compile
- [x] `[iconPositionEnd]` selector matching confirmed against the lowercased DOM attribute (no longer needed after widening to both arrows, but checked)
- [ ] Confirm on dev after deploy: pager arrows and /help icons fully visible

Refs DEV-7011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)