### PR TITLE
fix: fresh clone setup fails loud on the wrong toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ testem.log
 /typings
 metals*
 .npmrc
+!/.npmrc
 
 #Documentation Files
 docs/_site/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+allow-git=root

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This monorepo is built on:
 
 ## Quick Start
 
-Use the NodeJs version supported by the installed Angular version ([compatibility table](https://angular.dev/reference/versions)), or the version pinned in [.nvmrc](.nvmrc).
+Activate the Node.js version pinned in [.nvmrc](.nvmrc) — for example `nvm use`, `fnm use`, or `n auto` — before running `npm install`.
 
 ```shell
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
       },
       "engines": {
         "node": "^22.13.0",
-        "npm": "^10.9.0"
+        "npm": "^10.9.0 || ^11 || ^12"
       },
       "optionalDependencies": {
         "@nx/nx-darwin-arm64": "23.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,21 @@
   },
   "engines": {
     "node": "^22.13.0",
-    "npm": "^10.9.0"
+    "npm": "^10.9.0 || ^11 || ^12"
+  },
+  "allowScripts": {
+    "@openapitools/openapi-generator-cli": true,
+    "@parcel/watcher": true,
+    "@sentry/cli": true,
+    "@swc/core": true,
+    "core-js-pure": true,
+    "cypress": true,
+    "esbuild": true,
+    "fsevents": true,
+    "lmdb": true,
+    "msgpackr-extract": true,
+    "nx": true,
+    "unrs-resolver": true
   },
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
[DEV-7198](https://linear.app/dasch/issue/DEV-7198)

## Summary
- A committed `.npmrc` makes a fresh clone abort loud (`EBADENGINE`) on the wrong Node or npm version, instead of failing later with an unrelated error.
- `allow-git=root` permits only the project's own `ckeditor5-custom-build` git dependency, which npm 12 refuses by default.
- `allowScripts` allowlists every dependency that needs an install script, using name-only keys so a version bump doesn't invalidate the entry.
- The README gives one instruction to activate the `.nvmrc` pin, instead of offering an alternative.

## Changes
- `.gitignore`: narrowed the bare `.npmrc` rule with `!/.npmrc` so a committed root `.npmrc` is tracked while a nested one stays ignored.
- `.npmrc` (new): `engine-strict=true`, `allow-git=root`.
- `package.json`: widened `engines.npm` to `^10.9.0 || ^11 || ^12`; added a 12-entry `allowScripts` block.
- `package-lock.json`: synced the mirrored root `engines` field.
- `README.md`: Quick Start now gives one instruction to activate `.nvmrc`.

## Test Plan
- Verified live on Node 26.8.1 / npm 12.0.2 (no toolchain manager available on this machine): `npm install` aborts with `EBADENGINE`, naming both the required and actual versions.
- `npm install-scripts ls` reports zero uncovered packages except `@tybys/wasm-util` — confirmed harmless: its `prepare` script (`tsgo build`) has never been runnable by any consumer (`tsgo` is its own devDependency, never installed downstream) and isn't needed, since the published package already ships pre-built output. Full investigation in the plan.
- `git check-ignore -v .npmrc` confirms the root file is tracked; a nested `.npmrc` stays ignored.
- A real install under the `.nvmrc`-pinned Node 22.23.1 was not run locally (no matching Node available here) — CI and a follow-up check on a pinned machine still cover this.
- Plan and execution journal: `specs/2026-09-08-dsp-app-fresh-clone-setup/` in dasch-specs.

## Screenshots
N/A — no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)